### PR TITLE
Add `StaticFiles` scenarios

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -7,6 +7,7 @@
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
     <Scenarios Include="-n Json -o KestrelHttpServer@feature/dev-si" />
     <Scenarios Include="-n Plaintext" />
+    <Scenarios Include="-n StaticFiles --path plaintext" />
     <Scenarios Include="-n Plaintext -r Desktop" />
     <Scenarios Include="-n Plaintext --webHost HttpSys" />
     <Scenarios Include="-n Plaintext -f Benchmarks.PassthroughConnectionFilter" />

--- a/experimental/PureNativeHttpServer/PureNativeHttpServer.vcxproj
+++ b/experimental/PureNativeHttpServer/PureNativeHttpServer.vcxproj
@@ -15,7 +15,6 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PureNativeHttpServer</RootNamespace>
     <ProjectName>PureNativeHttpServer</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/experimental/PureNativeHttpServer/PureNativeHttpServer.vcxproj
+++ b/experimental/PureNativeHttpServer/PureNativeHttpServer.vcxproj
@@ -15,6 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PureNativeHttpServer</RootNamespace>
     <ProjectName>PureNativeHttpServer</ProjectName>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/Benchmarks.ServerJob/Scenario.cs
+++ b/src/Benchmarks.ServerJob/Scenario.cs
@@ -37,5 +37,8 @@ namespace Benchmarks.ServerJob
 
         [ScenarioPath("/responsecaching/plaintext/varybycached")]
         ResponseCachingPlaintextVaryByCached,
+
+        [ScenarioPath("/plaintext", "/128B.txt", "/512B.txt", "/1KB.txt", "/4KB.txt", "/16KB.txt", "/512KB.txt", "/1MB.txt", "/5MB.txt")]
+        StaticFiles,
     }
 }

--- a/src/Benchmarks.ServerJob/ScenarioPathAttribute.cs
+++ b/src/Benchmarks.ServerJob/ScenarioPathAttribute.cs
@@ -10,6 +10,16 @@ namespace Benchmarks.ServerJob
     {
         public ScenarioPathAttribute(params string[] paths)
         {
+            if (paths == null)
+            {
+                throw new ArgumentNullException(nameof(paths));
+            }
+
+            if (paths.Length == 0)
+            {
+                throw new ArgumentException("Do not use this attribute without at least one path.", nameof(paths));
+            }
+
             Paths = paths;
         }
 

--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Benchmarks.Configuration
@@ -41,8 +41,19 @@ namespace Benchmarks.Configuration
         [ScenarioPath("/json")]
         public bool Json { get; set; }
 
-        [ScenarioPath("/128B.txt", "/512B.txt", "/1KB.txt", "/4KB.txt", "/16KB.txt", "/512KB.txt", "/1MB.txt", "/5MB.txt")]
+        [ScenarioPath("/mvc/plaintext")]
+        public bool MvcPlaintext { get; set; }
+
+        [ScenarioPath("/mvc/json")]
+        public bool MvcJson { get; set; }
+
+        [ScenarioPath("/plaintext", "/128B.txt", "/512B.txt", "/1KB.txt", "/4KB.txt", "/16KB.txt", "/512KB.txt", "/1MB.txt", "/5MB.txt")]
         public bool StaticFiles { get; set; }
+
+        //**
+        // Scenarios below this point are not currently automated. They are available for use when starting up the
+        // Benchmarks application manually.
+        //**
 
         [ScenarioPath("/copy")]
         public bool Copy { get; set; }
@@ -82,12 +93,6 @@ namespace Benchmarks.Configuration
 
         [ScenarioPath("/fortunes/dapper")]
         public bool DbFortunesDapper { get; set; }
-
-        [ScenarioPath("/mvc/plaintext")]
-        public bool MvcPlaintext { get; set; }
-
-        [ScenarioPath("/mvc/json")]
-        public bool MvcJson { get; set; }
 
         [ScenarioPath("/mvc/view")]
         public bool MvcViews { get; set; }

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -151,7 +151,12 @@ namespace Benchmarks
                 loggerFactory.AddConsole(appSettings.Value.LogLevel.Value);
             }
 
