### PR TITLE
Add Jil JSON test

### DIFF
--- a/src/Benchmarks/JsonJilMiddleware.cs
+++ b/src/Benchmarks/JsonJilMiddleware.cs
@@ -7,19 +7,18 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
-using Newtonsoft.Json;
+using Jil;
 
 namespace Benchmarks
 {
-    public class JsonMiddleware
+    public class JsonJilMiddleware
     {
         private static readonly Task _done = Task.FromResult(0);
-        private static readonly PathString _path = new PathString("/json");
-        private static readonly JsonSerializer _json = new JsonSerializer();
+        private static readonly PathString _path = new PathString("/json/jil");
 
         private readonly RequestDelegate _next;
         
-        public JsonMiddleware(RequestDelegate next)
+        public JsonJilMiddleware(RequestDelegate next)
         {
             _next = next;
         }
@@ -36,7 +35,7 @@ namespace Benchmarks
 
                 using (var sw = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, bufferSize: 30))
                 {
-                    _json.Serialize(sw, new { message = "Hello, World!" });
+                    JSON.Serialize(new { message = "Hello, World!" }, sw);
                 }
 
                 return _done;
@@ -46,11 +45,11 @@ namespace Benchmarks
         }
     }
     
-    public static class JsonMiddlewareExtensions
+    public static class JsonJilMiddlewareExtensions
     {
-        public static IApplicationBuilder UseJson(this IApplicationBuilder builder)
+        public static IApplicationBuilder UseJilJson(this IApplicationBuilder builder)
         {
-            return builder.UseMiddleware<JsonMiddleware>();
+            return builder.UseMiddleware<JsonJilMiddleware>();
         }
     }
 }

--- a/src/Benchmarks/JsonNewtonsoftMiddleware.cs
+++ b/src/Benchmarks/JsonNewtonsoftMiddleware.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Newtonsoft.Json;
+
+namespace Benchmarks
+{
+    public class JsonNewtonsoftMiddleware
+    {
+        private static readonly Task _done = Task.FromResult(0);
+        private static readonly PathString _path = new PathString("/json/newtonsoft");
+        private static readonly JsonSerializer _json = new JsonSerializer();
+
+        private readonly RequestDelegate _next;
+        
+        public JsonNewtonsoftMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext httpContext)
+        {
+            // We check Ordinal explicitly first because it's faster than OrdinalIgnoreCase
+            if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal) ||
+                httpContext.Request.Path.StartsWithSegments(_path, StringComparison.OrdinalIgnoreCase))
+            {
+                httpContext.Response.StatusCode = 200;
+                httpContext.Response.ContentType = "application/json";
+                httpContext.Response.ContentLength = 30;
+
+                using (var sw = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, bufferSize: 30))
+                {
+                    _json.Serialize(sw, new { message = "Hello, World!" });
+                }
+
+                return _done;
+            }
+
+            return _next(httpContext);
+        }
+    }
+    
+    public static class JsonNewtonsoftMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseNewtonsoftJson(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<JsonNewtonsoftMiddleware>();
+        }
+    }
+}

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -66,7 +66,8 @@ namespace Benchmarks
         {
             app.UseErrorHandler();
             app.UsePlainText();
-            app.UseJson();
+            app.UseNewtonsoftJson();
+            app.UseJilJson();
 
             if (StartupOptions.EnableDbTests)
             {

--- a/src/Benchmarks/project.json
+++ b/src/Benchmarks/project.json
@@ -15,7 +15,8 @@
     "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
     "Microsoft.AspNet.StaticFiles": "1.0.0-*",
     "Microsoft.Extensions.WebEncoders": "1.0.0-*",
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "7.0.1",
+    "Jil": "2.13.0-*"
   },
 
   "commands": {


### PR DESCRIPTION
This moves the JSON.Net test to /json/newtonsoft (to match the other multi-implementation test patterns) and adds /json/jil as another JSON serialization test.
