### PR TITLE
Harness improvements

### DIFF
--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -118,7 +118,7 @@ namespace BenchmarksDriver
                 $"Arguments used when collecting a PerfView trace.  Defaults to \"{_defaultTraceArguments}\".",
                 CommandOptionType.SingleValue);
             var traceOutputOption = app.Option("--trace-output",
-                "Can be a file prefix (app will add *.DATE.RPS*.etl.zip) , or a specific name (end in *.etl.zip) and no DATE will be added e.g. --trace-output c:\traces\myTrace", CommandOptionType.SingleValue);
+                @"Can be a file prefix (app will add *.DATE.RPS*.etl.zip) , or a specific name (end in *.etl.zip) and no DATE.RPS* will be added e.g. --trace-output c:\traces\myTrace", CommandOptionType.SingleValue);
             var disableR2ROption = app.Option("--no-crossgen",
                 "Disables Ready To Run.", CommandOptionType.NoValue);
             var collectR2RLogOption = app.Option("--collect-crossgen",

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -962,7 +962,7 @@ namespace BenchmarksDriver
                                 }
 
                                 Log($"Downloading trace...");
-                                if (!traceDestination.EndsWith(".etl.zip", StringComparison.OrdinalIgnoreCase))
+                                if (traceDestination == null || !traceDestination.EndsWith(".etl.zip", StringComparison.OrdinalIgnoreCase))
                                 {
                                     // If it does not end with a *.etl.zip then we add a DATE.etl.zip to it
                                     if (String.IsNullOrEmpty(traceDestination))

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -801,6 +801,7 @@ namespace BenchmarksDriver
                             await Task.Delay(1000);
                         }
                     }
+                    System.Threading.Thread.Sleep(200);  // Make it clear on traces when startup has finished and warmup begins.  
 
                     TimeSpan latencyNoLoad, latencyFirstRequest;
 

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -969,7 +969,7 @@ namespace BenchmarksDriver
                                     if (String.IsNullOrEmpty(traceDestination))
                                         traceDestination = "trace";
 
-                                    string rpsStr = "RPS=" + ((int)((statistics.RequestsPerSecond+500) / 1000)) + "K";
+                                    string rpsStr = "RPS-" + ((int)((statistics.RequestsPerSecond+500) / 1000)) + "K";
                                     traceDestination = traceDestination + "." + DateTime.Now.ToString("MM-dd-HH-mm-ss") + "." + rpsStr + ".etl.zip";
                                 }
                                 Log($"Creating trace: {traceDestination}");

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -118,7 +118,7 @@ namespace BenchmarksDriver
                 $"Arguments used when collecting a PerfView trace.  Defaults to \"{_defaultTraceArguments}\".",
                 CommandOptionType.SingleValue);
             var traceOutputOption = app.Option("--trace-output",
-                "Can be a file prefix (app will add *.DATE.etl.zip) , or a specific name (end in *.etl.zip) and no DATE will be added e.g. --trace-output c:\traces\trace", CommandOptionType.SingleValue);
+                "Can be a file prefix (app will add *.DATE.RPS*.etl.zip) , or a specific name (end in *.etl.zip) and no DATE will be added e.g. --trace-output c:\traces\myTrace", CommandOptionType.SingleValue);
             var disableR2ROption = app.Option("--no-crossgen",
                 "Disables Ready To Run.", CommandOptionType.NoValue);
             var collectR2RLogOption = app.Option("--collect-crossgen",

--- a/src/BenchmarksDriver/README.md
+++ b/src/BenchmarksDriver/README.md
@@ -46,7 +46,7 @@ Options:
   --querystring          Querystring to add to the requests. (e.g., "?page=1")
   -j|--jobs              The path or url to the jobs definition.
   --collect-trace        Collect a PerfView trace. Optionally set custom arguments. e.g., BufferSize=256;InMemoryCircularBuffer
-  --trace-output         An optional location to download the trace file to, e.g., --trace-output c:\traces
+  --trace-output         Can be a file prefix (app will add *.DATE.RPS*.etl.zip) , or a specific name (end in *.etl.zip) and no DATE.RPS* will be added e.g. --trace-output c:\traces\myTrace
   --before-shutdown      An endpoint to call before the application has shut down.
   -sp|--span             The time during which the client jobs are repeated, in 'HH:mm:ss' format. e.g., 48:00:00 for 2 days
   -t|--table             Table name of the SQL Database to store results

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1427,31 +1427,11 @@ namespace BenchmarkServer
                     if (job.State == ServerState.Starting &&
                         (e.Data.ToLowerInvariant().Contains("started") || e.Data.ToLowerInvariant().Contains("listening")))
                     {
-                        MarkAsRunning(hostname, benchmarksRepo, job, perfview, stopwatch, process);
+                        MarkAsRunning(hostname, benchmarksRepo, job, stopwatch, process);
                     }
                 }
             };
 
-            stopwatch.Start();
-            process.Start();
-            process.BeginOutputReadLine();
-
-            if (iis)
-            {
-                await WaitToListen(job, hostname);
-                MarkAsRunning(hostname, benchmarksRepo, job, perfview, stopwatch, process);
-            }
-
-            return process;
-        }
-
-        private static void MarkAsRunning(string hostname, string benchmarksRepo, ServerJob job, bool perfview, Stopwatch stopwatch,
-            Process process)
-        {
-            job.StartupMainMethod = stopwatch.Elapsed;
-
-            Log.WriteLine($"Running job '{job.Id}' with scenario '{job.Scenario}'");
-            job.Url = ComputeServerUrl(hostname, job);
 
             // Start perfview?
             if (perfview)
@@ -1481,7 +1461,29 @@ namespace BenchmarkServer
 
                 perfviewArguments += $" \"{job.PerfViewTraceFile}\"";
                 RunPerfview(perfviewArguments, Path.Combine(benchmarksRepo, job.BasePath));
+                Log.WriteLine($"Starting PerfView {perfviewArguments}");
             }
+
+            stopwatch.Start();
+            process.Start();
+            process.BeginOutputReadLine();
+
+            if (iis)
+            {
+                await WaitToListen(job, hostname);
+                MarkAsRunning(hostname, benchmarksRepo, job,  stopwatch, process);
+            }
+
+            return process;
+        }
+
+        private static void MarkAsRunning(string hostname, string benchmarksRepo, ServerJob job, Stopwatch stopwatch,
+            Process process)
+        {
+            job.StartupMainMethod = stopwatch.Elapsed;
+
+            Log.WriteLine($"Running job '{job.Id}' with scenario '{job.Scenario}'");
+            job.Url = ComputeServerUrl(hostname, job);
 
             // Mark the job as running to allow the Client to start the test
             job.State = ServerState.Running;


### PR DESCRIPTION
1. Start PerfView before the benchmark starts.  This allows perfVIew to see the startup which is valuable.
2. Stamp the files by default with the date and RPS value.  Also allow the user
to specify the file prefix (which can be a directory).   This avoids having to rename (or worse loose track of which data is which).

Note that the diff in startup is a bit confusing.  It looks like I removed stuff, but all I did was move the PerfView logic from one function to another (to before benchmark start).  

@sebastienros 