### PR TITLE
Add Header+Stream pooling

### DIFF
--- a/src/Benchmarks/appsettings.json
+++ b/src/Benchmarks/appsettings.json
@@ -1,4 +1,6 @@
 ﻿{
   "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "Scenarios": "Plaintext,Json"
+  "Scenarios": "Plaintext,Json",
+  "kestrel.maxPooledStreams": 256,
+  "kestrel.maxPooledHeaders": 256
 }


### PR DESCRIPTION
Headers were previously reused for every request on a connection; now they are created for each request. This override restores the previous behaviour (though slightly different - as it is cross connection and runs with a lower idling memory set)

Ref https://github.com/aspnet/KestrelHttpServer/pull/608

/cc @DamianEdwards 