### PR TITLE
Increase StringBuilder initial capacity for batch update query string generation

### DIFF
--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -65,7 +65,7 @@ namespace Benchmarks.Data
         {
             var results = new World[count];
             IDictionary<string, object> parameters = new ExpandoObject();
-            var updateCommand = new StringBuilder(count);
+            var updateCommand = new StringBuilder(count * 64);
 
             using (var db = _dbProviderFactory.CreateConnection())
             {
@@ -83,11 +83,12 @@ namespace Benchmarks.Data
                 for (int i = 0; i < count; i++)
                 {
                     var randomNumber = _random.Next(1, 10001);
-                    parameters[BatchUpdateString.Strings[i].Random] = randomNumber;
-                    parameters[BatchUpdateString.Strings[i].Id] = results[i].Id;
+                    var data = BatchUpdateString.Strings[i];
+                    parameters[data.Random] = randomNumber;
+                    parameters[data.Id] = results[i].Id;
 
                     results[i].RandomNumber = randomNumber;
-                    updateCommand.Append(BatchUpdateString.Strings[i].UpdateQuery);
+                    updateCommand.Append(data.UpdateQuery);
                 }
 
                 await db.ExecuteAsync(updateCommand.ToString(), parameters);

--- a/src/Benchmarks/Data/RawDb.cs
+++ b/src/Benchmarks/Data/RawDb.cs
@@ -91,7 +91,7 @@ namespace Benchmarks.Data
         {
             var results = new World[count];
 
-            var updateCommand = new StringBuilder(count);
+            var updateCommand = new StringBuilder(count * 64);
 
             using (var db = _dbProviderFactory.CreateConnection())
             {
@@ -113,12 +113,13 @@ namespace Benchmarks.Data
                     for(int i = 0; i < count; i++)
                     {
                         var id = updateCmd.CreateParameter();
-                        id.ParameterName = BatchUpdateString.Strings[i].Id;
+                        var data = BatchUpdateString.Strings[i];
+                        id.ParameterName = data.Id;
                         id.DbType = DbType.Int32;
                         updateCmd.Parameters.Add(id);
 
                         var random = updateCmd.CreateParameter();
-                        random.ParameterName = BatchUpdateString.Strings[i].Random;
+                        random.ParameterName = data.Random;
                         random.DbType = DbType.Int32;
                         updateCmd.Parameters.Add(random);
 
@@ -127,7 +128,7 @@ namespace Benchmarks.Data
                         random.Value = randomNumber;
                         results[i].RandomNumber = randomNumber;
 
-                        updateCommand.Append(BatchUpdateString.Strings[i].UpdateQuery);
+                        updateCommand.Append(data.UpdateQuery);
                     }
 
                     updateCmd.CommandText = updateCommand.ToString();


### PR DESCRIPTION
Query count (1, 5, 10, 15...) is being used as StringBuilder initial capacity:
https://github.com/aspnet/benchmarks/blob/e135b1e439c5174cc46b2cf7d87f3bf04d461442/src/Benchmarks/Data/DapperDb.cs#L64-L68

https://github.com/aspnet/benchmarks/blob/281d5dd82054819f02d8111253c36ff5f9e61f66/src/Benchmarks/Data/RawDb.cs#L90-L94

In most of the cases, it is lower than the default capacity of 16. 
Wonder if increasing this value should contribute to a better result, I tried to simulate it here:
https://gist.github.com/jo-ninja/33d05778f4c283f1c27f63d8beb38743

Result:
![image](https://user-images.githubusercontent.com/29521868/38454600-0aa5a626-3aa5-11e8-9462-79adbfa33c21.png)

It seems that with the initial capacity of 64x, overall it's about 1.5x faster and a slightly lower memory usage.
/cc @sebastienros @benaadams @davidfowl 
But it is a nanoseconds world, so I don't think it will really help... 😶 