### PR TITLE
Remove all usages of IApplicationEnvironment

### DIFF
--- a/src/Benchmarks/Middleware/DebugInfoPageMiddleware.cs
+++ b/src/Benchmarks/Middleware/DebugInfoPageMiddleware.cs
@@ -23,18 +23,16 @@ namespace Benchmarks.Middleware
 #else
         private static readonly string _configurationName = "";
 #endif
-
-        private readonly IApplicationEnvironment _appEnv;
+        
         private readonly IHostingEnvironment _hostingEnv;
         private readonly RequestDelegate _next;
         private readonly Scenarios _scenarios;
         private readonly IServerAddressesFeature _serverAddresses;
 
-        public DebugInfoPageMiddleware(RequestDelegate next, IServerAddressesFeature serverAddresses, IHostingEnvironment hostingEnv, IApplicationEnvironment appEnv, Scenarios scenarios)
+        public DebugInfoPageMiddleware(RequestDelegate next, IServerAddressesFeature serverAddresses, IHostingEnvironment hostingEnv, Scenarios scenarios)
         {
             _next = next;
             _hostingEnv = hostingEnv;
-            _appEnv = appEnv;
             _scenarios = scenarios;
             _serverAddresses = serverAddresses;
         }
@@ -48,7 +46,7 @@ namespace Benchmarks.Middleware
             await httpContext.Response.WriteAsync("<h2>Configuration Information</h2>");
             await httpContext.Response.WriteAsync("<ul>");
             await httpContext.Response.WriteAsync($"<li>Environment: {_hostingEnv.EnvironmentName}</li>");
-            await httpContext.Response.WriteAsync($"<li>Framework: {_appEnv.RuntimeFramework.FullName}</li>");
+            await httpContext.Response.WriteAsync($"<li>Framework: {PlatformServices.Default.Application.RuntimeFramework.FullName}</li>");
             await httpContext.Response.WriteAsync($"<li>Server GC enabled: {GCSettings.IsServerGC}</li>");
             await httpContext.Response.WriteAsync($"<li>Configuration: {_configurationName}</li>");
             await httpContext.Response.WriteAsync($"<li>Server: {Program.Server}</li>");

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Data.Common;
 using System.Data.SqlClient;
-using System.Reflection;
 using Benchmarks.Configuration;
 using Benchmarks.Data;
 using Benchmarks.Middleware;

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -25,12 +25,6 @@ namespace BenchmarkClient
 
         private static readonly IRepository<ClientJob> _jobs = new InMemoryRepository<ClientJob>();
 
-        private IApplicationEnvironment _env;
-        public Startup(IApplicationEnvironment environment)
-        {
-            _env = environment;
-        }
-
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -14,9 +14,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.PlatformAbstractions;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Repository;
 
 namespace BenchmarkServer
@@ -30,12 +28,6 @@ namespace BenchmarkServer
         private static readonly string _defaultHostname = Environment.MachineName.ToLowerInvariant();
 
         private static readonly IRepository<ServerJob> _jobs = new InMemoryRepository<ServerJob>();
-
-        private IApplicationEnvironment _env;
-        public Startup(IApplicationEnvironment environment)
-        {
-            _env = environment;
-        }
 
         public void ConfigureServices(IServiceCollection services)
         {


### PR DESCRIPTION
This is a more thorough change to fix the issues on the CI with the latest packages.

`IApplicationEnvironment` is going to be removed wholesale in the near future. This should fix the current issues and issues to come.