### PR TITLE
Adding support for RSP files

### DIFF
--- a/src/BenchmarksDriver/BenchmarksDriver.csproj
+++ b/src/BenchmarksDriver/BenchmarksDriver.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Data.SqlClient" Version="$(CoreFxVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Switching to Nate's library that supports @ parameters
Also supports urls in filenames

Example:
`@local-linux.rsp @kestrel-plaintext.rsp --duration 10`