### PR TITLE
Stop testing kestrel@feature/dev-si

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -2,10 +2,7 @@
   <ItemGroup>
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 2" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@feature/dev-si --kestrelThreadCount 32 --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
-    <Scenarios Include="-n Json -o KestrelHttpServer@feature/dev-si" />
     <Scenarios Include="-n Plaintext" />
     <Scenarios Include="-n StaticFiles --path plaintext" />
     <Scenarios Include="-n Plaintext -r Desktop" />


### PR DESCRIPTION
* Breaking changes made in kestrel@dev mean that kestrel@feature/dev-si is no longer compatible with Benchmarks.