### PR TITLE
Adding HardwareVersion column

### DIFF
--- a/docker/benchmarks/run-server.sh
+++ b/docker/benchmarks/run-server.sh
@@ -7,6 +7,14 @@ if [ -z server_ip ]
 then
     # tries to get the ip from the available NICs, but it's recommended to set it manually to use the fastest one
     server_ip=$(ip route get 1 | awk '{print $NF;exit}')
+
+    echo "Using server_ip=$server_ip"
+fi
+
+if [ -z hardware_version ]
+then
+    echo "harware_version needs to be set"
+    exit 1
 fi
 
 if [ -e /var/log/waagent.log ]
@@ -40,6 +48,7 @@ then
         /benchmarks/src/BenchmarksServer/bin/Debug/netcoreapp2.0/BenchmarksServer.dll \
         -n $server_ip \
         --hardware $hardware \
+        --hardware-version $hardware_version \
         $postgresql  \
         $mysql  \
         $mssql \

--- a/src/Benchmarks.ServerJob/ServerJob.cs
+++ b/src/Benchmarks.ServerJob/ServerJob.cs
@@ -18,6 +18,8 @@ namespace Benchmarks.ServerJob
         [JsonConverter(typeof(StringEnumConverter))]
         public Hardware? Hardware { get; set; }
 
+        public string HardwareVersion { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public OperatingSystem? OperatingSystem { get; set; }
 

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -959,8 +959,7 @@ namespace BenchmarksDriver
                     p.AddWithValue("@AspNetCoreVersion", aspnetCoreVersion);
                     p.AddWithValue("@Scenario", scenario.ToString());
                     p.AddWithValue("@Hardware", hardware.ToString());
-                    p.AddWithValue("@HardwareVersion",
-                        string.IsNullOrEmpty(hardwareVersion) ? (object)DBNull.Value : hardwareVersion);
+                    p.AddWithValue("@HardwareVersion", hardwareVersion);
                     p.AddWithValue("@OperatingSystem", operatingSystem.ToString());
                     p.AddWithValue("@Framework", "Core");
                     p.AddWithValue("@RuntimeStore", runtimeStore);

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -472,6 +472,11 @@ namespace BenchmarksDriver
                         throw new InvalidOperationException("Server is required to set ServerJob.Hardware.");
                     }
 
+                    if (String.IsNullOrWhiteSpace(serverJob.HardwareVersion))
+                    {
+                        throw new InvalidOperationException("Server is required to set ServerJob.HardwareVersion.");
+                    }
+
                     if (!serverJob.OperatingSystem.HasValue)
                     {
                         throw new InvalidOperationException("Server is required to set ServerJob.OperatingSystem.");
@@ -804,6 +809,7 @@ namespace BenchmarksDriver
                         description: description,
                         aspnetCoreVersion: serverJob.AspNetCoreVersion,
                         hardware: serverJob.Hardware.Value,
+                        hardwareVersion: serverJob.HardwareVersion,
                         operatingSystem: serverJob.OperatingSystem.Value,
                         scheme: serverJob.Scheme,
                         sources: serverJob.ReferenceSources,
@@ -828,6 +834,7 @@ namespace BenchmarksDriver
             string aspnetCoreVersion,
             string scenario,
             Hardware hardware,
+            string hardwareVersion,
             OperatingSystem operatingSystem,
             Scheme scheme,
             IEnumerable<Source> sources,
@@ -858,6 +865,7 @@ namespace BenchmarksDriver
                         [AspNetCoreVersion] [nvarchar](max) NOT NULL,
                         [Scenario] [nvarchar](max) NOT NULL,
                         [Hardware] [nvarchar](max) NOT NULL,
+                        [HardwareVersion] [nvarchar](128) NOT NULL,
                         [OperatingSystem] [nvarchar](max) NOT NULL,
                         [Framework] [nvarchar](max) NOT NULL,
                         [RuntimeStore] [bit] NOT NULL,
@@ -888,6 +896,7 @@ namespace BenchmarksDriver
                            ,[AspNetCoreVersion]
                            ,[Scenario]
                            ,[Hardware]
+                           ,[HardwareVersion]
                            ,[OperatingSystem]
                            ,[Framework]
                            ,[RuntimeStore]
@@ -912,6 +921,7 @@ namespace BenchmarksDriver
                            ,@AspNetCoreVersion
                            ,@Scenario
                            ,@Hardware
+                           ,@HardwareVersion
                            ,@OperatingSystem
                            ,@Framework
                            ,@RuntimeStore
@@ -949,6 +959,8 @@ namespace BenchmarksDriver
                     p.AddWithValue("@AspNetCoreVersion", aspnetCoreVersion);
                     p.AddWithValue("@Scenario", scenario.ToString());
                     p.AddWithValue("@Hardware", hardware.ToString());
+                    p.AddWithValue("@HardwareVersion",
+                        string.IsNullOrEmpty(hardwareVersion) ? (object)DBNull.Value : hardwareVersion);
                     p.AddWithValue("@OperatingSystem", operatingSystem.ToString());
                     p.AddWithValue("@Framework", "Core");
                     p.AddWithValue("@RuntimeStore", runtimeStore);

--- a/src/BenchmarksServer/Controllers/JobsController.cs
+++ b/src/BenchmarksServer/Controllers/JobsController.cs
@@ -52,6 +52,7 @@ namespace BenchmarkServer.Controllers
             }
 
             job.Hardware = Startup.Hardware;
+            job.HardwareVersion = Startup.HardwareVersion;
             job.OperatingSystem = Startup.OperatingSystem;
             job = _jobs.Add(job);
 

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -42,6 +42,7 @@ namespace BenchmarkServer
 
         public static OperatingSystem OperatingSystem { get; }
         public static Hardware Hardware { get; private set; }
+        public static string HardwareVersion { get; private set; }
         public static Dictionary<Database, string> ConnectionStrings = new Dictionary<Database, string>();
 
         static Startup()
@@ -125,6 +126,8 @@ namespace BenchmarkServer
                 CommandOptionType.SingleValue);
             var hardwareOption = app.Option("--hardware", "Hardware (Cloud or Physical).  Required.",
                 CommandOptionType.SingleValue);
+            var hardwareVersionOption = app.Option("--hardware-version", "Hardware version (e.g, D3V2, Z420, ...).  Required.",
+                CommandOptionType.SingleValue);
             var databaseOption = app.Option("-d|--database", "Database (PostgreSQL, SqlServer, MySql or MongoDb).",
                 CommandOptionType.SingleValue);
             var noCleanupOption = app.Option("--no-cleanup",
@@ -160,6 +163,15 @@ namespace BenchmarkServer
                 if (mongoDbConnectionStringOption.HasValue())
                 {
                     ConnectionStrings[Database.MongoDb] = mongoDbConnectionStringOption.Value();
+                }
+                if (hardwareVersionOption.HasValue() && !string.IsNullOrWhiteSpace(hardwareVersionOption.Value()))
+                {
+                    HardwareVersion = hardwareVersionOption.Value();
+                }
+                else
+                {
+                    Console.WriteLine("Option --hardware-version is required.");
+                    return 3;
                 }
                 if (Enum.TryParse(hardwareOption.Value(), ignoreCase: true, result: out Hardware hardware))
                 {


### PR DESCRIPTION
Mandatory option on BenchmarkServer.
Will add the column once the change is approved, and set the correct historical values.
Also update the onenote.