### PR TITLE
Don't hard code the thread count when thread pool dispatching is off

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 16 --kestrelThreadPoolDispatching false" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadPoolDispatching false" />
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
     <Scenarios Include="-n Plaintext" />
     <Scenarios Include="-n StaticFiles --path plaintext" />


### PR DESCRIPTION
- Netty uses 2 * numbers of cores by default so that's what the benchmark does
when dispatching is off. On windows at least, picking 2 * cores is recommended for
IOCP usage. It's likely this is the same for linux (at least that's what i've seen in the wild)