### PR TITLE
Bring over a few changes from the TechEmpower repo

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(CoreFxVersion)" />
     <PackageReference Include="Dapper" Version="$(DapperVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="$(AspNetCoreVersion)" />
@@ -17,7 +16,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(AspNetCoreVersion)" />
@@ -31,10 +29,6 @@
     -->
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(CoreFxVersion)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.Dotnet" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-
 </Project>

--- a/src/Benchmarks/Configuration/AppSettings.cs
+++ b/src/Benchmarks/Configuration/AppSettings.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
-
-using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Benchmarks.Configuration
 {

--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -162,7 +162,7 @@ namespace Benchmarks.Configuration
             }
 
             var props = typeof(Scenarios).GetTypeInfo().DeclaredProperties
-                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0)
+                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.StartsWith(partialName, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             foreach (var p in props)

--- a/src/Benchmarks/Configuration/Scenarios.cs
+++ b/src/Benchmarks/Configuration/Scenarios.cs
@@ -155,14 +155,14 @@ namespace Benchmarks.Configuration
 
         public int Enable(string partialName)
         {
-            if(string.Equals(partialName, "[default]", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(partialName, "[default]", StringComparison.OrdinalIgnoreCase))
             {
                 EnableDefault();
                 return 2;
             }
 
             var props = typeof(Scenarios).GetTypeInfo().DeclaredProperties
-                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.StartsWith(partialName, StringComparison.OrdinalIgnoreCase))
+                .Where(p => string.Equals(partialName, "[all]", StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf(partialName, StringComparison.OrdinalIgnoreCase) >= 0)
                 .ToList();
 
             foreach (var p in props)

--- a/src/Benchmarks/Data/ApplicationDbContext.cs
+++ b/src/Benchmarks/Data/ApplicationDbContext.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore;
 

--- a/src/Benchmarks/Data/ApplicationDbSeeder.cs
+++ b/src/Benchmarks/Data/ApplicationDbSeeder.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -40,7 +40,7 @@ namespace Benchmarks.Data
         async Task<World> ReadSingleRow(DbConnection db)
         {
             return await db.QueryFirstOrDefaultAsync<World>(
-                    "SELECT id, randomnumber FROM world WHERE Id = @Id",
+                    "SELECT id, randomnumber FROM world WHERE id = @Id",
                     new { Id = _random.Next(1, 10001) });
         }
 

--- a/src/Benchmarks/Data/EfDb.cs
+++ b/src/Benchmarks/Data/EfDb.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Benchmarks/Data/World.cs
+++ b/src/Benchmarks/Data/World.cs
@@ -1,5 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations.Schema;
 

--- a/src/Benchmarks/Middleware/DebugInfoPageMiddleware.cs
+++ b/src/Benchmarks/Middleware/DebugInfoPageMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
@@ -24,13 +24,7 @@ namespace Benchmarks.Middleware
         private static readonly string _configurationName = "";
 #endif
 
-#if NET46
-        private static readonly string _targetFrameworkName = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
-#elif NETCOREAPP2_0
         private static readonly string _targetFrameworkName = AppContext.TargetFrameworkName;
-#else
-#error the target framework needs to be updated.                    
-#endif
 
         private readonly IHostingEnvironment _hostingEnv;
         private readonly RequestDelegate _next;

--- a/src/Benchmarks/Middleware/FortunesDapperMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesDapperMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Text.Encodings.Web;
@@ -40,7 +40,7 @@ namespace Benchmarks.Middleware
             await _next(httpContext);
         }
     }
-    
+
     public static class FortunesDapperMiddlewareExtensions
     {
         public static IApplicationBuilder UseFortunesDapper(this IApplicationBuilder builder)

--- a/src/Benchmarks/Middleware/FortunesRawMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesRawMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Text.Encodings.Web;
@@ -40,7 +40,7 @@ namespace Benchmarks.Middleware
             await _next(httpContext);
         }
     }
-    
+
     public static class FortunesRawMiddlewareExtensions
     {
         public static IApplicationBuilder UseFortunesRaw(this IApplicationBuilder builder)

--- a/src/Benchmarks/Middleware/MiddlewareHelpers.cs
+++ b/src/Benchmarks/Middleware/MiddlewareHelpers.cs
@@ -51,7 +51,6 @@ namespace Benchmarks.Middleware
             // fortunes includes multibyte characters so response.Length is incorrect
             httpContext.Response.ContentLength = Encoding.UTF8.GetByteCount(response);
             await httpContext.Response.WriteAsync(response);
-
         }
     }
 }

