### PR TITLE
Validate service scopes to prevent bugs related to DI

### DIFF
--- a/src/Benchmarks/Data/ApplicationDbSeeder.cs
+++ b/src/Benchmarks/Data/ApplicationDbSeeder.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
-using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Benchmarks.Data
 {

--- a/src/Benchmarks/Data/ApplicationDbSeeder.cs
+++ b/src/Benchmarks/Data/ApplicationDbSeeder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 
@@ -10,13 +11,13 @@ namespace Benchmarks.Data
     {
         private readonly object _locker = new object();
         private readonly IRandom _random;
-        private readonly ApplicationDbContext _dbContext;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
         private bool _seeded = false;
 
-        public ApplicationDbSeeder(IRandom random, ApplicationDbContext dbContext)
+        public ApplicationDbSeeder(IRandom random, IServiceScopeFactory serviceScopeFactory)
         {
             _random = random;
-            _dbContext = dbContext;
+            _serviceScopeFactory = serviceScopeFactory;
         }
 
         public bool Seed()
@@ -29,47 +30,54 @@ namespace Benchmarks.Data
                     {
                         try
                         {
-                            var world = _dbContext.World.Count();
-                            var fortune = _dbContext.Fortune.Count();
-
-                            if (world == 0 || fortune == 0)
+                            using (var serviceScope = _serviceScopeFactory.CreateScope())
                             {
-                                if (world == 0)
+                                var dbContext = serviceScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+                                dbContext.Database.EnsureCreated();
+
+                                var world = dbContext.World.Count();
+                                var fortune = dbContext.Fortune.Count();
+
+                                if (world == 0 || fortune == 0)
                                 {
-                                    for (int i = 0; i < 10000; i++)
+                                    if (world == 0)
                                     {
-                                        _dbContext.World.Add(new World { RandomNumber = _random.Next(1, 10001) });
+                                        for (int i = 0; i < 10000; i++)
+                                        {
+                                            dbContext.World.Add(new World { RandomNumber = _random.Next(1, 10001) });
+                                        }
+                                        dbContext.SaveChanges();
                                     }
-                                    _dbContext.SaveChanges();
-                                }
 
-                                if (fortune == 0)
+                                    if (fortune == 0)
+                                    {
+                                        dbContext.Fortune.Add(new Fortune { Message = "fortune: No such file or directory" });
+                                        dbContext.Fortune.Add(new Fortune { Message = "A computer scientist is someone who fixes things that aren't broken." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "After enough decimal places, nobody gives a damn." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1" });
+                                        dbContext.Fortune.Add(new Fortune { Message = "A computer program does what you tell it to do, not what you want it to do." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen" });
+                                        dbContext.Fortune.Add(new Fortune { Message = "Any program that runs right is obsolete." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "A list is only as strong as its weakest link. — Donald Knuth" });
+                                        dbContext.Fortune.Add(new Fortune { Message = "Feature: A bug with seniority." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "Computers make very fast, very accurate mistakes." });
+                                        dbContext.Fortune.Add(new Fortune { Message = "<script>alert(\"This should not be displayed in a browser alert box.\");</script>" });
+                                        dbContext.Fortune.Add(new Fortune { Message = "フレームワークのベンチマーク" });
+
+                                        dbContext.SaveChanges();
+                                    }
+
+                                    Console.WriteLine("Database successfully seeded!");
+                                }
+                                else
                                 {
-                                    _dbContext.Fortune.Add(new Fortune { Message = "fortune: No such file or directory" });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "A computer scientist is someone who fixes things that aren't broken." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "After enough decimal places, nobody gives a damn." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "A bad random number generator: 1, 1, 1, 1, 1, 4.33e+67, 1, 1, 1" });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "A computer program does what you tell it to do, not what you want it to do." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "Emacs is a nice operating system, but I prefer UNIX. — Tom Christaensen" });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "Any program that runs right is obsolete." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "A list is only as strong as its weakest link. — Donald Knuth" });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "Feature: A bug with seniority." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "Computers make very fast, very accurate mistakes." });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "<script>alert(\"This should not be displayed in a browser alert box.\");</script>" });
-                                    _dbContext.Fortune.Add(new Fortune { Message = "フレームワークのベンチマーク" });
-
-                                    _dbContext.SaveChanges();
+                                    Console.WriteLine("Database already seeded!");
                                 }
 
-                                Console.WriteLine("Database successfully seeded!");
+                                _seeded = true;
+                                return true;
                             }
-                            else
-                            {
-                                Console.WriteLine("Database already seeded!");
-                            }
-
-                            _seeded = true;
-                            return true;
                         }
                         catch (Exception ex)
                         {

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -53,7 +53,7 @@ namespace Benchmarks
             services.AddSingleton<ApplicationDbSeeder>();
             services.AddEntityFrameworkSqlServer()
                 .AddDbContext<ApplicationDbContext>();
-            
+
             if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
             {
                 services.AddSingleton<DbProviderFactory>((provider) => {
@@ -123,7 +123,7 @@ namespace Benchmarks
             return services.BuildServiceProvider(validateScopes: true);
         }
 
-        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder, ApplicationDbContext dbContext)
+        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder)
         {
             if (Scenarios.Plaintext)
             {
@@ -206,8 +206,6 @@ namespace Benchmarks
 
             if (Scenarios.Any("Db"))
             {
-                dbContext.Database.EnsureCreated();
-
                 if (!dbSeeder.Seed())
                 {
                     Environment.Exit(1);

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -40,7 +40,7 @@ namespace Benchmarks
 
         public Scenarios Scenarios { get; }
 
-        public void ConfigureServices(IServiceCollection services)
+        public IServiceProvider ConfigureServices(IServiceCollection services)
         {
             services.Configure<AppSettings>(Configuration);
 
@@ -119,6 +119,8 @@ namespace Benchmarks
             {
                 services.AddMemoryResponseCacheStore();
             }
+
+            return services.BuildServiceProvider(validateScopes: true);
         }
 
         public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder, ApplicationDbContext dbContext)


### PR DESCRIPTION
- `ApplicationDbSeeder` manually creates a scope for `ApplicationDbContext`, since a singleton cannot consume a scoped via ctor injection.
- Moved `dbContext.Database.EnsureCreated()` from `Configure` to `ApplicationDbSeeder`.  Otherwise, the `ApplicationDbContext` passed to `Configure` will not be disposed until the app exits.

@nathana1, @halter73, @sebastienros 

Diff ignoring whitespace: https://github.com/aspnet/benchmarks/pull/135/files?w=1