### PR TITLE
Support running driver and server on Linux

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -3,6 +3,8 @@ var AUTHORS='Microsoft Open Technologies, Inc.'
 use-standard-lifecycle
 k-standard-goals
 
+default DOTNET_ARGUMENT='-v '
+
 #build-compile target='compile'
   @{
     var projectFiles = Files
@@ -12,6 +14,9 @@ k-standard-goals
 
     projectFiles.ForEach(projectFile => DotnetBuild(projectFile, E("Configuration"), E("KOREBUILD_BUILD_FRAMEWORK")));
   }
+
+#benchmark-quiet target='--quiet'
+  -DOTNET_ARGUMENT='';
 
 #benchmark-tests .compile
   @{
@@ -37,8 +42,26 @@ k-standard-goals
       "-n ResponseCachingPlaintextRequestNoCache",
       "-n ResponseCachingPlaintextVaryByCached",
     };
+
+    // Expect failures with HttpSys if BenchmarksServer is running on Linux. Never expect two failures in a row.
+    var lastFailed = false;
     foreach (var scenario in scenarios) {
-      Dotnet(String.Format("-v run -- {0} -s {1} -c {2} {3}", scenario, E("BENCHMARK_SERVER"), E("BENCHMARK_CLIENT"), sql),
-        "src/BenchmarksDriver");
+      try
+      {
+        Dotnet(
+          String.Format("{4}run -- {0} -s {1} -c {2} {3}", scenario, E("BENCHMARK_SERVER"), E("BENCHMARK_CLIENT"), sql,
+            DOTNET_ARGUMENT),
+          "src/BenchmarksDriver");
+        lastFailed = false;
+      }
+      catch
+      {
+        if (lastFailed)
+        {
+          throw;
+        }
+
+        lastFailed = true;
+      }
     }
   }

--- a/makefile.shade
+++ b/makefile.shade
@@ -43,25 +43,10 @@ default DOTNET_ARGUMENT='-v '
       "-n ResponseCachingPlaintextVaryByCached",
     };
 
-    // Expect failures with HttpSys if BenchmarksServer is running on Linux. Never expect two failures in a row.
-    var lastFailed = false;
     foreach (var scenario in scenarios) {
-      try
-      {
-        Dotnet(
-          String.Format("{4}run -- {0} -s {1} -c {2} {3}", scenario, E("BENCHMARK_SERVER"), E("BENCHMARK_CLIENT"), sql,
-            DOTNET_ARGUMENT),
-          "src/BenchmarksDriver");
-        lastFailed = false;
-      }
-      catch
-      {
-        if (lastFailed)
-        {
-          throw;
-        }
-
-        lastFailed = true;
-      }
+      Dotnet(
+        String.Format("{4}run -- {0} -s {1} -c {2} {3}", scenario, E("BENCHMARK_SERVER"), E("BENCHMARK_CLIENT"), sql,
+          DOTNET_ARGUMENT),
+        "src/BenchmarksDriver");
     }
   }

--- a/src/Benchmarks.ServerJob/ServerState.cs
+++ b/src/Benchmarks.ServerJob/ServerState.cs
@@ -9,6 +9,7 @@ namespace Benchmarks.ServerJob
         Starting,
         Running,
         Failed,
-        Deleting
+        Deleting,
+        NotSupported,
     }
 }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -231,8 +231,12 @@ namespace BenchmarkDriver
                     }
                     else if (serverJob.State == ServerState.Failed)
                     {
-                        LogVerbose("Server job failed");
-                        return 1;
+                        throw new InvalidOperationException("Server job failed");
+                    }
+                    else if (serverJob.State == ServerState.NotSupported)
+                    {
+                        Log("Server does not support this job configuration.");
+                        return 0;
                     }
                     else
                     {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -231,7 +231,8 @@ namespace BenchmarkDriver
                     }
                     else if (serverJob.State == ServerState.Failed)
                     {
-                        throw new InvalidOperationException("Server job failed");
+                        LogVerbose("Server job failed");
+                        return 1;
                     }
                     else
                     {

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -116,9 +116,9 @@ namespace BenchmarkServer
                         {
                             if (!_isWindows && job.WebHost != WebHost.Kestrel)
                             {
-                                Log.WriteLine($"Failing job '{job.Id}' with scenario '{job.Scenario}'.");
+                                Log.WriteLine($"Skipping job '{job.Id}' with scenario '{job.Scenario}'.");
                                 Log.WriteLine($"'{job.WebHost}' is not supported on this platform.");
-                                job.State = ServerState.Failed;
+                                job.State = ServerState.NotSupported;
                                 continue;
                             }
 


### PR DESCRIPTION
Support BenchmarksServer on Linux
- use correct path separator everywhere
- fail HttpSys jobs immediately on Linux
- only use `taskkill.exe` on Windows (`pkill` on Linux)

Enable benchmark-tests with everything on Linux
- allow HttpSys jobs to fail without interrupting `benchmark-tests` target
- also don't make `dotnet run` verbose `--quiet` target used