-            if (Scenarios.Plaintext)
+            if (Scenarios.StaticFiles)
+            {
+                app.UseStaticFiles();
+            }
+
+            if (Scenarios.StaticFiles || Scenarios.Plaintext)
             {
                 app.UsePlainText();
             }
@@ -241,11 +246,6 @@ namespace Benchmarks
             if (Scenarios.Any("Mvc"))
             {
                 app.UseMvc();
-            }
-
-            if (Scenarios.StaticFiles)
-            {
-                app.UseStaticFiles();
             }
 
             if (Scenarios.MemoryCachePlaintext)

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -4,24 +4,18 @@
 using System;
 using System.Data.Common;
 using System.Data.SqlClient;
-using System.Diagnostics;
-using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
-using System.Threading;
 using Benchmarks.Configuration;
 using Benchmarks.Data;
 using Benchmarks.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Npgsql;
 
 namespace Benchmarks
@@ -74,11 +68,6 @@ namespace Benchmarks
                         ob.UseSqlServer(appSettings.ConnectionString);
                     }
                 });
-
-            if (Scenarios.StaticFiles)
-            {
-                AddCachedWebRoot(services);
-            }
 
             if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
             {
@@ -290,247 +279,6 @@ namespace Benchmarks
             }
 
             app.RunDebugInfoPage();
