### PR TITLE
React to change moving ExpressionExtensions in assembly Microsoft.Ent…

### DIFF
--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
 using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Benchmarks.Configuration
 {


### PR DESCRIPTION
…ityFrameworkCore from namespace System.Linq.Expressions to Microsoft.EntityFrameworkCore.Internal.

Source change: https://github.com/aspnet/EntityFramework/commit/f2ece6c26ddcdde6dd8c3dbae61aca3cc98e7971#diff-f27e5dca0cb2fa6bb2be02ffbb011ce8

@halter73 