### PR TITLE
Add support for transports in the benchmark driver

### DIFF
--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,31 +1,39 @@
 <Project>
   <ItemGroup>
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadPoolDispatching false" />
-    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelTransport Sockets" />
-    <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
-    <Scenarios Include="-n Json -o KestrelHttpServer@dev --kestrelTransport Sockets" />
-    <Scenarios Include="-n Plaintext" />
-    <Scenarios Include="-n StaticFiles --path plaintext" />
+    <Scenarios Include="-n Plaintext --kestrelThreadCount 2" />
+    <Scenarios Include="-n Plaintext --kestrelTransport Sockets" />
     <Scenarios Include="-n Plaintext -r Desktop" />
     <Scenarios Include="-n Plaintext --webHost HttpSys" />
     <Scenarios Include="-n Plaintext -f Benchmarks.PassthroughConnectionFilter" />
+    
     <Scenarios Include="-n Plaintext -m https" />
+    <Scenarios Include="-n Plaintext -m https --kestrelTransport Sockets" />
     <Scenarios Include="-n Plaintext -m https -r Desktop" />
     <Scenarios Include="-n Plaintext -m https --webHost HttpSys" />
+
+    <!-- TODO: Optimize threadcount -->
     <Scenarios Include="-n Json" />
+    <Scenarios Include="-n Json --kestrelTransport Sockets" />
     <Scenarios Include="-n Json -r Desktop" />
     <Scenarios Include="-n Json --webHost HttpSys" />
     <Scenarios Include="-n Json -f Benchmarks.PassthroughConnectionFilter" />
+
     <Scenarios Include="-n Json -m https" />
+    <Scenarios Include="-n Json -m https --kestrelTransport Sockets" />
     <Scenarios Include="-n Json -m https -r Desktop" />
     <Scenarios Include="-n Json -m https --webHost HttpSys" />
+
+    <Scenarios Include="-n StaticFiles --path plaintext" />
+    
     <Scenarios Include="-n MvcPlaintext" />
     <Scenarios Include="-n MvcPlaintext -r Desktop" />
+    
     <Scenarios Include="-n MvcJson" />
     <Scenarios Include="-n MvcJson -r Desktop" />
+    
     <Scenarios Include="-n MemoryCachePlaintext" />
     <Scenarios Include="-n MemoryCachePlaintextSetRemove" />
+    
     <Scenarios Include="-n ResponseCachingPlaintextCached" />
     <Scenarios Include="-n ResponseCachingPlaintextCached --method DELETE" />
     <Scenarios Include="-n ResponseCachingPlaintextResponseNoCache" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -2,7 +2,9 @@
   <ItemGroup>
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadCount 2" />
     <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelThreadPoolDispatching false" />
+    <Scenarios Include="-n Plaintext -o KestrelHttpServer@dev --kestrelTransport Sockets" />
     <Scenarios Include="-n Json -o KestrelHttpServer@dev" />
+    <Scenarios Include="-n Json -o KestrelHttpServer@dev --kestrelTransport Sockets" />
     <Scenarios Include="-n Plaintext" />
     <Scenarios Include="-n StaticFiles --path plaintext" />
     <Scenarios Include="-n Plaintext -r Desktop" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,6 +1,8 @@
 <Project>
   <ItemGroup>
+    <!-- Optimal ThreadCount for current hardware -->
     <Scenarios Include="-n Plaintext --kestrelThreadCount 2" />
+    
     <Scenarios Include="-n Plaintext --kestrelTransport Sockets" />
     <Scenarios Include="-n Plaintext -r Desktop" />
     <Scenarios Include="-n Plaintext --webHost HttpSys" />
@@ -11,8 +13,9 @@
     <Scenarios Include="-n Plaintext -m https -r Desktop" />
     <Scenarios Include="-n Plaintext -m https --webHost HttpSys" />
 
-    <!-- TODO: Optimize threadcount -->
+    <!-- Default ThreadCount (cores / 2) is optimal for current hardware -->
     <Scenarios Include="-n Json" />
+    
     <Scenarios Include="-n Json --kestrelTransport Sockets" />
     <Scenarios Include="-n Json -r Desktop" />
     <Scenarios Include="-n Json --webHost HttpSys" />

--- a/src/Benchmarks.ServerJob/KestrelTransport.cs
+++ b/src/Benchmarks.ServerJob/KestrelTransport.cs
@@ -1,0 +1,8 @@
+﻿namespace Benchmarks.ServerJob
+{
+    public enum KestrelTransport
+    {
+        Libuv,
+        Sockets
+    }
+}

