### PR TITLE
Dapper: micro-optimizations

### DIFF
--- a/src/Benchmarks/FortunesDapperMiddleware.cs
+++ b/src/Benchmarks/FortunesDapperMiddleware.cs
@@ -46,14 +46,13 @@ namespace Benchmarks
 
         private static async Task<IEnumerable<Fortune>> LoadRows(string connectionString, DbProviderFactory dbProviderFactory)
         {
-            var result = new List<Fortune>();
+            List<Fortune> result;
 
             using (var db = dbProviderFactory.CreateConnection())
             {
                 db.ConnectionString = connectionString;
-                await db.OpenAsync();
-
-                result.AddRange(await db.QueryAsync<Fortune>("SELECT [Id], [Message] FROM [Fortune]"));
+                // note: don't need to open connection if only doing one thing; let dapper do it
+                result = (await db.QueryAsync<Fortune>("SELECT [Id], [Message] FROM [Fortune]")).AsList();
             }
 
             result.Add(new Fortune { Message = "Additional fortune added at request time." });

--- a/src/Benchmarks/MultipleQueriesDapperMiddleware.cs
+++ b/src/Benchmarks/MultipleQueriesDapperMiddleware.cs
@@ -85,11 +85,9 @@ namespace Benchmarks
 
                 for (int i = 0; i < count; i++)
                 {
-                    var world = await db.QueryAsync<World>(
+                    result[i] = await db.QueryFirstOrDefaultAsync<World>(
                         "SELECT [Id], [RandomNumber] FROM [World] WHERE [Id] = @Id",
                         new { Id = _random.Next(1, 10001) });
-
-                    result[i] = world.First();
                 }
 
                 db.Close();

--- a/src/Benchmarks/SingleQueryDapperMiddleware.cs
+++ b/src/Benchmarks/SingleQueryDapperMiddleware.cs
@@ -61,15 +61,10 @@ namespace Benchmarks
             using (var db = dbProviderFactory.CreateConnection())
             {
                 db.ConnectionString = connectionString;
-                await db.OpenAsync();
-
-                var world = await db.QueryAsync<World>(
+                // note: don't need to open connection if only doing one thing; let dapper do it
+                return await db.QueryFirstOrDefaultAsync<World>(
                     "SELECT [Id], [RandomNumber] FROM [World] WHERE [Id] = @Id",
                     new { Id = _random.Next(1, 10001) });
-
-                db.Close();
-
-                return world.First();
             }
         }
     }


### PR DESCRIPTION
(from: dapper team) use QueryFirstOrDefault (in 1.50-beta4); let dapper worry about connection opening if single-op; use AsList to use pre-existing buffered list when available