### PR TITLE
add new command line options

### DIFF
--- a/src/Benchmarks/Configuration/ConsoleHostScenariosConfiguration.cs
+++ b/src/Benchmarks/Configuration/ConsoleHostScenariosConfiguration.cs
@@ -22,19 +22,17 @@ namespace Benchmarks.Configuration
             var scenarioConfig = new ConfigurationBuilder()
                 .AddJsonFile("scenarios.json", optional: true)
                 .AddCommandLine(_args)
-                .Build()
-                .GetChildren()
-                .ToList();
+                .Build();
 
             var enabledCount = 0;
-
-            if (scenarioConfig.Count > 0)
+            var configuredScenarios = scenarioConfig["scenarios"];
+            if (!string.IsNullOrWhiteSpace(configuredScenarios))
             {
                 Console.WriteLine("Scenario configuration found in scenarios.json and/or command line args");
-
-                foreach (var scenario in scenarioConfig)
+                var choices = configuredScenarios.Split(',');
+                foreach (var choice in choices)
                 {
-                    enabledCount += scenarios.Enable(scenario.Value);
+                    enabledCount += scenarios.Enable(choice);
                 }
             }
             else

--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -111,6 +111,12 @@ namespace Benchmarks.Configuration
 
         public int Enable(string partialName)
         {
+            if(string.Equals(partialName, "[default]", StringComparison.OrdinalIgnoreCase))
+            {
+                EnableDefault();
+                return 2;
+            }
+            
             var props = typeof(Scenarios).GetTypeInfo().DeclaredProperties
                 .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0)
                 .ToList();

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
 using Newtonsoft.Json;
 
 namespace Benchmarks.Middleware
@@ -31,9 +32,8 @@ namespace Benchmarks.Middleware
             {
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentType = "application/json";
-                httpContext.Response.ContentLength = 30;
 
-                using (var sw = new StreamWriter(httpContext.Response.Body, Encoding.UTF8, bufferSize: 30))
+                using (var sw = new HttpResponseStreamWriter(httpContext.Response.Body, Encoding.UTF8))
                 {
                     _json.Serialize(sw, new { message = "Hello, World!" });
                 }

--- a/src/Benchmarks/appsettings.json
+++ b/src/Benchmarks/appsettings.json
@@ -1,4 +1,3 @@
 ﻿{
-  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "Scenarios": "Plaintext,Json"
+  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true"
 }

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -247,7 +247,7 @@ namespace BenchmarkServer
         private static Process StartProcess(string hostname, string benchmarksRepo, ServerJob job)
         {
             var filename = "dotnet";
-            var arguments = $"run -c Release -- --scenario {job.Scenario} --server.urls http://{hostname}:5000";
+            var arguments = $"run -c Release -- --scenarios {job.Scenario} --server.urls http://{hostname}:5000";
 
             Log.WriteLine($"Starting process '{filename} {arguments}'");
 


### PR DESCRIPTION
* Add new configuration options to toggle interactive thread and choose between kestrel and weblistener
* Add ability to specify multiple scenarios in configuration and a new [default] option for just middleware plaintext and json scenarios
* Fix json scenario so it doesn't emit a BOM

These make it possible to the benchmarks in the TechEmpower automation.

/cc @DamianEdwards @halter73 @mikeharder 