### PR TITLE
Downgrade to stable dependencies and remove redundant settings

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,12 +1,11 @@
 <Project>
+  <Import Project="dependencies.props" />
   <Import Project="..\version.props" />
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>
     <RepositoryUrl>https://github.com/aspnet/Benchmarks</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetCoreAppImplicitPackageVersion>1.2.0-*</NetCoreAppImplicitPackageVersion>
-    <NetStandardImplicitPackageVersion>1.6.2-*</NetStandardImplicitPackageVersion>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <CoreFxVersion>4.3.0</CoreFxVersion>
+  </PropertyGroup>
+</Project>

--- a/experimental/HttpBenchmark/HttpBenchmark.csproj
+++ b/experimental/HttpBenchmark/HttpBenchmark.csproj
@@ -6,6 +6,7 @@
     <Description>HTTP benchmarking tool</Description>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>

--- a/experimental/HttpBenchmark/runtimeconfig.template.json
+++ b/experimental/HttpBenchmark/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.GC.Server": true
-  }
-}

--- a/src/Benchmarks.ClientJob/Benchmarks.ClientJob.csproj
+++ b/src/Benchmarks.ClientJob/Benchmarks.ClientJob.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <Description>Class to transfer data to/from the benchmark client.</Description>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Benchmarks.ServerJob/Benchmarks.ServerJob.csproj
+++ b/src/Benchmarks.ServerJob/Benchmarks.ServerJob.csproj
@@ -5,11 +5,13 @@
   <PropertyGroup>
     <Description>Class to transfer data to/from the benchmark server.</Description>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Repository\Repository.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -6,16 +6,8 @@
     <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
     <!-- TODO remove rid when https://github.com/dotnet/sdk/issues/396 is resolved -->
     <RuntimeIdentifier Condition="'$(TargetFramework)'!='netcoreapp1.1'">win7-x64</RuntimeIdentifier>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
-    <Content Update="testCert.pfx" CopyToOutputDirectory="PreserveNewest" />
-    <Content Update="wwwroot\**\*" CopyToOutputDirectory="PreserveNewest" />
-    <Content Update="Views\**\*" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.*" />
@@ -42,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.4.0-*" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/runtimeconfig.template.json
+++ b/src/Benchmarks/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.GC.Server": true
-  }
-}

--- a/src/BenchmarksClient/BenchmarksClient.csproj
+++ b/src/BenchmarksClient/BenchmarksClient.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <Description>REST APIs to run ASP.NET benchmark client.</Description>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/BenchmarksClient/runtimeconfig.template.json
+++ b/src/BenchmarksClient/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.GC.Server": true
-  }
-}

--- a/src/BenchmarksDriver/BenchmarksDriver.csproj
+++ b/src/BenchmarksDriver/BenchmarksDriver.csproj
@@ -5,17 +5,19 @@
   <PropertyGroup>
     <Description>Schedules benchmark jobs on both the server and client.</Description>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Benchmarks.ClientJob\Benchmarks.ClientJob.csproj" />
     <ProjectReference Include="..\Benchmarks.ServerJob\Benchmarks.ServerJob.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.0-preview2-003121" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.2.0-*" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-*" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.4.0-*" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/BenchmarksServer/BenchmarksServer.csproj
+++ b/src/BenchmarksServer/BenchmarksServer.csproj
@@ -5,14 +5,15 @@
   <PropertyGroup>
     <Description>REST APIs to run ASP.NET benchmark server.</Description>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Repository\Repository.csproj" />
     <ProjectReference Include="..\Benchmarks.ServerJob\Benchmarks.ServerJob.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.2.0-*" />

--- a/src/BenchmarksServer/runtimeconfig.template.json
+++ b/src/BenchmarksServer/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-  "configProperties": {
-    "System.GC.Server": true
-  }
-}

--- a/src/Repository/Repository.csproj
+++ b/src/Repository/Repository.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <Description>Repository to hold objects which can be identified by an integer.</Description>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <WarningsAsErrors>true</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
We downgraded all of our test projects to .NET Core 1.1 for now.