### PR TITLE
Install latest SDK and runtime before restore and build

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -34,8 +34,11 @@
   <PropertyGroup>
     <BenchmarksDependsOn Condition="'$(NoBuild)' != 'true'">Compile</BenchmarksDependsOn>
   </PropertyGroup>
-  
-  <!-- Used by BenchmarksServer to install latest SDK and runtime but do nothing else -->
+
+  <!--
+    BenchmarksServer calls "build /t:noop" to install the latest SDK and runtime as quickly as possible.
+    The default target would compile benchmarks.sln which takes much longer.
+  -->
   <Target Name="NoOp" />
 
   <Target Name="TestBenchmarks" DependsOnTargets="$(BenchmarksDependsOn)">

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -34,6 +34,9 @@
   <PropertyGroup>
     <BenchmarksDependsOn Condition="'$(NoBuild)' != 'true'">Compile</BenchmarksDependsOn>
   </PropertyGroup>
+  
+  <!-- Used by BenchmarksServer to install latest SDK and runtime but do nothing else -->
+  <Target Name="NoOp" />
 
   <Target Name="TestBenchmarks" DependsOnTargets="$(BenchmarksDependsOn)">
     <Error Text="BENCHMARK_SERVER must be set" Condition="'$(BENCHMARK_SERVER)' == ''" />

--- a/src/BenchmarksServer/ProcessUtil.cs
+++ b/src/BenchmarksServer/ProcessUtil.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -11,7 +12,7 @@ namespace BenchmarkServer
     public static class ProcessUtil
     {
         public static ProcessResult Run(string filename, string arguments, string workingDirectory = null,
-            bool throwOnError = true)
+            bool throwOnError = true, IDictionary<string, string> environmentVariables = null)
         {
             var logWorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory();
             Log.WriteLine($"[{logWorkingDirectory}] {filename} {arguments}");
@@ -31,6 +32,14 @@ namespace BenchmarkServer
             if (workingDirectory != null)
             {
                 process.StartInfo.WorkingDirectory = workingDirectory;
+            }
+
+            if (environmentVariables != null)
+            {
+                foreach (var kvp in environmentVariables)
+                {
+                    process.StartInfo.Environment.Add(kvp);
+                }
             }
 
             var outputBuilder = new StringBuilder();

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -235,7 +235,6 @@ namespace BenchmarkServer
 
             // Build and Restore
             var benchmarksApp = Path.Combine(benchmarksRoot, "src", "Benchmarks");
-
             var dotnetExecutable = Path.Combine(dotnetInstallDir, "dotnet");
 
             // Project versions must be higher than package versions to resolve those dependencies to project ones as expected.

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -214,13 +214,18 @@ namespace BenchmarkServer
 
             AddSourceDependencies(path, benchmarksDir, dirs);
 
-            var benchmarksPath = Path.Combine(path, benchmarksDir, "src", "Benchmarks");
+            // Install latest SDK and runtime
+            var benchmarksRoot = Path.Combine(path, benchmarksDir);
+            ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot);
+
+            // Build and Restore
+            var benchmarksApp = Path.Combine(benchmarksRoot, "src", "Benchmarks");
 
             // Project versions must be higher than package versions to resolve those dependencies to project ones as expected.
             // Passing VersionSuffix to restore will have it append that to the version of restored projects, making them
             // higher than packages references by the same name.
-            ProcessUtil.Run("dotnet", "restore /p:VersionSuffix=zzzzz-99999", workingDirectory: benchmarksPath);
-            ProcessUtil.Run("dotnet", $"build -c Release -f {GetTFM(job.Framework)}", workingDirectory: benchmarksPath);
+            ProcessUtil.Run("dotnet", "restore /p:VersionSuffix=zzzzz-99999", workingDirectory: benchmarksApp);
+            ProcessUtil.Run("dotnet", $"build -c Release -f {GetTFM(job.Framework)}", workingDirectory: benchmarksApp);
 
             return benchmarksDir;
         }

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -32,6 +32,9 @@ namespace BenchmarkServer
         private static readonly IRepository<ServerJob> _jobs = new InMemoryRepository<ServerJob>();
         private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+        // Use custom install dir to avoid changing the default install,  which is impossible if other processes
