### PR TITLE
Optimize kestrelThreadCount values for Plaintext

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -3,7 +3,7 @@
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 2" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 32 --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
     <Scenarios Include="-n Json -o KestrelHttpServer@feature/dev-si" />
     <Scenarios Include="-n Plaintext" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,13 +1,11 @@
 <Project>
   <ItemGroup>
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 1" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 1 --kestrelThreadPoolDispatching false" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 2" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 2 --kestrelThreadPoolDispatching false" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
-    <Scenarios Include="-n Json -o KestrelHttpServer@dev --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Json -o KestrelHttpServer@feature/dev-si" />
-    <Scenarios Include="-n Json -o KestrelHttpServer@feature/dev-si --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Plaintext" />
     <Scenarios Include="-n Plaintext -r Desktop" />
     <Scenarios Include="-n Plaintext --webHost HttpSys" />


### PR DESCRIPTION
- Temporarily remove JSON kestrelThreadPoolDispatch until it can be optimized