### PR TITLE
Add LogLevel parameter to help diagnose failures 

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.2.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.TaskCache.Sources" Version="1.2.0-*" PrivateAssets="All" />
     <!--

--- a/src/Benchmarks/Configuration/AppSettings.cs
+++ b/src/Benchmarks/Configuration/AppSettings.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using Microsoft.Extensions.Logging;
 
 namespace Benchmarks.Configuration
 {
     public class AppSettings
     {
         public string ConnectionString { get; set; }
+
         public DatabaseServer Database { get; set; } = DatabaseServer.SqlServer;
+
+        public LogLevel LogLevel { get; set; } = LogLevel.None;
     }
 }

--- a/src/Benchmarks/Configuration/AppSettings.cs
+++ b/src/Benchmarks/Configuration/AppSettings.cs
@@ -11,6 +11,6 @@ namespace Benchmarks.Configuration
 
         public DatabaseServer Database { get; set; } = DatabaseServer.SqlServer;
 
-        public LogLevel LogLevel { get; set; } = LogLevel.None;
+        public LogLevel? LogLevel { get; set; }
     }
 }

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -14,8 +14,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.PlatformAbstractions;
 using Npgsql;
 
 namespace Benchmarks
@@ -143,8 +143,14 @@ namespace Benchmarks
             return services.BuildServiceProvider(validateScopes: true);
         }
 
-        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder)
+        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder, IOptions<AppSettings> appSettings,
+            ILoggerFactory loggerFactory)
         {
+            if (appSettings.Value.LogLevel != LogLevel.None)
+            {
+                loggerFactory.AddConsole(appSettings.Value.LogLevel);
+            }
+
             if (Scenarios.Plaintext)
             {
                 app.UsePlainText();

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -146,9 +146,9 @@ namespace Benchmarks
         public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder, IOptions<AppSettings> appSettings,
             ILoggerFactory loggerFactory)
         {
-            if (appSettings.Value.LogLevel != LogLevel.None)
+            if (appSettings.Value.LogLevel.HasValue)
             {
-                loggerFactory.AddConsole(appSettings.Value.LogLevel);
+                loggerFactory.AddConsole(appSettings.Value.LogLevel.Value);
             }
 
             if (Scenarios.Plaintext)


### PR DESCRIPTION
- No-op when LogLevel is not set to avoid any possible performance impact