### PR TITLE
Allow configuration of scenarios

### DIFF
--- a/src/Benchmarks/MultipleQueriesDapperMiddleware.cs
+++ b/src/Benchmarks/MultipleQueriesDapperMiddleware.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Data.Common;
-using System.Linq;
 using System.Threading.Tasks;
 using Benchmarks.Data;
 using Dapper;

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -2,42 +2,122 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
 using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Benchmarks
 {
     public class Program
     {
+        public static string[] Args;
+        
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                            .UseDefaultConfiguration(args)
-                            .UseStartup<Startup>()
-                            .Build();
+            Args = args;
+            
             Console.WriteLine();
-            Console.WriteLine("ASP.NET 5 Benchmarks");
-            Console.WriteLine("--------------------");
+            Console.WriteLine("ASP.NET Core Benchmarks");
+            Console.WriteLine("-----------------------");
 
-            var config = new ConfigurationBuilder()
-                .AddCommandLine(args)
+            var scenarios = LoadScenarios(args);
+
+            StartInteractiveConsoleThread();
+
+            var webHost = new WebHostBuilder()
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseCaptureStartupErrors(false)
+                .UseDefaultConfiguration(args)
+                .UseStartup<Startup>()
+                .ConfigureServices(services => services.AddSingleton(scenarios))
                 .Build();
 
-            if (string.IsNullOrEmpty(config["scenarios"]))
+            webHost.Run();
+        }
+
+        private static Scenarios LoadScenarios(string[] args)
+        {
+            var scenarioConfig = new ConfigurationBuilder()
+                .AddJsonFile("scenarios.json", optional: true)
+                .AddCommandLine(args)
+                .Build()
+                .GetChildren()
+                .ToList();
+
+            var scenarios = new Scenarios();
+
+            if (scenarioConfig.Count > 0)
+            {
+                Console.WriteLine("Scenario configuration found in scenarios.json and/or command line args");
+                foreach (var scenario in scenarioConfig)
+                {
+                    scenarios.Enable(scenario.Value);
+                }
+            }
+            else
             {
                 Console.WriteLine("Which scenarios would you like to enable?:");
-                Console.WriteLine("  1: Raw middleware");
-                Console.WriteLine("  2: All MV");
-                Console.Write("1, 2, 3, A(ll)> ");
+                Console.WriteLine();
+                foreach (var scenario in scenarios.GetNames())
+                {
+                    Console.WriteLine("  " + scenario);
+                }
+                Console.WriteLine();
+                Console.WriteLine("Type full or partial scenario names separated by commas and hit [Enter]");
+                Console.Write("> ");
+
+                var choices = Console.ReadLine().Split(new [] {','}, StringSplitOptions.RemoveEmptyEntries);
+
+                if (choices.Length == 0)
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("No choice entered, enabling default scenarios");
+                    scenarios.EnableDefault();
+                }
+                else
+                {
+                    var count = 0;
+
+                    foreach (var choice in choices)
+                    {
+                        count += scenarios.Enable(choice);
+                    }
+
+                    if (count == 0)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine("No matching scenarios found, enabling defaults");
+                        scenarios.EnableDefault();
+                    }
+                }
             }
 
+            Console.WriteLine();
+            Console.WriteLine("The following scenarios were enabled:");
+            foreach (var scenario in scenarios.GetEnabled())
+            {
+                Console.WriteLine("  " + scenario);
+            }
+            Console.WriteLine();
+            
+            return scenarios;
+        }
+
+        private static void StartInteractiveConsoleThread()
+        {
             // Run the interaction on a separate thread as we don't have Console.KeyAvailable on .NET Core so can't
             // do a pre-emptive check before we call Console.ReadKey (which blocks, hard)
+            
+            var started = new ManualResetEvent(false);
+            
             var interactiveThread = new Thread(() =>
             {
-                Console.WriteLine();
                 Console.WriteLine("Press 'C' to force GC or any other key to display GC stats");
+                Console.WriteLine();
+
+                started.Set();
 
                 while (true)
                 {
@@ -60,10 +140,11 @@ namespace Benchmarks
                     }
                 }
             });
+
             interactiveThread.IsBackground = true;
             interactiveThread.Start();
 
