### PR TITLE
Initial docker support

### DIFF
--- a/src/Benchmarks.ServerJob/Source.cs
+++ b/src/Benchmarks.ServerJob/Source.cs
@@ -8,5 +8,6 @@ namespace Benchmarks.ServerJob
         public string BranchOrCommit { get; set; }
         public string Repository { get; set; }
         public string Project { get; set; }
+        public string DockerFile { get; set; }
     }
 }

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -111,7 +111,7 @@ namespace BenchmarkClient
                 if (job != null)
                 {
                     var jobLogText =
-                        $"[ID:{job.Id} Connections:{job.Connections} Threads:{job.Threads} Duration:{job.Duration} Method:{job.Method}";
+                        $"[ID:{job.Id} Connections:{job.Connections} Threads:{job.Threads} Duration:{job.Duration} Method:{job.Method} ServerUrl:{job.ServerBenchmarkUri}";
 
                     Debug.Assert(job.PipelineDepth <= 0 || job.ScriptName != null, "A script name must be present when the pipeline depth is larger than 0.");
 

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -264,7 +264,7 @@ namespace BenchmarkServer
 
                                     try
                                     {
-                                        if (disposed || Debugger.IsAttached)
+                                        if (disposed)
                                         {
                                             return;
                                         }


### PR DESCRIPTION
- Support passing a docker file as the source of a benchmark
- The steps we do with this change are:
 - Clone the repo
 - Build a random image name
 - Start the container with an exposed port
 - Use docker container stats to get the status of the container we started
- Clean up when finished
- Also fixed some race conditions with the timer callback.

I only tested locally which means the numbers were all out of wack as client/server and driver were all on the same machine. I'll make sure i didn't break any mainline scenarios as well. The code generally needs some refactoring as it's getting to be lots of spaghetti in Startup.

PS: Args need to be added, they don't work as yet.