### PR TITLE
Handle bad responses and sockets errors

### DIFF
--- a/src/Benchmarks.ClientJob/ClientJob.cs
+++ b/src/Benchmarks.ClientJob/ClientJob.cs
@@ -55,6 +55,10 @@ namespace Benchmarks.ClientJob
         public ClientState State { get; set; }
 
         public double RequestsPerSecond { get; set; }
+        public int Requests { get; set; }
+        public TimeSpan ActualDuration { get; set; }
+        public int SocketErrors { get; set; }
+        public int BadResponses { get; set; }
         public Latency Latency { get;set; } = new Latency();
 
         public string Output { get; set; }

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -285,7 +285,17 @@ namespace BenchmarkClient
 
                 var p99Match = Regex.Match(job.Output, @"99%\s*([\d\.]*)\s*(s|ms|us)");
                 job.Latency.Within99thPercentile = ReadLatency(p99Match);
-                
+
+                var socketErrorsMatch = Regex.Match(job.Output, @"Socket errors: connect ([\d\.]*), read ([\d\.]*), write ([\d\.]*), timeout ([\d\.]*)");
+                job.SocketErrors = CountSocketErrors(socketErrorsMatch);
+
+                var badResponsesMatch = Regex.Match(job.Output, @"Non-2xx or 3xx responses: ([\d\.]*)");
+                job.BadResponses = ReadBadReponses(badResponsesMatch);
+
+                var requestsCountMatch = Regex.Match(job.Output, @"([\d\.]*) requests in ([\d\.]*)s");
+                job.Requests = ReadRequests(requestsCountMatch);
+                job.ActualDuration = ReadDuration(requestsCountMatch);
+
                 job.State = ClientState.Completed;
             };
 
@@ -294,6 +304,57 @@ namespace BenchmarkClient
             process.BeginErrorReadLine();
 
             return process;                
+        }
+
+        private static TimeSpan ReadDuration(Match responseCountMatch)
+        {
+            if (!responseCountMatch.Success || responseCountMatch.Groups.Count != 3)
+            {
+                throw new NotSupportedException("Failed to parse duration");
+            }
+
+            var value = double.Parse(responseCountMatch.Groups[2].Value);
+            return TimeSpan.FromSeconds(value);
+        }
+
+        private static int ReadRequests(Match responseCountMatch)
+        {
+            if (!responseCountMatch.Success || responseCountMatch.Groups.Count != 3)
+            {
+                throw new NotSupportedException("Failed to parse requests");
+            }
+
+            var value = int.Parse(responseCountMatch.Groups[1].Value);
+            return value;
+        }
+
+        private static int ReadBadReponses(Match badResponsesMatch)
+        {
+            if (!badResponsesMatch.Success || badResponsesMatch.Groups.Count != 2)
+            {
+                return 0;
+            }
+
+            var value = int.Parse(badResponsesMatch.Groups[1].Value);
+
+            return value;
+        }
+
+        private static int CountSocketErrors(Match socketErrorsMatch)
+        {
+            if (!socketErrorsMatch.Success || socketErrorsMatch.Groups.Count != 5)
+            {
+                return 0;
+            }
+
+            var value = 
+                int.Parse(socketErrorsMatch.Groups[1].Value) +
+                int.Parse(socketErrorsMatch.Groups[2].Value) +
+                int.Parse(socketErrorsMatch.Groups[3].Value) +
+                int.Parse(socketErrorsMatch.Groups[4].Value)
+                ;
+
+            return value;
         }
 
         private static TimeSpan ReadLatency(Match match)

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -526,7 +526,7 @@ namespace BenchmarksDriver
                     Log($"First Request (ms):          {clientJob.LatencyFirstRequest.TotalMilliseconds}");
                     Log($"Latency (ms):                {clientJob.LatencyNoLoad.TotalMilliseconds}");
                     Log($"Socket Errors:               {clientJob.SocketErrors}");
-                    Log($"Bad Responsed:               {clientJob.BadResponses}");
+                    Log($"Bad Responses:               {clientJob.BadResponses}");
 
                     if (!string.IsNullOrWhiteSpace(sqlConnectionString))
                     {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -661,6 +661,26 @@ namespace BenchmarksDriver
                             description: description,
                             dimension: "BadResponses",
                             value: clientJob.BadResponses);
+
+                        await WriteJobsToSql(
+                            serverJob: serverJob,
+                            clientJob: clientJob,
+                            connectionString: sqlConnectionString,
+                            path: serverJob.Path,
+                            session: session,
+                            description: description,
+                            dimension: "TotalRequests",
+                            value: clientJob.Requests);
+
+                        await WriteJobsToSql(
+                            serverJob: serverJob,
+                            clientJob: clientJob,
+                            connectionString: sqlConnectionString,
+                            path: serverJob.Path,
+                            session: session,
+                            description: description,
+                            dimension: "Duration (ms)",
+                            value: clientJob.ActualDuration.TotalMilliseconds);
                     }
                 }
             }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -525,7 +525,9 @@ namespace BenchmarksDriver
                     Log($"Startup Main (ms):           {serverJob.StartupMainMethod.TotalMilliseconds}");
                     Log($"First Request (ms):          {clientJob.LatencyFirstRequest.TotalMilliseconds}");
                     Log($"Latency (ms):                {clientJob.LatencyNoLoad.TotalMilliseconds}");
-                    
+                    Log($"Socket Errors:               {clientJob.SocketErrors}");
+                    Log($"Bad Responsed:               {clientJob.BadResponses}");
+
                     if (!string.IsNullOrWhiteSpace(sqlConnectionString))
                     {
                         Log("Writing results to SQL...");
@@ -639,6 +641,26 @@ namespace BenchmarksDriver
                             description: description,
                             dimension: "Latency99Percentile (ms)",
                             value: clientJob.Latency.Within99thPercentile.TotalMilliseconds);
+
+                        await WriteJobsToSql(
+                            serverJob: serverJob,
+                            clientJob: clientJob,
+                            connectionString: sqlConnectionString,
+                            path: serverJob.Path,
+                            session: session,
+                            description: description,
+                            dimension: "SocketErrors",
+                            value: clientJob.SocketErrors);
+
+                        await WriteJobsToSql(
+                            serverJob: serverJob,
+                            clientJob: clientJob,
+                            connectionString: sqlConnectionString,
+                            path: serverJob.Path,
+                            session: session,
+                            description: description,
+                            dimension: "BadResponses",
+                            value: clientJob.BadResponses);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #320

The implemented strategy is to log the number of bad responses (non 2xx-3xx) and socket errors. This can then be used to create a report of the jobs that are failing. 