### PR TITLE
Run "dotnet restore" in "repo\src" rather than "repo\"

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -221,7 +221,7 @@ namespace BenchmarkServer
             // Restore in each dir
             foreach (var dir in dirs)
             {
-                ProcessUtil.Run("dotnet", "restore", workingDirectory: Path.Combine(path, dir));
+                ProcessUtil.Run("dotnet", "restore", workingDirectory: Path.Combine(path, dir, "src"));
             }
 
             return benchmarksDir;


### PR DESCRIPTION
- Reduces restore time of Mvc by 30s

@rynowak 