-        }
-
-        private static void AddCachedWebRoot(IServiceCollection services)
-        {
-            services.AddSingleton<IStartupFilter, AppStartFilter>();
-
-            // Turn off compaction on memory pressure as it results in things being evicted during the priming of the
-            // cache on application start.
-            services.AddMemoryCache(options => options.CompactOnMemoryPressure = false);
-            services.AddSingleton<CachedWebRootFileProvider>();
-            services.AddSingleton<IConfigureOptions<StaticFileOptions>, StaticFileOptionsSetup>();
-        }
-
-        private class StaticFileOptionsSetup : IConfigureOptions<StaticFileOptions>
-        {
-            private readonly CachedWebRootFileProvider _cachedWebRoot;
-
-            public StaticFileOptionsSetup(CachedWebRootFileProvider cachedWebRoot)
-            {
-                _cachedWebRoot = cachedWebRoot;
-            }
-
-            public void Configure(StaticFileOptions options)
-            {
-                options.FileProvider = _cachedWebRoot;
-            }
-        }
-
-        private class AppStartFilter : IStartupFilter
-        {
-            private readonly CachedWebRootFileProvider _cachedWebRoot;
-
-            public AppStartFilter(CachedWebRootFileProvider cachedWebRoot)
-            {
-                _cachedWebRoot = cachedWebRoot;
-            }
-
-            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
-            {
-                return app =>
-                {
-                    // Set usual stuff up.
-                    next(app);
-
-                    // Prime the cached file provider.
-                    _cachedWebRoot.PrimeCache();
-                };
-            }
-        }
-
-        private class CachedWebRootFileProvider : IFileProvider
-        {
-            private static readonly int _fileSizeLimit = 256 * 1024; // bytes
-
-            private readonly ILogger<CachedWebRootFileProvider> _logger;
-            private readonly IFileProvider _fileProvider;
-            private readonly IMemoryCache _cache;
-
-            public CachedWebRootFileProvider(ILogger<CachedWebRootFileProvider> logger, IHostingEnvironment hostingEnv, IMemoryCache memoryCache)
-            {
-                _logger = logger;
-                _fileProvider = hostingEnv.WebRootFileProvider;
-                _cache = memoryCache;
-            }
-
-            public void PrimeCache()
-            {
-                var started = _logger.IsEnabled(LogLevel.Information) ? Timing.GetTimestamp() : 0;
-
-                _logger.LogInformation("Priming the cache");
-                var cacheSize = PrimeCacheImpl("/");
-
-                if (started != 0)
-                {
-                    _logger.LogInformation("Cache primed with {cacheEntriesCount} entries totaling {cacheEntriesSizeBytes} bytes in {elapsed}", cacheSize.Item1, cacheSize.Item2, Timing.GetDuration(started));
-                }
-            }
-
-            private Tuple<int, long> PrimeCacheImpl(string currentPath)
-            {
-                _logger.LogTrace("Priming cache for {currentPath}", currentPath);
-                var cacheEntriesAdded = 0;
-                var bytesCached = (long)0;
-
-                // TODO: Normalize the currentPath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
-                var prefix = string.Equals(currentPath, "/", StringComparison.OrdinalIgnoreCase) ? "/" : currentPath + "/";
-
-                foreach (var fileInfo in GetDirectoryContents(currentPath))
-                {
-                    if (fileInfo.IsDirectory)
-                    {
-                        var cacheSize = PrimeCacheImpl(prefix + fileInfo.Name);
-                        cacheEntriesAdded += cacheSize.Item1;
-                        bytesCached += cacheSize.Item2;
-                    }
-                    else
-                    {
-                        var stream = GetFileInfo(prefix + fileInfo.Name).CreateReadStream();
-                        bytesCached += stream.Length;
-                        stream.Dispose();
-                        cacheEntriesAdded++;
-                    }
-                }
-
-                return Tuple.Create(cacheEntriesAdded, bytesCached);
-            }
-
-            public IDirectoryContents GetDirectoryContents(string subpath)
-            {
-                // TODO: Normalize the subpath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
-                var key = nameof(GetDirectoryContents) + "_" + subpath;
-                if (_cache.TryGetValue(key, out IDirectoryContents cachedResult))
-                {
-                    // Item already exists in cache, just return it
-                    return cachedResult;
-                }
-
-                var directoryContents = _fileProvider.GetDirectoryContents(subpath);
-                if (!directoryContents.Exists)
-                {
-                    // Requested subpath doesn't exist, just return
-                    return directoryContents;
-                }
-
-                // Create the cache entry and return
-                var cacheEntry = _cache.CreateEntry(key);
-                cacheEntry.Value = directoryContents;
-                cacheEntry.RegisterPostEvictionCallback((k, value, reason, s) =>
-                    _logger.LogTrace("Cache entry {key} was evicted due to {reason}", k, reason));
-                return directoryContents;
-            }
-
-            public IFileInfo GetFileInfo(string subpath)
-            {
-                // TODO: Normalize the subpath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
-                var key = nameof(GetFileInfo) + "_" + subpath;
-                if (_cache.TryGetValue(key, out IFileInfo cachedResult))
-                {
-                    // Item already exists in cache, just return it
-                    return cachedResult;
-                }
-
-                var fileInfo = _fileProvider.GetFileInfo(subpath);
-                if (!fileInfo.Exists)
-                {
-                    // Requested subpath doesn't exist, just return it
-                    return fileInfo;
-                }
-
-                if (fileInfo.Length > _fileSizeLimit)
-                {
-                    // File is too large to cache, just return it
-                    _logger.LogTrace("File contents for {subpath} will not be cached as it's over the file size limit of {fileSizeLimit}", subpath, _fileSizeLimit);
-                    return fileInfo;
-                }
-
-                // Create the cache entry and return
-                var cachedFileInfo = new CachedFileInfo(_logger, fileInfo, subpath);
-                var fileChangedToken = Watch(subpath);
-                fileChangedToken.RegisterChangeCallback(_ => _logger.LogDebug("Change detected for {subpath} located at {filepath}", subpath, fileInfo.PhysicalPath), null);
-                var cacheEntry = _cache.CreateEntry(key)
-                    .RegisterPostEvictionCallback((k, value, reason, s) =>
-                        _logger.LogTrace("Cache entry {key} was evicted due to {reason}", k, reason))
-                    .AddExpirationToken(fileChangedToken)
-                    .SetValue(cachedFileInfo);
-                // You have to call Dispose() to actually add the item to the underlying cache. Yeah, I know.
-                cacheEntry.Dispose();
-                return cachedFileInfo;
-            }
-
-            public IChangeToken Watch(string filter)
-            {
-                return _fileProvider.Watch(filter);
-            }
-
-            private class CachedFileInfo : IFileInfo
-            {
-                private readonly ILogger _logger;
-                private readonly IFileInfo _fileInfo;
-                private readonly string _subpath;
-                private byte[] _contents;
-
-                public CachedFileInfo(ILogger logger, IFileInfo fileInfo, string subpath)
-                {
-                    _logger = logger;
-                    _fileInfo = fileInfo;
-                    _subpath = subpath;
-                }
-
-                public bool Exists => _fileInfo.Exists;
-
-                public bool IsDirectory => _fileInfo.IsDirectory;
-
-                public DateTimeOffset LastModified => _fileInfo.LastModified;
-
-                public long Length => _fileInfo.Length;
-
-                public string Name => _fileInfo.Name;
-
-                public string PhysicalPath => _fileInfo.PhysicalPath;
-
-                public Stream CreateReadStream()
-                {
-                    var contents = _contents;
-                    if (contents != null)
-                    {
-                        _logger.LogTrace("Returning cached file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
-                        return new MemoryStream(contents);
-                    }
-                    else
-                    {
-                        _logger.LogTrace("Loading file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
-                        MemoryStream ms;
-                        using (var fs = _fileInfo.CreateReadStream())
-                        {
-                            ms = new MemoryStream((int)fs.Length);
-                            fs.CopyTo(ms);
-                            contents = ms.ToArray();
-                            ms.Position = 0;
-                        }
-
-                        if (Interlocked.CompareExchange(ref _contents, contents, null) == null)
-                        {
-                            _logger.LogTrace("Cached file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
-                        }
-
-                        return ms;
-                    }
-                }
-            }
-        }
-
-        private static class Timing
-        {
-            private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
-
-            public static long GetTimestamp() => Stopwatch.GetTimestamp();
-
-            public static TimeSpan GetDuration(long start) => GetDuration(start, Stopwatch.GetTimestamp());
-
-            public static TimeSpan GetDuration(long start, long end) => new TimeSpan((long)(TimestampToTicks * (end - start)));
         }
     }
 }

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -4,18 +4,24 @@
 using System;
 using System.Data.Common;
 using System.Data.SqlClient;
+using System.Diagnostics;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
+using System.Threading;
 using Benchmarks.Configuration;
 using Benchmarks.Data;
 using Benchmarks.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Npgsql;
 
 namespace Benchmarks
@@ -68,6 +74,11 @@ namespace Benchmarks
                         ob.UseSqlServer(appSettings.ConnectionString);
                     }
                 });