--- a/src/Benchmarks/Middleware/MultipleQueriesDapperMiddleware.cs
+++ b/src/Benchmarks/Middleware/MultipleQueriesDapperMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Middleware/MultipleQueriesRawMiddleware.cs
+++ b/src/Benchmarks/Middleware/MultipleQueriesRawMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Middleware/MultipleUpdatesDapperMiddleware.cs
+++ b/src/Benchmarks/Middleware/MultipleUpdatesDapperMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Middleware/MultipleUpdatesRawMiddleware.cs
+++ b/src/Benchmarks/Middleware/MultipleUpdatesRawMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Middleware/PlaintextMiddleware.cs
+++ b/src/Benchmarks/Middleware/PlaintextMiddleware.cs
@@ -37,11 +37,7 @@ namespace Benchmarks.Middleware
             var payloadLength = _helloWorldPayload.Length;
             response.StatusCode = 200;
             response.ContentType = "text/plain";
-
-            // HACK: Setting the Content-Length header manually avoids the cost of serializing the int to a string.
-            //       This is instead of: httpContext.Response.ContentLength = payloadLength;
-            response.Headers["Content-Length"] = "13";
-
+            response.ContentLength = payloadLength;
             return response.Body.WriteAsync(_helloWorldPayload, 0, payloadLength);
         }
     }

--- a/src/Benchmarks/Middleware/PlaintextMiddleware.cs
+++ b/src/Benchmarks/Middleware/PlaintextMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Text;
@@ -16,7 +16,7 @@ namespace Benchmarks.Middleware
         private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("Hello, World!");
 
         private readonly RequestDelegate _next;
-        
+
         public PlaintextMiddleware(RequestDelegate next)
         {
             _next = next;
@@ -37,11 +37,15 @@ namespace Benchmarks.Middleware
             var payloadLength = _helloWorldPayload.Length;
             response.StatusCode = 200;
             response.ContentType = "text/plain";
-            response.ContentLength = payloadLength;
+
+            // HACK: Setting the Content-Length header manually avoids the cost of serializing the int to a string.
+            //       This is instead of: httpContext.Response.ContentLength = payloadLength;
+            response.Headers["Content-Length"] = "13";
+
             return response.Body.WriteAsync(_helloWorldPayload, 0, payloadLength);
         }
     }
-    
+
     public static class PlaintextMiddlewareExtensions
     {
         public static IApplicationBuilder UsePlainText(this IApplicationBuilder builder)

--- a/src/Benchmarks/Middleware/SingleQueryDapperMiddleware.cs
+++ b/src/Benchmarks/Middleware/SingleQueryDapperMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Middleware/SingleQueryEfMiddleware.cs
+++ b/src/Benchmarks/Middleware/SingleQueryEfMiddleware.cs
@@ -8,7 +8,6 @@ using Benchmarks.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 

--- a/src/Benchmarks/Middleware/SingleQueryRawMiddleware.cs
+++ b/src/Benchmarks/Middleware/SingleQueryRawMiddleware.cs
@@ -1,5 +1,5 @@
-// Copyright (c) .NET Foundation. All rights reserved. 
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -189,9 +189,11 @@ namespace Benchmarks
                         Console.WriteLine($"Gen 0: {GC.CollectionCount(0)}, Gen 1: {GC.CollectionCount(1)}, Gen 2: {GC.CollectionCount(2)}");
                     }
                 }
-            });
+            })
+            {
+                IsBackground = true
+            };
 
-            interactiveThread.IsBackground = true;
             interactiveThread.Start();
 
             started.WaitOne();

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Npgsql;
 
@@ -143,8 +142,7 @@ namespace Benchmarks
             return services.BuildServiceProvider(validateScopes: true);
         }
 
-        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder, IOptions<AppSettings> appSettings,
-            ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, ApplicationDbSeeder dbSeeder)
         {
             if (Scenarios.StaticFiles)
             {


### PR DESCRIPTION
- incorporate aspnet/FrameworkBenchmarks@4830e2fc, "Only Prepare DbCommand once"
- enable more scenarios e.g. "--scenarios plaintext" also enables "mvc/plaintext" scenario
- optimize `Content-Length` setting in plaintext scenario
- remove unused Microsoft.EntityFrameworkCore.Design dependency and EF tooling
- remove irrelevant `#if NET46` code

nits:
- sort dependencies
- clean up whitespace
- accept VS suggestions