### PR TITLE
Add some connection string checks for Npgsql

### DIFF
--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -59,6 +59,12 @@ namespace Benchmarks
             switch (appSettings.Database)
             {
                 case DatabaseServer.PostgreSql:
+                     var settings = new NpgsqlConnectionStringBuilder(appSettings.ConnectionString);
+                     if (!settings.NoResetOnClose)
+                         throw new ArgumentException("No Reset On Close=true must be specified for Npgsql");
+                     if (settings.Enlist)
+                         throw new ArgumentException("Enlist=false must be specified for Npgsql");
+
                     services.AddDbContextPool<ApplicationDbContext>(options => options.UseNpgsql(appSettings.ConnectionString));
 
                     if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))


### PR DESCRIPTION
To make sure we're in high-perf mode.

/cc @sebastienros 

Is it possible to also add something similar to https://github.com/aspnet/FrameworkBenchmarks to prevent accidental runs with non-optimized connection strings?