### PR TITLE
allow benchmarks to run within techempower automation on linux

### DIFF
--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -8,18 +8,16 @@ using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json;
 
 namespace Benchmarks.Middleware
 {
     public class JsonMiddleware
     {
-        private const int _contentLength = 27;
         private static readonly Task _done = Task.FromResult(0);
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
         private static readonly JsonSerializer _json = new JsonSerializer();
-        // don't emit a BOM
-        private static readonly UTF8Encoding _encoding = new UTF8Encoding(false);
 
         private readonly RequestDelegate _next;
         
@@ -34,9 +32,8 @@ namespace Benchmarks.Middleware
             {
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentType = "application/json";
-                httpContext.Response.ContentLength = _contentLength;
 
-                using (var sw = new StreamWriter(httpContext.Response.Body, _encoding, bufferSize: _contentLength))
+                using (var sw = new HttpResponseStreamWriter(httpContext.Response.Body, Encoding.UTF8))
                 {
                     _json.Serialize(sw, new { message = "Hello, World!" });
                 }

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -14,9 +14,12 @@ namespace Benchmarks.Middleware
 {
     public class JsonMiddleware
     {
+        private const int _contentLength = 27;
         private static readonly Task _done = Task.FromResult(0);
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
         private static readonly JsonSerializer _json = new JsonSerializer();
+        // don't emit a BOM
+        private static readonly UTF8Encoding _encoding = new UTF8Encoding(false);
 
         private readonly RequestDelegate _next;
         
@@ -31,9 +34,9 @@ namespace Benchmarks.Middleware
             {
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentType = "application/json";
-                httpContext.Response.ContentLength = 30;
+                httpContext.Response.ContentLength = _contentLength;
 
-                using (var sw = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, bufferSize: 30))
+                using (var sw = new StreamWriter(httpContext.Response.Body, _encoding, bufferSize: _contentLength))
                 {
                     _json.Serialize(sw, new { message = "Hello, World!" });
                 }

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -40,8 +40,15 @@ namespace Benchmarks
             Server = webHostBuilder.GetSetting(WebHostDefaults.ServerKey);
 
             var webHost = webHostBuilder.Build();
+            Console.WriteLine($"Server GC is currently {(GCSettings.IsServerGC ? "ENABLED" : "DISABLED")}");
+            
+            bool nonInteractive;
+            bool.TryParse(webHostBuilder.GetSetting("NonInteractive"), out nonInteractive);
 
-            StartInteractiveConsoleThread();
+            if(!nonInteractive)
+            {
+                StartInteractiveConsoleThread();
+            }
 
             webHost.Run();
         }
@@ -55,7 +62,6 @@ namespace Benchmarks
 
             var interactiveThread = new Thread(() =>
             {
-                Console.WriteLine($"Server GC is currently {(GCSettings.IsServerGC ? "ENABLED" : "DISABLED")}");
                 Console.WriteLine("Press 'C' to force GC or any other key to display GC stats");
                 Console.WriteLine();
 


### PR DESCRIPTION
2 fixes for running in the techempower suite:
- Console.ReadKey throws when the process is run in the background, so allow interactivity to be toggled off (remains on by default)
- the python JSON parser can't read responses that begin with a BOM