### PR TITLE
Use EF's new user-cached compiled queries and update scenario tweak

### DIFF
--- a/src/Benchmarks/Data/ApplicationDbContext.cs
+++ b/src/Benchmarks/Data/ApplicationDbContext.cs
@@ -11,6 +11,8 @@ namespace Benchmarks.Data
             : base(options)
         {
             Database.AutoTransactionsEnabled = false;
+            ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            ChangeTracker.AutoDetectChangesEnabled = false;
         }
 
         public DbSet<World> World { get; set; }

--- a/src/Benchmarks/Data/EfDb.cs
+++ b/src/Benchmarks/Data/EfDb.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data
@@ -14,19 +17,23 @@ namespace Benchmarks.Data
         private readonly IRandom _random;
         private readonly ApplicationDbContext _dbContext;
         private readonly bool _useBatchUpdate;
-
+        
         public EfDb(IRandom random, ApplicationDbContext dbContext, IOptions<AppSettings> appSettings)
         {
             _random = random;
             _dbContext = dbContext;
-            _dbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
             _useBatchUpdate = appSettings.Value.Database != DatabaseServer.PostgreSql;
         }
+
+        private static readonly Func<ApplicationDbContext, int, Task<World>> _firstWorldQuery
+            = EF.CompileAsyncQuery((ApplicationDbContext context, int id) 
+                => context.World.First(w => w.Id == id));
 
         public Task<World> LoadSingleQueryRow()
         {
             var id = _random.Next(1, 10001);
-            return _dbContext.World.FirstAsync(w => w.Id == id);
+
+            return _firstWorldQuery(_dbContext, id);
         }
 
         public async Task<World[]> LoadMultipleQueriesRows(int count)
@@ -36,7 +43,8 @@ namespace Benchmarks.Data
             for (var i = 0; i < count; i++)
             {
                 var id = _random.Next(1, 10001);
-                result[i] = await _dbContext.World.FirstAsync(w => w.Id == id);
+
+                result[i] = await _firstWorldQuery(_dbContext, id);
             }
 
             return result;
@@ -49,9 +57,10 @@ namespace Benchmarks.Data
             for (var i = 0; i < count; i++)
             {
                 var id = _random.Next(1, 10001);
-                var result = await _dbContext.World.AsTracking().FirstAsync(w => w.Id == id);
+                var result = await _firstWorldQuery(_dbContext, id);
 
-                result.RandomNumber = _random.Next(1, 10001);
+                _dbContext.Attach(result).Property("RandomNumber").CurrentValue = _random.Next(1, 10001);
+
                 results[i] = result;
 
                 if (!_useBatchUpdate)
@@ -68,9 +77,12 @@ namespace Benchmarks.Data
             return results;
         }
 
+        private static readonly Func<ApplicationDbContext, AsyncEnumerable<Fortune>> _fortunesQuery
+            = EF.CompileAsyncQuery((ApplicationDbContext context) => context.Fortune); 
+
         public async Task<IEnumerable<Fortune>> LoadFortunesRows()
         {
-            var result = await _dbContext.Fortune.ToListAsync();
+            var result = await _fortunesQuery(_dbContext).ToListAsync();
 
             result.Add(new Fortune { Message = "Additional fortune added at request time." });
             result.Sort();

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -71,17 +71,13 @@ namespace Benchmarks
 
             if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
             {
-                services.AddSingleton<DbProviderFactory>((provider) => {
+                services.AddSingleton(provider =>
+                {
                     var settings = provider.GetRequiredService<IOptions<AppSettings>>().Value;
 
-                    if (settings.Database == DatabaseServer.PostgreSql)
-                    {
-                        return NpgsqlFactory.Instance;
-                    }
-                    else
-                    {
-                        return SqlClientFactory.Instance;
-                    }
+                    return settings.Database == DatabaseServer.PostgreSql
+                        ? (DbProviderFactory) NpgsqlFactory.Instance
+                        : SqlClientFactory.Instance;
                 });
             }
 
@@ -104,7 +100,7 @@ namespace Benchmarks
             {
                 var settings = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Katakana, UnicodeRanges.Hiragana);
                 settings.AllowCharacter('\u2014');  // allow EM DASH through
-                services.AddWebEncoders((options) =>
+                services.AddWebEncoders(options =>
                 {
                     options.TextEncoderSettings = settings;
                 });


### PR DESCRIPTION
Avoids the internal automatic query cache. Typically yields 3-5% perf. improvement. Tweaked the update scenario to do an explicit state update vs. automatic change detection.

