### PR TITLE
Restore support for urls like "http://+:5000"

### DIFF
--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -190,7 +190,7 @@ namespace Benchmarks
                     listenOptions.ConnectionAdapters.Add(connectionFilter);
                 }
 
-                if (urlPrefix.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+                if (urlPrefix.IsHttps)
                 {
                     listenOptions.UseHttps("testCert.pfx", "testPassword");
                 }

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Adapter;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.AspNetCore.Server.Kestrel.Internal;
 
 namespace Benchmarks
@@ -178,8 +179,8 @@ namespace Benchmarks
 
         private static void Listen(KestrelServerOptions options, IConfigurationRoot config, string url)
         {
-            var uri = new Uri(url);
-            var endpoint =  CreateIPEndPoint(uri);
+            var urlPrefix = UrlPrefix.Create(url);
+            var endpoint =  CreateIPEndPoint(urlPrefix);
 
             options.Listen(endpoint, listenOptions =>
             {
@@ -189,27 +190,27 @@ namespace Benchmarks
                     listenOptions.ConnectionAdapters.Add(connectionFilter);
                 }
 
-                if (uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+                if (urlPrefix.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                 {
                     listenOptions.UseHttps("testCert.pfx", "testPassword");
                 }
             });
         }
 
-        private static IPEndPoint CreateIPEndPoint(Uri uri)
+        private static IPEndPoint CreateIPEndPoint(UrlPrefix urlPrefix)
         {
             IPAddress ip;
 
-            if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(urlPrefix.Host, "localhost", StringComparison.OrdinalIgnoreCase))
             {
                 ip = IPAddress.Loopback;
             }
-            else if (!IPAddress.TryParse(uri.Host, out ip))
+            else if (!IPAddress.TryParse(urlPrefix.Host, out ip))
             {
                 ip = IPAddress.IPv6Any;
             }
 
-            return new IPEndPoint(ip, uri.Port);
+            return new IPEndPoint(ip, urlPrefix.PortValue);
         }
     }
 }


### PR DESCRIPTION
- System.Uri doesn't support hostnames like "+", but Microsoft.AspNetCore.Server.HttpSys.UrlPrefix does.