### PR TITLE
Adding a timeout on jobs

### DIFF
--- a/src/Benchmarks.ServerJob/ServerJob.cs
+++ b/src/Benchmarks.ServerJob/ServerJob.cs
@@ -62,5 +62,6 @@ namespace Benchmarks.ServerJob
         public WebHost WebHost { get; set; }
 
         public bool UseRuntimeStore { get; set; }
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(5);
     }
 }

--- a/src/Benchmarks.ServerJob/ServerJob.cs
+++ b/src/Benchmarks.ServerJob/ServerJob.cs
@@ -62,6 +62,6 @@ namespace Benchmarks.ServerJob
         public WebHost WebHost { get; set; }
 
         public bool UseRuntimeStore { get; set; }
-        public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(5);
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(2);
     }
 }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -89,6 +89,8 @@ namespace BenchmarksDriver
                 "Relative path of the project to test in the repository. (e.g., \"src/Benchmarks/Benchmarks.csproj)\"", CommandOptionType.SingleValue);
             var useRuntimeStoreOption = app.Option("--useRuntimeStore",
                 "Runs the benchmarks using the runtime store if available.", CommandOptionType.NoValue);
+            var timeoutOption = app.Option("--timeout",
+                "The max delay to wait to the job to run. Default is 00:02:00.", CommandOptionType.SingleValue);
 
             // ClientJob Options
             var clientThreadsOption = app.Option("--clientThreads",
@@ -154,7 +156,8 @@ namespace BenchmarksDriver
                     (headersOption.HasValue() && !Enum.TryParse(headersOption.Value(), ignoreCase: true, result: out headers)) ||
                     (databaseOption.HasValue() && !Enum.TryParse(databaseOption.Value(), ignoreCase: true, result: out Database database)) ||
                     string.IsNullOrWhiteSpace(server) ||
-                    string.IsNullOrWhiteSpace(client))
+                    string.IsNullOrWhiteSpace(client) ||
+                    !TimeSpan.TryParse(timeoutOption.Value(), result: out TimeSpan timeoutValue))
                 {
                     app.ShowHelp();
                     return 2;
@@ -336,6 +339,10 @@ namespace BenchmarksDriver
                 if (projectOption.HasValue())
                 {
                     serverJob.Source.Project = projectOption.Value();
+                }
+                if (timeoutOption.HasValue())
+                {
+                    serverJob.Timeout = timeoutValue;
                 }
 
                 foreach (var source in sourceOption.Values)

--- a/src/BenchmarksDriver/README.md
+++ b/src/BenchmarksDriver/README.md
@@ -37,6 +37,7 @@ Options:
   --repository                    Project repository. Format is 'repo@branchOrCommit'. Repo can be a full URL, or a short name under https://github.com/aspnet.
   --project                       Relative path of the project to test in the repository. (e.g., "src/Benchmarks/Benchmarks.csproj)
   --useRuntimeStore               Runs the benchmarks using the runtime store if available.
+  --timeout                       The max delay to wait to the job to run. Default is 00:02:00.
 ```
 
 ### Examples

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -287,6 +287,13 @@ namespace BenchmarkServer
 
                                         var now = DateTime.UtcNow;
 
+                                        // Clean the job in case the driver that created the job was stopped, or the job is not running
+                                        if (now - startMonitorTime > job.Timeout)
+                                        {
+                                            Log.WriteLine($"Job timed out after {job.Timeout}. Halting job.");
+                                            job.State = ServerState.Deleting;
+                                        }
+
                                         if (process != null)
                                         {
                                             // TODO: Accessing the TotalProcessorTime on OSX throws so just leave it as 0 for now


### PR DESCRIPTION
In case the application throws an exception, or the driver gets killed and doesn't update the job.