--- a/src/Benchmarks.ServerJob/ServerJob.cs
+++ b/src/Benchmarks.ServerJob/ServerJob.cs
@@ -22,6 +22,8 @@ namespace Benchmarks.ServerJob
 
         public bool? KestrelThreadPoolDispatching { get; set; }
 
+        public string KestrelTransport { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public Scenario Scenario { get; set; }
 

--- a/src/Benchmarks.ServerJob/ServerJob.cs
+++ b/src/Benchmarks.ServerJob/ServerJob.cs
@@ -22,7 +22,8 @@ namespace Benchmarks.ServerJob
 
         public bool? KestrelThreadPoolDispatching { get; set; }
 
-        public string KestrelTransport { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public KestrelTransport? KestrelTransport { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public Scenario Scenario { get; set; }

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\build\common.props" />
 
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="2.0.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.0.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0-*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0-*" PrivateAssets="All" />

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -21,6 +21,7 @@ namespace Benchmarks
     {
         public static string[] Args;
         public static string Server;
+        public static string Transport;
 
         public static void Main(string[] args)
         {
@@ -39,6 +40,7 @@ namespace Benchmarks
                 .Build();
 
             Server = config["server"] ?? "Kestrel";
+            Transport = config["transport"] ?? "Libuv";
 
             var webHostBuilder = new WebHostBuilder()
                 .UseContentRoot(Directory.GetCurrentDirectory())
@@ -74,21 +76,34 @@ namespace Benchmarks
                     {
                         Listen(options, config, "http://localhost:5000/");
                     }
-                }).UseLibuv(options =>
-                {
-                    var threads = GetThreadCount(config);
-
-                    if (threads > 0)
-                    {
-                        options.ThreadCount = threads;
-                    }
-                    else if (threadPoolDispatching == false)
-                    {
-                        // If thread pool dispatching is explicitly set to false
-                        // and the thread count wasn't specified then use 2 * number of logical cores
-                        options.ThreadCount = Environment.ProcessorCount * 2;
-                    }
                 });
+
+                if (string.Equals(Transport, "Libuv", StringComparison.OrdinalIgnoreCase))
+                {
+                    webHostBuilder.UseLibuv(options =>
+                    {
+                        var threads = GetThreadCount(config);
+
+                        if (threads > 0)
+                        {
+                            options.ThreadCount = threads;
+                        }
+                        else if (threadPoolDispatching == false)
+                        {
+                            // If thread pool dispatching is explicitly set to false
+                            // and the thread count wasn't specified then use 2 * number of logical cores
+                            options.ThreadCount = Environment.ProcessorCount * 2;
+                        }
+                    });
+                }
+                else if (string.Equals(Transport, "Sockets", StringComparison.OrdinalIgnoreCase))
+                {
+                    webHostBuilder.UseSockets();
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unknown transport {Transport}");
+                }
 
                 webHostBuilder.UseSetting(WebHostDefaults.ServerUrlsKey, string.Empty);
             }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -110,6 +110,9 @@ namespace BenchmarkDriver
             var kestrelThreadPoolDispatchingOption = app.Option("--kestrelThreadPoolDispatching",
                 "Maps to InternalKestrelServerOptions.ThreadPoolDispatching.",
                 CommandOptionType.SingleValue);
+            var kestrelTransportOption = app.Option("--kestrelTransport",
+                "Kestrel's transport (Libuv or Sockets). Default is Libuv.",
+                CommandOptionType.SingleValue);
             var scenarioOption = app.Option("-n|--scenario",
                 "Benchmark scenario to run", CommandOptionType.SingleValue);
             var schemeOption = app.Option("-m|--scheme",
@@ -241,6 +244,11 @@ namespace BenchmarkDriver
                     serverJob.KestrelThreadPoolDispatching = bool.Parse(kestrelThreadPoolDispatchingOption.Value());
                 }
 
+                if (kestrelTransportOption.HasValue())
+                {
+                    serverJob.KestrelTransport = kestrelTransportOption.Value();
+                }
+
                 var sources = new List<Source>();
                 foreach (var source in sourceOption.Values)
                 {
@@ -370,6 +378,7 @@ namespace BenchmarkDriver
                         webHost: serverJob.WebHost,
                         kestrelThreadCount: serverJob.KestrelThreadCount,
                         kestrelThreadPoolDispatching: serverJob.KestrelThreadPoolDispatching,
+                        kestrelTransport: serverJob.KestrelTransport,
                         clientThreads: clientJob.Threads,
                         connections: clientJob.Connections,
                         duration: clientJob.Duration,
@@ -486,6 +495,7 @@ namespace BenchmarkDriver
             WebHost webHost,
             int? kestrelThreadCount,
             bool? kestrelThreadPoolDispatching,
+            string kestrelTransport,
             int clientThreads,
             int connections,
             int duration,
@@ -512,6 +522,7 @@ namespace BenchmarkDriver
                         [WebHost] [nvarchar](max) NOT NULL,
                         [KestrelThreadCount] [int] NULL,
                         [KestrelThreadPoolDispatching] [bit] NULL,
+                        [KestrelTransport] [nvarchar](max) NULL,
                         [ClientThreads] [int] NOT NULL,
                         [Connections] [int] NOT NULL,
                         [Duration] [int] NOT NULL,
@@ -536,6 +547,7 @@ namespace BenchmarkDriver
                            ,[WebHost]
                            ,[KestrelThreadCount]
                            ,[KestrelThreadPoolDispatching]
+                           ,[KestrelTransport]
                            ,[ClientThreads]
                            ,[Connections]
                            ,[Duration]
@@ -554,6 +566,7 @@ namespace BenchmarkDriver
                            ,@WebHost
                            ,@KestrelThreadCount
                            ,@KestrelThreadPoolDispatching
+                           ,@KestrelTransport
                            ,@ClientThreads
                            ,@Connections
                            ,@Duration
@@ -586,6 +599,7 @@ namespace BenchmarkDriver
                     p.AddWithValue("@WebHost", webHost.ToString());
                     p.AddWithValue("@KestrelThreadCount", (object)kestrelThreadCount ?? DBNull.Value);
                     p.AddWithValue("@KestrelThreadPoolDispatching", (object)kestrelThreadPoolDispatching ?? DBNull.Value);
+                    p.AddWithValue("@KestrelTransport", string.IsNullOrEmpty(kestrelTransport) ? (object)DBNull.Value : kestrelTransport);
                     p.AddWithValue("@ClientThreads", clientThreads);
                     p.AddWithValue("@Connections", connections);
                     p.AddWithValue("@Duration", duration);

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -170,14 +170,10 @@ namespace BenchmarkDriver
                 var client = clientOption.Value();
                 var sqlConnectionString = sqlConnectionStringOption.Value();
 
-                Scheme scheme;
-                Scenario scenario;
-                WebHost webHost;
-                Framework framework;
-                if (!Enum.TryParse(schemeValue, ignoreCase: true, result: out scheme) ||
-                    !Enum.TryParse(scenarioOption.Value(), ignoreCase: true, result: out scenario) ||
-                    !Enum.TryParse(webHostValue, ignoreCase: true, result: out webHost) ||
-                    !Enum.TryParse(frameworkValue, ignoreCase: true, result: out framework) ||
+                if (!Enum.TryParse(schemeValue, ignoreCase: true, result: out Scheme scheme) ||
+                    !Enum.TryParse(scenarioOption.Value(), ignoreCase: true, result: out Scenario scenario) ||
+                    !Enum.TryParse(webHostValue, ignoreCase: true, result: out WebHost webHost) ||
+                    !Enum.TryParse(frameworkValue, ignoreCase: true, result: out Framework framework) ||
                     string.IsNullOrWhiteSpace(server) ||
                     string.IsNullOrWhiteSpace(client))
                 {
@@ -234,6 +230,16 @@ namespace BenchmarkDriver
                     serverJob.ConnectionFilter = connectionFilterOption.Value();
                 }
 
+                if (kestrelTransportOption.HasValue())
+                {
+                    if (!Enum.TryParse(kestrelTransportOption.Value(), ignoreCase: true, result: out KestrelTransport kestrelTransport))
+                    {
+                        app.ShowHelp();
+                        return 2;
+                    }
+                    serverJob.KestrelTransport = kestrelTransport;
+                }
+
                 if (kestrelThreadCountOption.HasValue())
                 {
                     serverJob.KestrelThreadCount = int.Parse(kestrelThreadCountOption.Value());
@@ -242,11 +248,6 @@ namespace BenchmarkDriver
                 if (kestrelThreadPoolDispatchingOption.HasValue())
                 {
                     serverJob.KestrelThreadPoolDispatching = bool.Parse(kestrelThreadPoolDispatchingOption.Value());
-                }
-
-                if (kestrelTransportOption.HasValue())
-                {
-                    serverJob.KestrelTransport = kestrelTransportOption.Value();
                 }
 
                 var sources = new List<Source>();
@@ -493,9 +494,9 @@ namespace BenchmarkDriver
             IEnumerable<Source> sources,
             string connectionFilter,
             WebHost webHost,
+            KestrelTransport? kestrelTransport,
             int? kestrelThreadCount,
             bool? kestrelThreadPoolDispatching,
-            string kestrelTransport,
             int clientThreads,
             int connections,
             int duration,
@@ -520,9 +521,9 @@ namespace BenchmarkDriver
                         [Sources] [nvarchar](max) NULL,
                         [ConnectionFilter] [nvarchar](max) NULL,
                         [WebHost] [nvarchar](max) NOT NULL,
+                        [KestrelTransport] [nvarchar](max) NULL,
                         [KestrelThreadCount] [int] NULL,
                         [KestrelThreadPoolDispatching] [bit] NULL,
-                        [KestrelTransport] [nvarchar](max) NULL,
                         [ClientThreads] [int] NOT NULL,
                         [Connections] [int] NOT NULL,
                         [Duration] [int] NOT NULL,
@@ -545,9 +546,9 @@ namespace BenchmarkDriver
                            ,[Sources]
                            ,[ConnectionFilter]
                            ,[WebHost]
+                           ,[KestrelTransport]
                            ,[KestrelThreadCount]
                            ,[KestrelThreadPoolDispatching]
-                           ,[KestrelTransport]
                            ,[ClientThreads]
                            ,[Connections]
                            ,[Duration]
@@ -564,9 +565,9 @@ namespace BenchmarkDriver
                            ,@Sources
                            ,@ConnectionFilter
                            ,@WebHost
+                           ,@KestrelTransport
                            ,@KestrelThreadCount
                            ,@KestrelThreadPoolDispatching
-                           ,@KestrelTransport
                            ,@ClientThreads
                            ,@Connections
                            ,@Duration
@@ -597,9 +598,9 @@ namespace BenchmarkDriver
                     p.AddWithValue("@ConnectionFilter",
                         string.IsNullOrEmpty(connectionFilter) ? (object)DBNull.Value : connectionFilter);
                     p.AddWithValue("@WebHost", webHost.ToString());
+                    p.AddWithValue("@KestrelTransport", kestrelTransport?.ToString() ?? (object)DBNull.Value);
                     p.AddWithValue("@KestrelThreadCount", (object)kestrelThreadCount ?? DBNull.Value);
                     p.AddWithValue("@KestrelThreadPoolDispatching", (object)kestrelThreadPoolDispatching ?? DBNull.Value);
-                    p.AddWithValue("@KestrelTransport", string.IsNullOrEmpty(kestrelTransport) ? (object)DBNull.Value : kestrelTransport);
                     p.AddWithValue("@ClientThreads", clientThreads);
                     p.AddWithValue("@Connections", connections);
                     p.AddWithValue("@Duration", duration);

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -384,6 +384,11 @@ namespace BenchmarkServer
                 arguments += $" --kestrelThreadPoolDispatching {job.KestrelThreadPoolDispatching.Value}";
             }
 
+            if (!string.IsNullOrEmpty(job.KestrelTransport))
+            {
+                arguments += $" --transport {job.KestrelTransport}";
+            }
+
             Log.WriteLine($"Starting process '{filename} {arguments}'");
 
             var process = new Process()

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -374,6 +374,11 @@ namespace BenchmarkServer
                 arguments += $" --connectionFilter {job.ConnectionFilter}";
             }
 
+            if (job.KestrelTransport.HasValue)
+            {
+                arguments += $" --kestrelTransport {job.KestrelTransport.Value}";
+            }
+
             if (job.KestrelThreadCount.HasValue)
             {
                 arguments += $" --threadCount {job.KestrelThreadCount.Value}";
@@ -382,11 +387,6 @@ namespace BenchmarkServer
             if (job.KestrelThreadPoolDispatching.HasValue)
             {
                 arguments += $" --kestrelThreadPoolDispatching {job.KestrelThreadPoolDispatching.Value}";
-            }
-
-            if (!string.IsNullOrEmpty(job.KestrelTransport))
-            {
-                arguments += $" --transport {job.KestrelTransport}";
             }
 
             Log.WriteLine($"Starting process '{filename} {arguments}'");


### PR DESCRIPTION
- Added support for specifying kestrel transports in the benchmark driver and the
benchmark itself
- Added sockets to the Plaintext and JSON benchmark.

Fixes #250 