### PR TITLE
Fix kestrel benchmarks

### DIFF
--- a/src/AspNet5/Startup.cs
+++ b/src/AspNet5/Startup.cs
@@ -8,7 +8,6 @@ namespace AspNet5
     public class Startup
     {
         private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("HelloWorld");
-        private static readonly Task _done = Task.FromResult(0);
 
         public void Configure(IApplicationBuilder app)
         {
@@ -16,9 +15,8 @@ namespace AspNet5
             {
                 context.Response.StatusCode = 200;
                 context.Response.ContentLength = _helloWorldPayload.Length;
-                context.Response.Body.Write(_helloWorldPayload, 0, _helloWorldPayload.Length);
-
-                return _done;
+                return context.Response.Body.WriteAsync(_helloWorldPayload, 0, _helloWorldPayload.Length);
+                
             });
         }
     }


### PR DESCRIPTION
Calling Write is fatal to performance here; WriteAsync makes it happy

You might want to revisit https://github.com/aspnet/KestrelHttpServer/blob/8cb66582154eec872e1c1ecbef0afe977739f454/src/Microsoft.AspNet.Server.Kestrel/Http/FrameResponseStream.cs#L63

The .Wait() is deadly...