### PR TITLE
Update Newtonsoft.Json version

### DIFF
--- a/src/Benchmarks.ClientJob/project.json
+++ b/src/Benchmarks.ClientJob/project.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "Repository": "1.0.0-*",
-    "Newtonsoft.Json": "8.0.3"
+    "Newtonsoft.Json": "9.0.1-beta1"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/Benchmarks.ServerJob/project.json
+++ b/src/Benchmarks.ServerJob/project.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "Repository": "1.0.0-*",
-    "Newtonsoft.Json": "8.0.3"
+    "Newtonsoft.Json": "9.0.1-beta1"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/BenchmarksClient/project.json
+++ b/src/BenchmarksClient/project.json
@@ -15,7 +15,6 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
     "System.Diagnostics.Process": "4.1.0-*",
-    "Newtonsoft.Json": "8.0.*",
     "Repository": "1.0.0-*",
     "Benchmarks.ClientJob": "1.0.0-*"
   },

--- a/src/BenchmarksDriver/project.json
+++ b/src/BenchmarksDriver/project.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
-    "Newtonsoft.Json": "8.0.3",
     "Repository": "1.0.0-*",
     "Benchmarks.ClientJob": "1.0.0-*",
     "Benchmarks.ServerJob": "1.0.0-*",

--- a/src/BenchmarksServer/project.json
+++ b/src/BenchmarksServer/project.json
@@ -15,7 +15,6 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils": "1.0.0-*",
     "System.Diagnostics.Process": "4.1.0-*",
-    "Newtonsoft.Json": "8.0.*",
     "Repository": "1.0.0-*",
     "Benchmarks.ServerJob": "1.0.0-*"
   },


### PR DESCRIPTION
This was apparently missed when the version was bumped elsewhere.

Removed version references in a few places where we need to do the same thing as the framework. Let's discuss if there's a good reason to have these.