### PR TITLE
Add a scenario where ReponseCaching Middleware no-ops

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -38,6 +38,7 @@ default DOTNET_ARGUMENT='-v '
       "-n MemoryCachePlaintext",
       "-n MemoryCachePlaintextSetRemove",
       "-n ResponseCachingPlaintextCached",
+      "-n ResponseCachingPlaintextCached --method DELETE",
       "-n ResponseCachingPlaintextResponseNoCache",
       "-n ResponseCachingPlaintextRequestNoCache",
       "-n ResponseCachingPlaintextVaryByCached",

--- a/scripts/pipeline.lua
+++ b/scripts/pipeline.lua
@@ -1,21 +1,27 @@
 local pipelineDepth = 1
 local counter = 0
 local maxRequests = -1
+local method = "GET"
 
 function init(args)
+
    if args[1] ~= nil then
       pipelineDepth = tonumber(args[1])
    end
 
+   if args[2] ~= nil then
+      method = args[2]
+   end
+
    local r = {}
    for i = 1, pipelineDepth, 1 do
-      r[i] = wrk.format(nil)
+      r[i] = wrk.format(method)
    end
 
    print("Pipeline depth: " .. pipelineDepth)
 
-   if args[2] ~= nil then
-      maxRequests = tonumber(args[2])
+   if args[3] ~= nil then
+      maxRequests = tonumber(args[3])
       print("Max requests: " .. maxRequests)
    end
 

--- a/src/Benchmarks.ClientJob/ClientJob.cs
+++ b/src/Benchmarks.ClientJob/ClientJob.cs
@@ -26,6 +26,7 @@ namespace Benchmarks.ClientJob
             RequestsPerSecond = clientJob.RequestsPerSecond;
             Output = clientJob.Output;
             Error = clientJob.Error;
+            Method = clientJob.Method;
         }
 
         public int Id { get; set; }
@@ -50,5 +51,7 @@ namespace Benchmarks.ClientJob
         public string Output { get; set; }
 
         public string Error { get; set; }
+
+        public string Method { get; set; } = "GET";
     }
 }

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -97,7 +97,7 @@ namespace BenchmarkClient
                 if (job != null)
                 {
                     var jobLogText = $"[ID:{job.Id} Connections:{job.Connections} Threads:{job.Threads} " +
-                        $"Duration:{job.Duration} Pipeline:{job.PipelineDepth}";
+                        $"Duration:{job.Duration} Pipeline:{job.PipelineDepth} Method:{job.Method}";
 
                     if (job.Headers != null)
                     {
@@ -161,6 +161,11 @@ namespace BenchmarkClient
             if (job.PipelineDepth > 0)
             {
                 command += $" -- {job.PipelineDepth}";
+
+                if (job.Method != "GET")
+                {
+                    command += $" {job.Method}";
+                }
             }
 
             var process = new Process()


### PR DESCRIPTION
#169 

We skip the middleware for unsafe methods so I'm adding a scenario where a DELETE request is sent to the same endpoint that is used by plaintext cached. 

I needed to update the pipeline.lua script to handle specific methods but I think we don't need to update the SQL update query to add Method into the database since the scenario name should be sufficient.