+
+            if (Scenarios.StaticFiles)
+            {
+                AddCachedWebRoot(services);
+            }
 
             if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
             {
@@ -279,6 +290,247 @@ namespace Benchmarks
             }
 
             app.RunDebugInfoPage();
+        }
+
+        private static void AddCachedWebRoot(IServiceCollection services)
+        {
+            services.AddSingleton<IStartupFilter, AppStartFilter>();
+
+            // Turn off compaction on memory pressure as it results in things being evicted during the priming of the
+            // cache on application start.
+            services.AddMemoryCache(options => options.CompactOnMemoryPressure = false);
+            services.AddSingleton<CachedWebRootFileProvider>();
+            services.AddSingleton<IConfigureOptions<StaticFileOptions>, StaticFileOptionsSetup>();
+        }
+
+        private class StaticFileOptionsSetup : IConfigureOptions<StaticFileOptions>
+        {
+            private readonly CachedWebRootFileProvider _cachedWebRoot;
+
+            public StaticFileOptionsSetup(CachedWebRootFileProvider cachedWebRoot)
+            {
+                _cachedWebRoot = cachedWebRoot;
+            }
+
+            public void Configure(StaticFileOptions options)
+            {
+                options.FileProvider = _cachedWebRoot;
+            }
+        }
+
+        private class AppStartFilter : IStartupFilter
+        {
+            private readonly CachedWebRootFileProvider _cachedWebRoot;
+
+            public AppStartFilter(CachedWebRootFileProvider cachedWebRoot)
+            {
+                _cachedWebRoot = cachedWebRoot;
+            }
+
+            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            {
+                return app =>
+                {
+                    // Set usual stuff up.
+                    next(app);
+
+                    // Prime the cached file provider.
+                    _cachedWebRoot.PrimeCache();
+                };
+            }
+        }
+
+        private class CachedWebRootFileProvider : IFileProvider
+        {
+            private static readonly int _fileSizeLimit = 256 * 1024; // bytes
+
+            private readonly ILogger<CachedWebRootFileProvider> _logger;
+            private readonly IFileProvider _fileProvider;
+            private readonly IMemoryCache _cache;
+
+            public CachedWebRootFileProvider(ILogger<CachedWebRootFileProvider> logger, IHostingEnvironment hostingEnv, IMemoryCache memoryCache)
+            {
+                _logger = logger;
+                _fileProvider = hostingEnv.WebRootFileProvider;
+                _cache = memoryCache;
+            }
+
+            public void PrimeCache()
+            {
+                var started = _logger.IsEnabled(LogLevel.Information) ? Timing.GetTimestamp() : 0;
+
+                _logger.LogInformation("Priming the cache");
+                var cacheSize = PrimeCacheImpl("/");
+
+                if (started != 0)
+                {
+                    _logger.LogInformation("Cache primed with {cacheEntriesCount} entries totaling {cacheEntriesSizeBytes} bytes in {elapsed}", cacheSize.Item1, cacheSize.Item2, Timing.GetDuration(started));
+                }
+            }
+
+            private Tuple<int, long> PrimeCacheImpl(string currentPath)
+            {
+                _logger.LogTrace("Priming cache for {currentPath}", currentPath);
+                var cacheEntriesAdded = 0;
+                var bytesCached = (long)0;
+
+                // TODO: Normalize the currentPath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
+                var prefix = string.Equals(currentPath, "/", StringComparison.OrdinalIgnoreCase) ? "/" : currentPath + "/";
+
+                foreach (var fileInfo in GetDirectoryContents(currentPath))
+                {
+                    if (fileInfo.IsDirectory)
+                    {
+                        var cacheSize = PrimeCacheImpl(prefix + fileInfo.Name);
+                        cacheEntriesAdded += cacheSize.Item1;
+                        bytesCached += cacheSize.Item2;
+                    }
+                    else
+                    {
+                        var stream = GetFileInfo(prefix + fileInfo.Name).CreateReadStream();
+                        bytesCached += stream.Length;
+                        stream.Dispose();
+                        cacheEntriesAdded++;
+                    }
+                }
+
+                return Tuple.Create(cacheEntriesAdded, bytesCached);
+            }
+
+            public IDirectoryContents GetDirectoryContents(string subpath)
+            {
+                // TODO: Normalize the subpath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
+                var key = nameof(GetDirectoryContents) + "_" + subpath;
+                if (_cache.TryGetValue(key, out IDirectoryContents cachedResult))
+                {
+                    // Item already exists in cache, just return it
+                    return cachedResult;
+                }
+
+                var directoryContents = _fileProvider.GetDirectoryContents(subpath);
+                if (!directoryContents.Exists)
+                {
+                    // Requested subpath doesn't exist, just return
+                    return directoryContents;
+                }
+
+                // Create the cache entry and return
+                var cacheEntry = _cache.CreateEntry(key);
+                cacheEntry.Value = directoryContents;
+                cacheEntry.RegisterPostEvictionCallback((k, value, reason, s) =>
+                    _logger.LogTrace("Cache entry {key} was evicted due to {reason}", k, reason));
+                return directoryContents;
+            }
+
+            public IFileInfo GetFileInfo(string subpath)
+            {
+                // TODO: Normalize the subpath here, e.g. strip/always-add leading slashes, ensure slash consistency, etc.
+                var key = nameof(GetFileInfo) + "_" + subpath;
+                if (_cache.TryGetValue(key, out IFileInfo cachedResult))
+                {
+                    // Item already exists in cache, just return it
+                    return cachedResult;
+                }
+
+                var fileInfo = _fileProvider.GetFileInfo(subpath);
+                if (!fileInfo.Exists)
+                {
+                    // Requested subpath doesn't exist, just return it
+                    return fileInfo;
+                }
+
+                if (fileInfo.Length > _fileSizeLimit)
+                {
+                    // File is too large to cache, just return it
+                    _logger.LogTrace("File contents for {subpath} will not be cached as it's over the file size limit of {fileSizeLimit}", subpath, _fileSizeLimit);
+                    return fileInfo;
+                }
+
+                // Create the cache entry and return
+                var cachedFileInfo = new CachedFileInfo(_logger, fileInfo, subpath);
+                var fileChangedToken = Watch(subpath);
+                fileChangedToken.RegisterChangeCallback(_ => _logger.LogDebug("Change detected for {subpath} located at {filepath}", subpath, fileInfo.PhysicalPath), null);
+                var cacheEntry = _cache.CreateEntry(key)
+                    .RegisterPostEvictionCallback((k, value, reason, s) =>
+                        _logger.LogTrace("Cache entry {key} was evicted due to {reason}", k, reason))
+                    .AddExpirationToken(fileChangedToken)
+                    .SetValue(cachedFileInfo);
+                // You have to call Dispose() to actually add the item to the underlying cache. Yeah, I know.
+                cacheEntry.Dispose();
+                return cachedFileInfo;
+            }
+
+            public IChangeToken Watch(string filter)
+            {
+                return _fileProvider.Watch(filter);
+            }
+
+            private class CachedFileInfo : IFileInfo
+            {
+                private readonly ILogger _logger;
+                private readonly IFileInfo _fileInfo;
+                private readonly string _subpath;
+                private byte[] _contents;
+
+                public CachedFileInfo(ILogger logger, IFileInfo fileInfo, string subpath)
+                {
+                    _logger = logger;
+                    _fileInfo = fileInfo;
+                    _subpath = subpath;
+                }
+
+                public bool Exists => _fileInfo.Exists;
+
+                public bool IsDirectory => _fileInfo.IsDirectory;
+
+                public DateTimeOffset LastModified => _fileInfo.LastModified;
+
+                public long Length => _fileInfo.Length;
+
+                public string Name => _fileInfo.Name;
+
+                public string PhysicalPath => _fileInfo.PhysicalPath;
+
+                public Stream CreateReadStream()
+                {
+                    var contents = _contents;
+                    if (contents != null)
+                    {
+                        _logger.LogTrace("Returning cached file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
+                        return new MemoryStream(contents);
+                    }
+                    else
+                    {
+                        _logger.LogTrace("Loading file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
+                        MemoryStream ms;
+                        using (var fs = _fileInfo.CreateReadStream())
+                        {
+                            ms = new MemoryStream((int)fs.Length);
+                            fs.CopyTo(ms);
+                            contents = ms.ToArray();
+                            ms.Position = 0;
+                        }
+
+                        if (Interlocked.CompareExchange(ref _contents, contents, null) == null)
+                        {
+                            _logger.LogTrace("Cached file contents for {subpath} located at {filepath}", _subpath, _fileInfo.PhysicalPath);
+                        }
+
+                        return ms;
+                    }
+                }
+            }
+        }
+
+        private static class Timing
+        {
+            private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+            public static long GetTimestamp() => Stopwatch.GetTimestamp();
+
+            public static TimeSpan GetDuration(long start) => GetDuration(start, Stopwatch.GetTimestamp());
+
+            public static TimeSpan GetDuration(long start, long end) => new TimeSpan((long)(TimestampToTicks * (end - start)));
         }
     }
 }

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -392,7 +392,17 @@ namespace BenchmarkServer
             var pathAttribute = field.GetCustomAttribute<ScenarioPathAttribute>();
             if (pathAttribute != null)
             {
-                path = pathAttribute.Paths.First().Trim('/');
+                Debug.Assert(pathAttribute.Paths.Length > 0);
+                if (pathAttribute.Paths.Length == 1)
+                {
+                    path = pathAttribute.Paths[0].Trim('/');
+                }
+                else
+                {
+                    // Driver will choose between paths when more than one is available. The scenario name is not
+                    // necessarily even one of the choices.
+                    path = string.Empty;
+                }
             }
 
             return $"{scheme.ToString().ToLowerInvariant()}://{hostname}:5000/{path.ToLower()}";


### PR DESCRIPTION
- plumb scenario from `Benchmarks` through to `BenchmarksDriver`
  - add `"/plaintext"` as a supported path for this scenario
  - reorder configuration so that `PlaintextMiddleware` is always enabled after `StaticFilesMiddleware`
- add `--path` option to differentiate potential test URLs and `[Path]` column to save the information

nit: enforce `[ScenarioPath]` usage restrictions in its constructor