-            host.Run();
+            started.WaitOne();
         }
 
         private static string GetAllocatedMemory(bool forceFullCollection = false)

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 
 namespace Benchmarks
 {
@@ -16,6 +16,21 @@ namespace Benchmarks
                             .UseDefaultConfiguration(args)
                             .UseStartup<Startup>()
                             .Build();
+            Console.WriteLine();
+            Console.WriteLine("ASP.NET 5 Benchmarks");
+            Console.WriteLine("--------------------");
+
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .Build();
+
+            if (string.IsNullOrEmpty(config["scenarios"]))
+            {
+                Console.WriteLine("Which scenarios would you like to enable?:");
+                Console.WriteLine("  1: Raw middleware");
+                Console.WriteLine("  2: All MV");
+                Console.Write("1, 2, 3, A(ll)> ");
+            }
 
             // Run the interaction on a separate thread as we don't have Console.KeyAvailable on .NET Core so can't
             // do a pre-emptive check before we call Console.ReadKey (which blocks, hard)
@@ -47,7 +62,7 @@ namespace Benchmarks
             });
             interactiveThread.IsBackground = true;
             interactiveThread.Start();
-            
+
             host.Run();
         }
 

--- a/src/Benchmarks/Scenarios.cs
+++ b/src/Benchmarks/Scenarios.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+
+namespace Benchmarks
+{
+    public class Scenarios
+    {
+        public bool Plaintext { get; set; }
+
+        public bool Json { get; set; }
+
+        public bool StaticFiles { get; set; }
+
+        public bool MvcApis { get; set; }
+
+        public bool MvcViews { get; set; }
+
+        public bool DbSingleQueryRaw { get; set; }
+
+        public bool DbSingleQueryEf { get; set; }
+
+        public bool DbSingleQueryDapper { get; set; }
+
+        public bool DbMultiQueryRaw { get; set; }
+
+        public bool DbMultiQueryEf { get; set; }
+
+        public bool DbMultiQueryDapper { get; set; }
+
+        public bool DbFortunesRaw { get; set; }
+
+        public bool DbFortunesEf { get; set; }
+
+        public bool DbFortunesDapper { get; set; }
+
+        public bool Any(string partialName) =>
+            typeof(Scenarios).GetTypeInfo().DeclaredProperties
+                .Where(p => p.Name.IndexOf(partialName, StringComparison.Ordinal) >= 0 && (bool)p.GetValue(this))
+                .Any();
+
+        public IEnumerable<string> GetNames() =>
+            typeof(Scenarios).GetTypeInfo().DeclaredProperties
+                .Select(p => p.Name);
+
+        public IEnumerable<string> GetEnabled() =>
+            typeof(Scenarios).GetTypeInfo().DeclaredProperties
+                .Where(p => p.GetValue(this) is bool && (bool)p.GetValue(this))
+                .Select(p => p.Name);
+
+        public int Enable(string partialName)
+        {
+            var props = typeof(Scenarios).GetTypeInfo().DeclaredProperties
+                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToList();
+
+            foreach (var p in props)
+            {
+                p.SetValue(this, true);
+            }
+            
+            return props.Count;
+        }
+        
+        public void EnableDefault()
+        {
+            Plaintext = true;
+            Json = true;
+        }
+    }
+}

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -145,7 +145,7 @@ namespace Benchmarks
 
             app.UseDebugInfoPage();
 
-            app.Run(context => context.Response.WriteAsync("Try /plaintext instead"));
+            app.Run(context => context.Response.WriteAsync("Try /plaintext instead, or /debug for more information"));
         }
 
         public class Options

--- a/src/Benchmarks/appsettings.json
+++ b/src/Benchmarks/appsettings.json
@@ -1,3 +1,4 @@
 ﻿{
-  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true",
+  "Scenarios": "Plaintext,Json"
 }

--- a/src/Benchmarks/hosting.json
+++ b/src/Benchmarks/hosting.json
@@ -1,5 +1,0 @@
-{
-  "server": "Microsoft.AspNetCore.Server.Kestrel",
-  "server.urls": "http://*:5001",
-  "captureStartupErrors": true
-}

--- a/src/Benchmarks/project.json
+++ b/src/Benchmarks/project.json
@@ -19,7 +19,7 @@
     "ef": "Microsoft.EntityFrameworkCore.Commands"
   },
   "frameworks": {
-    "dnx451": {},
+    "net451": {},
     "dnxcore50": {
       "dependencies": {
         "System.Runtime.Serialization.Primitives": "4.1.0-*"


### PR DESCRIPTION
Allows configuration of which scenarios to enable via interactive prompts in the console, cmd line args, or a `scenarios.json` file. This is to ensure scenarios don't suffer any performance impact from other bits in the app not required for that scenario.

@davidfowl