### PR TITLE
Fix bad PerfView collection parameter

### DIFF
--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -29,7 +29,7 @@ namespace BenchmarksDriver
         private static string _tableName = "AspNetBenchmarks";
 
         // Default to arguments which should be sufficient for collecting trace of default Plaintext run
-        private const string _defaultTraceArguments = "";
+        private const string _defaultTraceArguments = "BufferSizeMB=1024;CircularMB=1024";
 
         public static int Main(string[] args)
         {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -29,7 +29,7 @@ namespace BenchmarksDriver
         private static string _tableName = "AspNetBenchmarks";
 
         // Default to arguments which should be sufficient for collecting trace of default Plaintext run
-        private const string _defaultTraceArguments = "BufferSize=1024";
+        private const string _defaultTraceArguments = "";
 
         public static int Main(string[] args)
         {
@@ -1032,6 +1032,8 @@ namespace BenchmarksDriver
                                 Log($"Startup Main (ms):           {average.StartupMain}");
                                 Log($"First Request (ms):          {average.FirstRequest}");
                                 Log($"Latency (ms):                {average.Latency}");
+                                Log($"Total Requests:              {average.TotalRequests:n0}");
+                                Log($"Duration: (ms)               {average.Duration}");
                                 Log($"Socket Errors:               {average.SocketErrors}");
                                 Log($"Bad Responses:               {average.BadResponses}");
                                 Log($"SDK:                         {serverJob.SdkVersion}");

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -495,7 +495,7 @@ namespace BenchmarkServer
                             if (perfviewEnabled)
                             {
                                 // Start perfview
-                                var perfviewArguments = $"stop /AcceptEula /NoNGenRundown /NoRundown /NoView";
+                                var perfviewArguments = $"stop /AcceptEula /NoNGenRundown /NoView";
                                 var perfViewProcess = RunPerfview(perfviewArguments, benchmarksDir);
                                 job.State = ServerState.TraceCollected;
                             }
@@ -1406,6 +1406,8 @@ namespace BenchmarkServer
                             perfViewArguments["AcceptEula"] = "";
                             perfViewArguments["NoGui"] = "";
                             perfViewArguments["Process"] = process.Id.ToString();
+                            perfViewArguments["CircularMB"] = "1024";
+                            perfViewArguments["BufferSizeMB"] = "1024";
 
                             if (!String.IsNullOrEmpty(job.CollectArguments))
                             {


### PR DESCRIPTION
We use the /NoRundown switch on stop.
This is not meant for general use, and causes the modules of methods to not
be resolved as well as methods (which means that source code lookup also
fails.

I also limited the collection to a circular buffer of 1 GB by default.
This avoids creating very large files which are generally not useful.
ALso increased the bufferSize to 1GB to avoid lost events (this scenario
CAN produce alot of events).

@davidfowl  @steveharter 

David, Steve:  If we check this in, does it immediately become live on say asp-perf-win?  
If not what is needed to make them take the update?