### PR TITLE
Add option "--trace-arguments"

### DIFF
--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -110,7 +110,10 @@ namespace BenchmarksDriver
                 "\"--runtimeFile c:\\build\\System.Net.Security.dll\"",
                 CommandOptionType.MultipleValue);
             var collectTraceOption = app.Option("--collect-trace",
-                "Collect a PerfView trace. Optionally set custom arguments. e.g., BufferSize=256;InMemoryCircularBuffer", CommandOptionType.NoValue);
+                "Collect a PerfView trace.", CommandOptionType.NoValue);
+            var traceArgumentsOption = app.Option("--trace-arguments",
+                "Arguments used when collecting a PerfView trace.  Defaults to \"BufferSize=1024\".",
+                CommandOptionType.SingleValue);
             var traceOutputOption = app.Option("--trace-output",
                 "An optional location to download the trace file to, e.g., --trace-output c:\traces", CommandOptionType.SingleValue);
             var disableR2ROption = app.Option("--no-crossgen",
@@ -382,13 +385,8 @@ namespace BenchmarksDriver
                 {
                     serverJob.Collect = true;
 
-                    serverJob.CollectArguments = collectTraceOption.Value();
-
-                    // Clear the arguments if the value is "on" as this is a marker for NoValue on the command parser
-                    if (serverJob.CollectArguments == "on")
-                    {
-                        serverJob.CollectArguments = "";
-                    }
+                    // Default to arguments which should be sufficient for collecting trace of default Plaintext run
+                    serverJob.CollectArguments = traceArgumentsOption.Value() ?? "BufferSize=1024";
                 }
                 if (disableR2ROption.HasValue())
                 {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -28,6 +28,9 @@ namespace BenchmarksDriver
         private static ClientJob _clientJob;
         private static string _tableName = "AspNetBenchmarks";
 
+        // Default to arguments which should be sufficient for collecting trace of default Plaintext run
+        private const string _defaultTraceArguments = "BufferSize=1024";
+
         public static int Main(string[] args)
         {
             var app = new CommandLineApplication()
@@ -112,7 +115,7 @@ namespace BenchmarksDriver
             var collectTraceOption = app.Option("--collect-trace",
                 "Collect a PerfView trace.", CommandOptionType.NoValue);
             var traceArgumentsOption = app.Option("--trace-arguments",
-                "Arguments used when collecting a PerfView trace.  Defaults to \"BufferSize=1024\".",
+                $"Arguments used when collecting a PerfView trace.  Defaults to \"{_defaultTraceArguments}\".",
                 CommandOptionType.SingleValue);
             var traceOutputOption = app.Option("--trace-output",
                 "An optional location to download the trace file to, e.g., --trace-output c:\traces", CommandOptionType.SingleValue);
@@ -384,9 +387,11 @@ namespace BenchmarksDriver
                 if (collectTraceOption.HasValue())
                 {
                     serverJob.Collect = true;
-
-                    // Default to arguments which should be sufficient for collecting trace of default Plaintext run
-                    serverJob.CollectArguments = traceArgumentsOption.Value() ?? "BufferSize=1024";
+                    serverJob.CollectArguments = _defaultTraceArguments;
+                    if (traceArgumentsOption.HasValue())
+                    {
+                        serverJob.CollectArguments = string.Join(';', serverJob.CollectArguments, traceArgumentsOption.Value());
+                    }
                 }
                 if (disableR2ROption.HasValue())
                 {

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1305,7 +1305,6 @@ namespace BenchmarkServer
                             var perfViewArguments = new Dictionary<string, string>();
                             perfViewArguments["AcceptEula"] = "";
                             perfViewArguments["NoGui"] = "";
-                            perfViewArguments["BufferSize"] = "256";
                             perfViewArguments["Process"] = process.Id.ToString();
 
                             if (!String.IsNullOrEmpty(job.CollectArguments))


### PR DESCRIPTION
- Increase default BufferSize from 256 to 1024, which should be sufficient for capturing a trace of a default Plaintext run
- Set default BufferSize in Driver rather than Server, so it can be changed without updating servers.