### PR TITLE
Added platform level plaintext benchmark

### DIFF
--- a/benchmarks.sln
+++ b/benchmarks.sln
@@ -105,6 +105,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "mongodb-techempower", "mong
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarksWorkers", "src\BenchmarksWorkers\BenchmarksWorkers.csproj", "{44D137AF-404D-4963-A096-C803F4774FCB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlatformBenchmarks", "src\PlatformBenchmarks\PlatformBenchmarks.csproj", "{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +187,14 @@ Global
 		{44D137AF-404D-4963-A096-C803F4774FCB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{44D137AF-404D-4963-A096-C803F4774FCB}.Release|x86.ActiveCfg = Release|Any CPU
 		{44D137AF-404D-4963-A096-C803F4774FCB}.Release|x86.Build.0 = Release|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Debug|x86.Build.0 = Debug|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Release|x86.ActiveCfg = Release|Any CPU
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -205,6 +215,7 @@ Global
 		{FA7BA2F5-47DA-418F-B29F-458714F44C89} = {EF444B27-3CBA-4581-893A-7F6DB5527371}
 		{13B1DC5E-AD37-4958-B22D-FAE26F6D4058} = {EF444B27-3CBA-4581-893A-7F6DB5527371}
 		{44D137AF-404D-4963-A096-C803F4774FCB} = {995FCFF9-E5F6-4BDD-8E5B-FBDEA21145F9}
+		{796DE0EB-A16B-47FC-B6C7-CBCDF5607E2F} = {995FCFF9-E5F6-4BDD-8E5B-FBDEA21145F9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C48AD7EE-82B1-4307-A869-3FC14AC9B21F}

--- a/src/PlatformBenchmarks/AsciiString.cs
+++ b/src/PlatformBenchmarks/AsciiString.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Text;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 

--- a/src/PlatformBenchmarks/AsciiString.cs
+++ b/src/PlatformBenchmarks/AsciiString.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+namespace PlatformBenchmarks
+{
+    public struct AsciiString : IEquatable<AsciiString>
+    {
+        private readonly byte[] _data;
+
+        public AsciiString(string s) => _data = Encoding.ASCII.GetBytes(s);
+
+        public int Length => _data.Length;
+
+        public ReadOnlySpan<byte> AsSpan() => _data;
+
+        public static implicit operator ReadOnlySpan<byte>(AsciiString str) => str._data;
+        public static implicit operator byte[] (AsciiString str) => str._data;
+
+        public static implicit operator AsciiString(string str) => new AsciiString(str);
+
+        public override string ToString() => HttpUtilities.GetAsciiStringNonNullCharacters(_data);
+        public static explicit operator string(AsciiString str) => str.ToString();
+
+        public bool Equals(AsciiString other) => ReferenceEquals(_data, other._data) || SequenceEqual(_data, other._data);
+        private bool SequenceEqual(byte[] data1, byte[] data2) => new Span<byte>(data1).SequenceEqual(data2);
+
+        public static bool operator ==(AsciiString a, AsciiString b) => a.Equals(b);
+        public static bool operator !=(AsciiString a, AsciiString b) => !a.Equals(b);
+        public override bool Equals(object other) => (other is AsciiString) && Equals((AsciiString)other);
+
+        public override int GetHashCode()
+        {
+            // Copied from x64 version of string.GetLegacyNonRandomizedHashCode()
+            // https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/String.Comparison.cs
+            var data = _data;
+            int hash1 = 5381;
+            int hash2 = hash1;
+            foreach (int b in data)
+            {
+                hash1 = ((hash1 << 5) + hash1) ^ b;
+            }
+            return hash1 + (hash2 * 1566083941);
+        }
+
+    }
+}

--- a/src/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/PlatformBenchmarks/BenchmarkApplication.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace PlatformBenchmarks
+{
+    public class BenchmarkApplication : HttpConnection
+    {
+        private static AsciiString _crlf = "\r\n";
+        private static AsciiString _http11OK = "HTTP/1.1 200 OK\r\n";
+        private static AsciiString _headerServer = "Server: Custom";
+        private static AsciiString _headerContentLength = "Content-Length: ";
+        private static AsciiString _headerContentLengthZero = "Content-Length: 0";
+        private static AsciiString _headerContentTypeText = "Content-Type: text/plain";
+
+        private static readonly DateHeaderValueManager _dateHeaderValueManager = new DateHeaderValueManager();
+
+        private static AsciiString _plainTextBody = "Hello, World!";
+
+        private static class Paths
+        {
+            public static AsciiString Plaintext = "/plaintext";
+        }
+
+        private bool _isPlainText;
+
+        public override void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+        {
+            _isPlainText = method == HttpMethod.Get && path.StartsWith(Paths.Plaintext);
+        }
+
+        public override void OnHeader(Span<byte> name, Span<byte> value)
+        {
+        }
+
+        public override ValueTask ProcessRequestAsync()
+        {
+            if (_isPlainText)
+            {
+                PlainText(Connection.Transport.Output);
+            }
+            else
+            {
+                Default(Connection.Transport.Output);
+            }
+
+            return default;
+        }
+
+        public override async ValueTask OnReadCompletedAsync()
+        {
+            await Connection.Transport.Output.FlushAsync();
+        }
+
+        private static void Default(PipeWriter pipeWriter)
+        {
+            var writer = new BufferWriter<PipeWriter>(pipeWriter);
+
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(_dateHeaderValueManager.GetDateHeaderValues().Bytes);
+            writer.Write(_crlf);
+
+            // Content-Length 0
+            writer.Write(_headerContentLengthZero);
+            writer.Write(_crlf);
+
+            // End of headers
+            writer.Write(_crlf);
+            writer.Commit();
+        }
+
+        private static void PlainText(PipeWriter pipeWriter)
+        {
+            var writer = new BufferWriter<PipeWriter>(pipeWriter);
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(_dateHeaderValueManager.GetDateHeaderValues().Bytes);
+            writer.Write(_crlf);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeText);
+            writer.Write(_crlf);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            writer.WriteNumeric((ulong)_plainTextBody.Length);
+            writer.Write(_crlf);
+
+            // End of headers
+            writer.Write(_crlf);
+
+            // Body
+            writer.Write(_plainTextBody);
+            writer.Commit();
+        }
+    }
+}

--- a/src/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/PlatformBenchmarks/BenchmarkApplication.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Threading.Tasks;

--- a/src/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/PlatformBenchmarks/BenchmarkApplication.cs
@@ -12,8 +12,8 @@ namespace PlatformBenchmarks
         private static AsciiString _http11OK = "HTTP/1.1 200 OK\r\n";
         private static AsciiString _headerServer = "Server: Custom";
         private static AsciiString _headerContentLength = "Content-Length: ";
-        private static AsciiString _headerContentLengthZero = "Content-Length: 0";
-        private static AsciiString _headerContentTypeText = "Content-Type: text/plain";
+        private static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
+        private static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
 
         private static readonly DateHeaderValueManager _dateHeaderValueManager = new DateHeaderValueManager();
 
@@ -70,7 +70,6 @@ namespace PlatformBenchmarks
 
             // Content-Length 0
             writer.Write(_headerContentLengthZero);
-            writer.Write(_crlf);
 
             // End of headers
             writer.Write(_crlf);
@@ -92,7 +91,6 @@ namespace PlatformBenchmarks
 
             // Content-Type header
             writer.Write(_headerContentTypeText);
-            writer.Write(_crlf);
 
             // Content-Length header
             writer.Write(_headerContentLength);

--- a/src/PlatformBenchmarks/BufferWriterExtensions.cs
+++ b/src/PlatformBenchmarks/BufferWriterExtensions.cs
@@ -1,0 +1,38 @@
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers
+{
+    internal static class BufferWriterExtensions
+    {
+        private const int MaxULongByteLength = 20;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void WriteNumeric(ref this BufferWriter<PipeWriter> buffer, ulong number)
+        {
+            // Try to format directly
+            if (Utf8Formatter.TryFormat(number, buffer.Span, out int bytesWritten))
+            {
+                buffer.Advance(bytesWritten);
+            }
+            else
+            {
+                // Ask for at least 20 bytes
+                buffer.Ensure(MaxULongByteLength);
+
+                Debug.Assert(buffer.Span.Length >= 20, "Buffer is < 20 bytes");
+
+                // Try again
+                if (Utf8Formatter.TryFormat(number, buffer.Span, out bytesWritten))
+                {
+                    buffer.Advance(bytesWritten);
+                }
+            }
+        }
+    }
+}

--- a/src/PlatformBenchmarks/BufferWriterExtensions.cs
+++ b/src/PlatformBenchmarks/BufferWriterExtensions.cs
@@ -1,3 +1,5 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Buffers;
 using System.Buffers.Text;

--- a/src/PlatformBenchmarks/HttpApplication.cs
+++ b/src/PlatformBenchmarks/HttpApplication.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Buffers;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Protocols;

--- a/src/PlatformBenchmarks/HttpApplication.cs
+++ b/src/PlatformBenchmarks/HttpApplication.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Buffers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Protocols;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace PlatformBenchmarks
+{
+    public static class HttpApplicationConnectionBuilderExtensions
+    {
+        public static IConnectionBuilder UseHttpApplication<TConnection>(this IConnectionBuilder builder) where TConnection : HttpConnection, new()
+        {
+            return builder.Use(next => new HttpApplication<TConnection>().ExecuteAsync);
+        }
+    }
+
+    public class HttpApplication<TConnection> where TConnection : HttpConnection, new()
+    {
+        public Task ExecuteAsync(ConnectionContext connection)
+        {
+            var parser = new HttpParser<HttpConnection>();
+
+            var httpConnection = new TConnection
+            {
+                Connection = connection,
+                Parser = parser
+            };
+            return httpConnection.ExecuteAsync();
+        }
+    }
+
+    public class HttpConnection : IHttpHeadersHandler, IHttpRequestLineHandler
+    {
+        private State _state;
+
+        public ConnectionContext Connection { get; set; }
+
+        internal HttpParser<HttpConnection> Parser { get; set; }
+
+        public virtual void OnHeader(Span<byte> name, Span<byte> value)
+        {
+
+        }
+
+        public virtual void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+        {
+
+        }
+
+        public virtual ValueTask ProcessRequestAsync()
+        {
+            return default;
+        }
+
+        public virtual ValueTask OnReadCompletedAsync()
+        {
+            return default;
+        }
+
+        public async Task ExecuteAsync()
+        {
+            try
+            {
+                while (true)
+                {
+                    var task = Connection.Transport.Input.ReadAsync();
+
+                    if (!task.IsCompleted)
+                    {
+                        // No more data in the input
+                        await OnReadCompletedAsync();
+                    }
+
+                    var result = await task;
+                    var buffer = result.Buffer;
+                    var consumed = buffer.Start;
+                    var examined = buffer.End;
+
+                    try
+                    {
+                        if (!buffer.IsEmpty)
+                        {
+                            ParseHttpRequest(buffer, out consumed, out examined);
+
+                            if (_state != State.Body && result.IsCompleted)
+                            {
+                                throw new InvalidOperationException("Unexpected end of data!");
+                            }
+                        }
+                        else if (result.IsCompleted)
+                        {
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        Connection.Transport.Input.AdvanceTo(consumed, examined);
+                    }
+
+                    if (_state == State.Body)
+                    {
+                        await ProcessRequestAsync();
+
+                        _state = State.StartLine;
+                    }
+                }
+
+                Connection.Transport.Input.Complete();
+            }
+            catch (Exception ex)
+            {
+                Connection.Transport.Input.Complete(ex);
+            }
+            finally
+            {
+                Connection.Transport.Output.Complete();
+            }
+        }
+
+        private void ParseHttpRequest(ReadOnlySequence<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
+        {
+            consumed = buffer.Start;
+            examined = buffer.End;
+
+            if (_state == State.StartLine)
+            {
+                if (Parser.ParseRequestLine(this, buffer, out consumed, out examined))
+                {
+                    _state = State.Headers;
+                    buffer = buffer.Slice(consumed);
+                }
+            }
+
+            if (_state == State.Headers)
+            {
+                if (Parser.ParseHeaders(this, buffer, out consumed, out examined, out int consumedBytes))
+                {
+                    _state = State.Body;
+                }
+            }
+        }
+
+        private enum State
+        {
+            StartLine,
+            Headers,
+            Body
+        }
+    }
+}

--- a/src/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -8,15 +8,6 @@
     <NETCoreAppImplicitPackageVersion>$(BenchmarksNETCoreAppImplicitPackageVersion)</NETCoreAppImplicitPackageVersion>
     <RuntimeFrameworkVersion>$(BenchmarksRuntimeFrameworkVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <PropertyGroup Condition="$(BenchmarksAspNetCoreVersion.StartsWith('2.1'))">
-    <DefineConstants>$(DefineConstants);DOTNET210</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$(BenchmarksAspNetCoreVersion.StartsWith('2.0'))">
-    <DefineConstants>$(DefineConstants);DOTNET200</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(BenchmarksAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Buffers.Sources" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />

--- a/src/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(BenchmarksAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Buffers.Sources" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/src/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -18,16 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jil" Version="$(JilVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="$(BenchmarksAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(BenchmarksAspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(BenchmarksAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Buffers.Sources" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(BenchmarksTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NETCoreAppImplicitPackageVersion>$(BenchmarksNETCoreAppImplicitPackageVersion)</NETCoreAppImplicitPackageVersion>
+    <RuntimeFrameworkVersion>$(BenchmarksRuntimeFrameworkVersion)</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(BenchmarksAspNetCoreVersion.StartsWith('2.1'))">
+    <DefineConstants>$(DefineConstants);DOTNET210</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(BenchmarksAspNetCoreVersion.StartsWith('2.0'))">
+    <DefineConstants>$(DefineConstants);DOTNET200</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Jil" Version="$(JilVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.HttpSys" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Buffers.Sources" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/PlatformBenchmarks/Program.cs
+++ b/src/PlatformBenchmarks/Program.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace PlatformBenchmarks
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            new WebHostBuilder()
+                .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Loopback, 8080, builder =>
+                    {
+                        builder.UseHttpApplication<BenchmarkApplication>();
+                    });
+                })
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/src/PlatformBenchmarks/Program.cs
+++ b/src/PlatformBenchmarks/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Net;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
@@ -45,7 +48,7 @@ namespace PlatformBenchmarks
             {
                 return new IPEndPoint(IPAddress.Loopback, 8080);
             }
-            
+
             var address = ServerAddress.FromUrl(url);
 
             IPAddress ip;

--- a/src/PlatformBenchmarks/Program.cs
+++ b/src/PlatformBenchmarks/Program.cs
@@ -1,6 +1,9 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
 
 namespace PlatformBenchmarks
 {
@@ -11,16 +14,52 @@ namespace PlatformBenchmarks
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            new WebHostBuilder()
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+
+            IPEndPoint endPoint = CreateIPEndPoint(config);
+
+            var host = new WebHostBuilder()
                 .UseKestrel(options =>
                 {
-                    options.Listen(IPAddress.Loopback, 8080, builder =>
+                    options.Listen(endPoint, builder =>
                     {
                         builder.UseHttpApplication<BenchmarkApplication>();
                     });
                 })
                 .UseStartup<Startup>()
                 .Build();
+
+            return host;
+        }
+
+        private static IPEndPoint CreateIPEndPoint(IConfigurationRoot config)
+        {
+            var url = config["server.urls"] ?? config["urls"];
+
+            if (string.IsNullOrEmpty(url))
+            {
+                return new IPEndPoint(IPAddress.Loopback, 8080);
+            }
+            
+            var address = ServerAddress.FromUrl(url);
+
+            IPAddress ip;
+
+            if (string.Equals(address.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                ip = IPAddress.Loopback;
+            }
+            else if (!IPAddress.TryParse(address.Host, out ip))
+            {
+                ip = IPAddress.IPv6Any;
+            }
+
+            return new IPEndPoint(ip, address.Port);
+        }
     }
 }

--- a/src/PlatformBenchmarks/Startup.cs
+++ b/src/PlatformBenchmarks/Startup.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace PlatformBenchmarks
+{
+    public class Startup
+    {
+        public void Configure(IApplicationBuilder app)
+        {
+            
+        }
+    }
+}

--- a/src/PlatformBenchmarks/Startup.cs
+++ b/src/PlatformBenchmarks/Startup.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Net.WebSockets;
 using System.Threading.Tasks;

--- a/src/PlatformBenchmarks/benchmarks.json
+++ b/src/PlatformBenchmarks/benchmarks.json
@@ -11,7 +11,7 @@
     "Source": {
       "Repository": "https://github.com/aspnet/benchmarks.git",
       "BranchOrCommit": "dev",
-      "Project": "src/Benchmarks/PlatformBenchmarks.csproj"
+      "Project": "src/PlatformBenchmarks/PlatformBenchmarks.csproj"
     },
     "Port": 8080
   },

--- a/src/PlatformBenchmarks/benchmarks.json
+++ b/src/PlatformBenchmarks/benchmarks.json
@@ -1,0 +1,30 @@
+{
+  "Default": {
+    "Client": "Wrk",
+    "ClientProperties": {
+      "ScriptName": "pipeline",
+      "PipelineDepth": 16
+    },
+    "ScriptName": "pipeline",
+    "PipelineDepth": 16,
+    "PresetHeaders": "Plaintext",
+    "Source": {
+      "Repository": "https://github.com/aspnet/benchmarks.git",
+      "BranchOrCommit": "dev",
+      "Project": "src/Benchmarks/PlatformBenchmarks.csproj"
+    },
+    "Port": 8080
+  },
+  "Plaintext": {
+    "Path": "/plaintext"
+  },
+  "PlaintextNonPipelined": {
+    "Path": "/plaintext",
+    "ClientProperties": {
+      "ScriptName": "",
+      "PipelineDepth": 0
+    },
+    "ScriptName": "",
+    "PipelineDepth": 0
+  }
+}


### PR DESCRIPTION
- Added very basic plain text benchmark
- Machinery is hidden behind an HttpConnection base class.
It encapsulates the Kestrel HttpParser and control flow
and has exposes virtual methods for handling request headers.
- Writing is manually writing headers to the output buffer.
We can no longer use the kestrel headers directly because of
some API changes...
- We may need to add a bit more API to make sure this doesn't
count as a stripped implementation.

/cc @benaadams @KrzysztofCwalina 