### PR TITLE
Eliminated some calls to Write in PlatformBenchmark

### DIFF
--- a/src/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/PlatformBenchmarks/BenchmarkApplication.cs
@@ -12,13 +12,14 @@ namespace PlatformBenchmarks
     public class BenchmarkApplication : HttpConnection
     {
         private static AsciiString _crlf = "\r\n";
+        private static AsciiString _eoh = "\r\n\r\n"; // End Of Headers
         private static AsciiString _http11OK = "HTTP/1.1 200 OK\r\n";
         private static AsciiString _headerServer = "Server: Custom";
         private static AsciiString _headerContentLength = "Content-Length: ";
         private static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
         private static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
 
-        private static readonly DateHeaderValueManager _dateHeaderValueManager = new DateHeaderValueManager();
+        private static readonly DateHeader _dateHeaderValueManager = new DateHeader();
 
         private static AsciiString _plainTextBody = "Hello, World!";
 
@@ -68,8 +69,7 @@ namespace PlatformBenchmarks
             writer.Write(_headerServer);
 
             // Date header
-            writer.Write(_dateHeaderValueManager.GetDateHeaderValues().Bytes);
-            writer.Write(_crlf);
+            writer.Write(_dateHeaderValueManager.HeaderBytes);
 
             // Content-Length 0
             writer.Write(_headerContentLengthZero);
@@ -89,8 +89,7 @@ namespace PlatformBenchmarks
             writer.Write(_headerServer);
 
             // Date header
-            writer.Write(_dateHeaderValueManager.GetDateHeaderValues().Bytes);
-            writer.Write(_crlf);
+            writer.Write(_dateHeaderValueManager.HeaderBytes);
 
             // Content-Type header
             writer.Write(_headerContentTypeText);
@@ -98,10 +97,9 @@ namespace PlatformBenchmarks
             // Content-Length header
             writer.Write(_headerContentLength);
             writer.WriteNumeric((ulong)_plainTextBody.Length);
-            writer.Write(_crlf);
 
             // End of headers
-            writer.Write(_crlf);
+            writer.Write(_eoh);
 
             // Body
             writer.Write(_plainTextBody);

--- a/src/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/PlatformBenchmarks/BenchmarkApplication.cs
@@ -19,8 +19,6 @@ namespace PlatformBenchmarks
         private static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
         private static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
 
-        private static readonly DateHeader _dateHeaderValueManager = new DateHeader();
-
         private static AsciiString _plainTextBody = "Hello, World!";
 
         private static class Paths
@@ -69,7 +67,7 @@ namespace PlatformBenchmarks
             writer.Write(_headerServer);
 
             // Date header
-            writer.Write(_dateHeaderValueManager.HeaderBytes);
+            writer.Write(DateHeader.HeaderBytes);
 
             // Content-Length 0
             writer.Write(_headerContentLengthZero);
@@ -89,7 +87,7 @@ namespace PlatformBenchmarks
             writer.Write(_headerServer);
 
             // Date header
-            writer.Write(_dateHeaderValueManager.HeaderBytes);
+            writer.Write(DateHeader.HeaderBytes);
 
             // Content-Type header
             writer.Write(_headerContentTypeText);

--- a/src/PlatformBenchmarks/BufferWriterExtensions.cs
+++ b/src/PlatformBenchmarks/BufferWriterExtensions.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {

--- a/src/PlatformBenchmarks/DateHeader.cs
+++ b/src/PlatformBenchmarks/DateHeader.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http
+{
+    /// <summary>
+    /// Manages the generation of the date header value.
+    /// </summary>
+    internal class DateHeader : IHeartbeatHandler
+    {
+        const int prefixLength = 8; // "\r\nDate: ".Length
+        const int dateTimeRLength = 29; // Wed, 14 Mar 2018 14:20:00 GMT
+        const int suffixLength = 2; // crlf
+        const int suffixIndex = dateTimeRLength + prefixLength;
+
+        private byte[] s_headerBytesMaster = new byte[prefixLength + dateTimeRLength + suffixLength];
+        private byte[] s_headerBytesScratch = new byte[prefixLength + dateTimeRLength + suffixLength];
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateHeaderValueManager"/> class.
+        /// </summary>
+        public DateHeader()
+        {
+            var utf8 = Encoding.ASCII.GetBytes("\r\nDate: ").AsSpan();
+            utf8.CopyTo(s_headerBytesMaster);
+            utf8.CopyTo(s_headerBytesScratch);
+            s_headerBytesMaster[suffixIndex] = (byte)'\r';
+            s_headerBytesMaster[suffixIndex + 1] = (byte)'\n';
+            s_headerBytesScratch[suffixIndex] = (byte)'\r';
+            s_headerBytesScratch[suffixIndex + 1] = (byte)'\n';
+            SetDateValues(DateTimeOffset.UtcNow);
+        }
+
+        // Called by the Timer (background) thread
+        public void OnHeartbeat(DateTimeOffset now) => SetDateValues(now);
+
+        public ReadOnlySpan<byte> HeaderBytes => s_headerBytesMaster;
+
+        private void SetDateValues(DateTimeOffset value)
+        {
+            lock (s_headerBytesMaster)
+            {
+                if (!Utf8Formatter.TryFormat(value, s_headerBytesScratch.AsSpan().Slice(prefixLength), out int written, 'R'))
+                {
+                    throw new Exception("date time format failed");
+                }
+                Debug.Assert(written == dateTimeRLength);
+                var temp = s_headerBytesMaster;
+                s_headerBytesMaster = s_headerBytesScratch;
+                s_headerBytesScratch = temp;
+            }
+        }
+    }
+}


### PR DESCRIPTION
DateHeader value now includes both leading and trailing CRLF
Also added constant for EOH (end of headers)

@davidfowl, is it possible to get numbers from this branch before we merge?

Also, I assume the heartbeat interval is large enough such that the lock does not matter.