### PR TITLE
Use AsNoTracking instead of ChangeTracker

### DIFF
--- a/src/Benchmarks/Data/ApplicationDbSeeder.cs
+++ b/src/Benchmarks/Data/ApplicationDbSeeder.cs
@@ -8,8 +8,8 @@ namespace Benchmarks.Data
 {
     public class ApplicationDbSeeder
     {
-        private object _locker = new object();
-        private bool _seeded = false;
+        private readonly object _locker = new object();
+        private bool _seeded;
 
         public bool Seed(ApplicationDbContext db)
         {

--- a/src/Benchmarks/MultipleQueriesEfMiddleware.cs
+++ b/src/Benchmarks/MultipleQueriesEfMiddleware.cs
@@ -34,7 +34,6 @@ namespace Benchmarks
                 httpContext.Request.Path.StartsWithSegments(_path, StringComparison.OrdinalIgnoreCase))
             {
                 var db = (ApplicationDbContext)httpContext.RequestServices.GetService(typeof(ApplicationDbContext));
-                db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
 
                 var count = GetQueryCount(httpContext);
                 var rows = await LoadRows(count, db);
@@ -77,7 +76,7 @@ namespace Benchmarks
             for (int i = 0; i < count; i++)
             {
                 var id = _random.Next(1, 10001);
-                result[i] = await dbContext.World.FirstAsync(w => w.Id == id);
+                result[i] = await dbContext.World.AsNoTracking().FirstAsync(w => w.Id == id);
             }
 
             return result;

--- a/src/Benchmarks/SingleQueryEfMiddleware.cs
+++ b/src/Benchmarks/SingleQueryEfMiddleware.cs
@@ -35,10 +35,8 @@ namespace Benchmarks
             {
                 var db = (ApplicationDbContext)httpContext.RequestServices.GetService(typeof(ApplicationDbContext));
 
-                db.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
-
                 var id = _random.Next(1, 10001);
-                var row = await db.World.FirstAsync(w => w.Id == id);
+                var row = await db.World.AsNoTracking().FirstAsync(w => w.Id == id);
                 var result = JsonConvert.SerializeObject(row, _jsonSettings);
 
                 httpContext.Response.StatusCode = StatusCodes.Status200OK;


### PR DESCRIPTION
… to prevent expensive initialization of ChangeTracker.

cc @DamianEdwards @halter73 @divega 

Related to: aspnet/EntityFramework#4133