+        // are already using it.  Custom install is located under default install, so deleting the default
+        // install will delete both.
         private static readonly string _dotnetInstallDir = _isWindows ?
             Path.Combine(Environment.GetEnvironmentVariable("LOCALAPPDATA"), "Microsoft", "dotnet", "BenchmarksServer") :
             Path.Combine("~", ".dotnet", "BenchmarksServer");
@@ -221,9 +224,10 @@ namespace BenchmarkServer
 
             AddSourceDependencies(path, benchmarksDir, dirs);
 
-            // Install latest SDK and runtime to custom install dir.  This avoids changing the default install folder,
-            // which is impossible if other processes are already using it
-
+            // Install latest SDK and runtime
+            // * Use custom install dir to avoid changing the default install,  which is impossible if other processes
+            //   are already using it.  Custom install is located under default install, so deleting the default
+            //   install will delete both.
             var benchmarksRoot = Path.Combine(path, benchmarksDir);
             ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
                 environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", _dotnetInstallDir } });

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -228,8 +228,7 @@ namespace BenchmarkServer
 
             // Install latest SDK and runtime
             // * Use custom install dir to avoid changing the default install,  which is impossible if other processes
-            //   are already using it.  Custom install is located under default install, so deleting the default
-            //   install will delete both.
+            //   are already using it.
             var benchmarksRoot = Path.Combine(path, benchmarksDir);
             ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
                 environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -221,7 +221,9 @@ namespace BenchmarkServer
 
             AddSourceDependencies(path, benchmarksDir, dirs);
 
-            // Install latest SDK and runtime to custom install dir
+            // Install latest SDK and runtime to custom install dir.  This avoids changing the default install folder,
+            // which is impossible if other processes are already using it
+
             var benchmarksRoot = Path.Combine(path, benchmarksDir);
             ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
                 environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", _dotnetInstallDir } });

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -230,8 +230,16 @@ namespace BenchmarkServer
             // * Use custom install dir to avoid changing the default install,  which is impossible if other processes
             //   are already using it.
             var benchmarksRoot = Path.Combine(path, benchmarksDir);
-            ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
-                environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });
+            if (_isWindows)
+            {
+                ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
+                    environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });
+            }
+            else
+            {
+                ProcessUtil.Run("/usr/bin/env", "bash build.sh /t:noop", workingDirectory: benchmarksRoot,
+                    environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });
+            }
 
             // Build and Restore
             var benchmarksApp = Path.Combine(benchmarksRoot, "src", "Benchmarks");

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -230,15 +230,15 @@ namespace BenchmarkServer
             // * Use custom install dir to avoid changing the default install,  which is impossible if other processes
             //   are already using it.
             var benchmarksRoot = Path.Combine(path, benchmarksDir);
+            var env = new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } };
             if (_isWindows)
             {
-                ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot,
-                    environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });
+                ProcessUtil.Run("cmd", "/c build.cmd /t:noop", workingDirectory: benchmarksRoot, environmentVariables: env);
             }
             else
             {
                 ProcessUtil.Run("/usr/bin/env", "bash build.sh /t:noop", workingDirectory: benchmarksRoot,
-                    environmentVariables: new Dictionary<string, string> { { "DOTNET_INSTALL_DIR", dotnetInstallDir } });
+                    environmentVariables: env);
             }
 
             // Build and Restore


### PR DESCRIPTION
* Increases time of benchmark run from 60 to 75 seconds, but required to avoid manual intervention when SDK or runtime is updated
* Addresses #87 

CC: @cesarbs, @rynowak 