### PR TITLE
Pin version of Microsoft.DotNet.Cli.Utils

### DIFF
--- a/src/BenchmarksDriver/project.json
+++ b/src/BenchmarksDriver/project.json
@@ -12,7 +12,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-preview2-003121",
     "Microsoft.Extensions.CommandLineUtils": "1.2.0-*",
     "Repository": {
       "target": "project"


### PR DESCRIPTION
Looks like a new version of Microsoft.DotNet.Cli.Utils was released on Monday that references Nuget packages that have not been published yet. 

```
error: Unable to resolve 'NuGet.Versioning (>= 4.0.0-rc3)' for '.NETCoreApp,Version=v1.1'.
error: Unable to resolve 'NuGet.Packaging (>= 4.0.0-rc3)' for '.NETCoreApp,Version=v1.1'.
error: Unable to resolve 'NuGet.Frameworks (>= 4.0.0-rc3)' for '.NETCoreApp,Version=v1.1'.
error: Unable to resolve 'NuGet.ProjectModel (>= 4.0.0-rc3)' for '.NETCoreApp,Version=v1.1'.
```

We should let the relevant teams know but for now I'll just pin the versions to what all of our repos are using. 

cc @muratg @mikeharder 