### PR TITLE
Remove "--infer-runtimes" from call to "dotnet restore"

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -221,7 +221,7 @@ namespace BenchmarkServer
             // Restore in each dir
             foreach (var dir in dirs)
             {
-                ProcessUtil.Run("dotnet", "restore --infer-runtimes", workingDirectory: Path.Combine(path, dir));
+                ProcessUtil.Run("dotnet", "restore", workingDirectory: Path.Combine(path, dir));
             }
 
             return benchmarksDir;


### PR DESCRIPTION
- No longer needed since benchmarks and all dependencies use netstandard or netcoreapp

@BrennanConroy, @rynowak, @JunTaoLuo 