### PR TITLE
Only enable scenarios starting with the partial name

### DIFF
--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -139,7 +139,7 @@ namespace Benchmarks.Configuration
             }
             
             var props = typeof(Scenarios).GetTypeInfo().DeclaredProperties
-                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0)
+                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.StartsWith(partialName, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             foreach (var p in props)


### PR DESCRIPTION
- Previous code enabled scenarios containing the partial name anywhere, which made it impossible to enable "Plaintext" without "MvcPlaintext".

@DamianEdwards, @nathana1 