### PR TITLE
Making Workers handle multiple jobs

### DIFF
--- a/src/Benchmarks.ClientJob/ClientJob.cs
+++ b/src/Benchmarks.ClientJob/ClientJob.cs
@@ -19,6 +19,8 @@ namespace Benchmarks.ClientJob
         {
             Id = clientJob.Id;
             Threads = clientJob.Threads;
+            SpanId = clientJob.SpanId;
+            SendDelay = clientJob.SendDelay;
             Connections = clientJob.Connections;
             Duration = clientJob.Duration;
             ClientProperties = new Dictionary<string, string>(clientJob.ClientProperties);
@@ -38,9 +40,14 @@ namespace Benchmarks.ClientJob
 
         public int Id { get; set; }
 
+        public string SpanId { get; set; }
+
         public Worker Client { get; set; } = Worker.Wrk;
 
         public int Threads { get; set; } = 32;
+
+        // Send delay in minutes for long running connection tests.
+        public TimeSpan SendDelay { get; set; } = TimeSpan.FromMinutes(10);
 
         public int Connections { get; set; } = 256;
 
@@ -57,7 +64,7 @@ namespace Benchmarks.ClientJob
         public string Query { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public ClientState State { get; set; }
+        public ClientJobState State { get; set; }
 
         public double RequestsPerSecond { get; set; }
         public int Requests { get; set; }

--- a/src/Benchmarks.ClientJob/ClientJob.cs
+++ b/src/Benchmarks.ClientJob/ClientJob.cs
@@ -20,7 +20,6 @@ namespace Benchmarks.ClientJob
             Id = clientJob.Id;
             Threads = clientJob.Threads;
             SpanId = clientJob.SpanId;
-            SendDelay = clientJob.SendDelay;
             Connections = clientJob.Connections;
             Duration = clientJob.Duration;
             ClientProperties = new Dictionary<string, string>(clientJob.ClientProperties);
@@ -45,9 +44,6 @@ namespace Benchmarks.ClientJob
         public Worker Client { get; set; } = Worker.Wrk;
 
         public int Threads { get; set; } = 32;
-
-        // Send delay in minutes for long running connection tests.
-        public TimeSpan SendDelay { get; set; } = TimeSpan.FromMinutes(10);
 
         public int Connections { get; set; } = 256;
 

--- a/src/Benchmarks.ClientJob/ClientJobState.cs
+++ b/src/Benchmarks.ClientJob/ClientJobState.cs
@@ -3,7 +3,7 @@
 
 namespace Benchmarks.ClientJob
 {
-    public enum ClientState
+    public enum ClientJobState
     {
         Waiting,
         Starting,

--- a/src/BenchmarksClient/Controllers/JobsController.cs
+++ b/src/BenchmarksClient/Controllers/JobsController.cs
@@ -44,7 +44,7 @@ namespace BenchmarkClient.Controllers
         [HttpPost]
         public IActionResult Create([FromBody] ClientJob job)
         {
-            if (job == null || job.Id != 0 || job.State != ClientState.Waiting)
+            if (job == null || job.Id != 0 || job.State != ClientJobState.Waiting)
             {
                 return BadRequest();
             }
@@ -61,7 +61,7 @@ namespace BenchmarkClient.Controllers
             try
             {
                 var job = _jobs.Find(id);
-                job.State = ClientState.Deleting;
+                job.State = ClientJobState.Deleting;
                 _jobs.Update(job);
 
                 Response.Headers["Location"] = $"/jobs/{job.Id}";
@@ -72,6 +72,5 @@ namespace BenchmarkClient.Controllers
                 return NotFound();
             }
         }
-
     }
 }

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -111,6 +111,7 @@ namespace BenchmarkClient
                     if (job.State == ClientJobState.Waiting)
                     {
                         Log($"Starting '{job.Client}' worker");
+                        Log($"Current Job SpanId '{job.SpanId}'");
                         job.State = ClientJobState.Starting;
 
                         try

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -169,20 +169,26 @@ namespace BenchmarkClient
                 await Task.Delay(100);
 
                 allJobs = _jobs.GetAll();
-                job = allJobs.FirstOrDefault(clientJob =>
+                if (job != null)
                 {
-                    return string.Equals(clientJob.SpanId, job.SpanId);
-                });
-                // If no more jobs with the span id exist then we can clear
-                // out the worker to signal to the worker factory to create
-                // a new worker.
-                if (job == null && worker != null)
+                    job = allJobs.FirstOrDefault(clientJob =>
+                    {
+                        return string.Equals(clientJob.SpanId, job.SpanId);
+                    });
+                }
+                else 
                 {
-                    await worker.DisposeAsync();
-                    worker = null;
-
                     // Get another job for the new worker we are going to create
                     job = allJobs.FirstOrDefault();
+
+                    // No more jobs with the same span id exist so we can clear
+                    // out the worker to signal to the worker factory to create
+                    // a new one.
+                    if (worker != null)
+                    {
+                        await worker.DisposeAsync();
+                        worker = null;
+                    }
                 }
             }
         }

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -176,7 +176,8 @@ namespace BenchmarkClient
                         return string.Equals(clientJob.SpanId, job.SpanId);
                     });
                 }
-                else 
+                // job will be null if there aren't any more jobs with the same spanId.
+                if (job == null)
                 {
                     // Get another job for the new worker we are going to create
                     job = allJobs.FirstOrDefault();

--- a/src/BenchmarksClient/Startup.cs
+++ b/src/BenchmarksClient/Startup.cs
@@ -157,7 +157,6 @@ namespace BenchmarkClient
                         {
                             if (worker != null)
                             {
-                                // We stop the worker but 
                                 await worker.StopJobAsync();
                             }
                         }

--- a/src/BenchmarksClient/Workers/IWorker.cs
+++ b/src/BenchmarksClient/Workers/IWorker.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Benchmarks.ClientJob;
 
 namespace BenchmarksClient.Workers
 {
@@ -10,7 +11,8 @@ namespace BenchmarksClient.Workers
     {
         string JobLogText { get; set; }
 
-        Task StartAsync();
-        Task StopAsync();
+        Task StartJobAsync(ClientJob job);
+        Task StopJobAsync();
+        Task DisposeAsync();
     }
 }

--- a/src/BenchmarksClient/Workers/SignalRWorker.cs
+++ b/src/BenchmarksClient/Workers/SignalRWorker.cs
@@ -34,9 +34,9 @@ namespace BenchmarksClient.Workers
         private string _scenario;
         private List<(double sum, int count)> _latencyAverage;
 
-        public SignalRWorker(ClientJob job)
+        private void InitializeJob()
         {
-            _job = job;
+            _stopped = false;
 
             Debug.Assert(_job.Connections > 0, "There must be more than 0 connections");
 
@@ -86,12 +86,16 @@ namespace BenchmarksClient.Workers
 
             jobLogText += "]";
             JobLogText = jobLogText;
-
-            CreateConnections(transportType);
+            if (_connections == null)
+            {
+                CreateConnections(transportType);
+            }
         }
 
-        public async Task StartAsync()
+        public async Task StartJobAsync(ClientJob job)
         {
+            _job = job;
+            InitializeJob();
             // start connections
             var tasks = new List<Task>(_connections.Count);
             foreach (var connection in _connections)
@@ -101,7 +105,7 @@ namespace BenchmarksClient.Workers
 
             await Task.WhenAll(tasks);
 
-            _job.State = ClientState.Running;
+            _job.State = ClientJobState.Running;
             _job.LastDriverCommunicationUtc = DateTime.UtcNow;
 
             var cts = new CancellationTokenSource();
@@ -135,6 +139,16 @@ namespace BenchmarksClient.Workers
                             }
                         }
                         break;
+                    case "echoLongRunning":
+                        while (!cts.IsCancellationRequested)
+                        {
+                            await Task.Delay(_job.SendDelay);
+                            for (var i = 0; i < _connections.Count; i++)
+                            {
+                                _ = _connections[i].SendAsync("EchoAll", DateTime.UtcNow);
+                            }
+                        }
+                        break;
                     default:
                         throw new Exception($"Scenario '{_scenario}' is not a known scenario.");
                 }
@@ -147,10 +161,10 @@ namespace BenchmarksClient.Workers
             }
 
             cts.Token.WaitHandle.WaitOne();
-            await StopAsync();
+            await StopJobAsync();
         }
 
-        public async Task StopAsync()
+        public async Task StopJobAsync()
         {
             if (_stopped || !await _lock.WaitAsync(0))
             {
@@ -162,24 +176,7 @@ namespace BenchmarksClient.Workers
                 _stopped = true;
                 _workTimer.Stop();
 
-                foreach (var callback in _recvCallbacks)
-                {
-                    // stops stat collection from happening quicker than StopAsync
-                    // and we can do all the calculations while close is occurring
-                    callback.Dispose();
-                }
-
-                // stop connections
-                Log("Stopping connections");
-                var tasks = new List<Task>(_connections.Count);
-                foreach (var connection in _connections)
-                {
-                    tasks.Add(connection.DisposeAsync());
-                }
-
                 CalculateStatistics();
-
-                await Task.WhenAll(tasks);
 
                 // TODO: Remove when clients no longer take a long time to "cool down"
                 await Task.Delay(5000);
@@ -189,8 +186,31 @@ namespace BenchmarksClient.Workers
             finally
             {
                 _lock.Release();
-                _job.State = ClientState.Completed;
+                _job.State = ClientJobState.Completed;
             }
+        }
+
+        // We want to move code from StopAsync into Release(). Any code that would prevent
+        // us from reusing the connnections. 
+        public async Task DisposeAsync()
+        {
+            foreach (var callback in _recvCallbacks)
+            {
+                // stops stat collection from happening quicker than StopAsync
+                // and we can do all the calculations while close is occurring
+                callback.Dispose();
+            }
+
+            // stop connections
+            Log("Stopping connections");
+            var tasks = new List<Task>(_connections.Count);
+            foreach (var connection in _connections)
+            {
+                tasks.Add(connection.DisposeAsync());
+            }
+
+            await Task.WhenAll(tasks);
+            _httpClientHandler.Dispose();
         }
 
         public void Dispose()

--- a/src/BenchmarksClient/Workers/WaitWorker.cs
+++ b/src/BenchmarksClient/Workers/WaitWorker.cs
@@ -16,14 +16,10 @@ namespace BenchmarksClient.Workers
 
         public string JobLogText { get; set; }
 
-        public WaitWorker(ClientJob clientJob)
+        public Task StartJobAsync(ClientJob job)
         {
-            _job = clientJob;            
-        }
-
-        public Task StartAsync()
-        {
-            _job.State = ClientState.Running;
+            _job = job;
+            _job.State = ClientJobState.Running;
             _job.LastDriverCommunicationUtc = DateTime.UtcNow;
 
             _cts = new CancellationTokenSource();
@@ -31,13 +27,13 @@ namespace BenchmarksClient.Workers
             _task = Task.Run(async () =>
             {
                 await Task.Delay(TimeSpan.FromSeconds(_job.Duration));
-                _job.State = ClientState.Completed;
+                _job.State = ClientJobState.Completed;
             }, _cts.Token);
 
             return Task.CompletedTask;
         }
 
-        public async Task StopAsync()
+        public async Task StopJobAsync()
         {
             try
             {
@@ -55,6 +51,11 @@ namespace BenchmarksClient.Workers
             }
 
             return;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/BenchmarksClient/Workers/WorkerFactory.cs
+++ b/src/BenchmarksClient/Workers/WorkerFactory.cs
@@ -1,37 +1,28 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-
-using System;
-using System.Collections.Generic;
 using Benchmarks.ClientJob;
 
 namespace BenchmarksClient.Workers
 {
     static public class WorkerFactory
     {
-        public static Dictionary<Worker, Func<ClientJob, IWorker>> Workers = new Dictionary<Worker, Func<ClientJob, IWorker>>();
-
-        static WorkerFactory()
-        {
-            // Wrk
-            Workers[Worker.Wrk] = clientJob => new WrkWorker(clientJob);
-
-            // SignalR
-            Workers[Worker.SignalR] = clientJob => new SignalRWorker(clientJob);
-
-            // Wait
-            Workers[Worker.Wait] = clientJob => new WaitWorker(clientJob);
-        }
-
         static public IWorker CreateWorker(ClientJob clientJob)
         {
-            if (Workers.TryGetValue(clientJob.Client, out var workerFactory))
+            IWorker worker = null;
+            switch (clientJob.Client)
             {
-                return workerFactory(clientJob);
+                case Worker.Wrk:
+                    worker = new WrkWorker();
+                    break;
+                case Worker.SignalR:
+                    worker = new SignalRWorker();
+                    break;
+                case Worker.Wait:
+                    worker = new WaitWorker();
+                    break;
             }
-
-            return null;
+            return worker;
         }
     }
 }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -170,6 +170,8 @@ namespace BenchmarksDriver
                 CommandOptionType.SingleValue);
             var jobsOptions = app.Option("-j|--jobs",
                 "The path or url to the jobs definition.", CommandOptionType.SingleValue);
+            var sendDelayOption = app.Option("-- sendDelay",
+                "Delay in minutes between sends for long running connection tests", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -548,6 +550,14 @@ namespace BenchmarksDriver
                 {
                     _clientJob.Query = querystringOption.Value();
                 }
+                if (span > TimeSpan.Zero)
+                {
+                    _clientJob.SpanId = new Guid().ToString();
+                }
+                if (sendDelayOption.HasValue())
+                {
+                    _clientJob.SendDelay = TimeSpan.FromMinutes(int.Parse(sendDelayOption.Value()));
+                }
 
                 switch (headers)
                 {
@@ -885,7 +895,7 @@ namespace BenchmarksDriver
 
                         clientJob = await RunClientJob(scenario, clientUri, serverJobUri, serverBenchmarkUri);
 
-                        if (clientJob.State == ClientState.Completed)
+                        if (clientJob.State == ClientJobState.Completed)
                         {
                             LogVerbose($"Client Job completed");
 
@@ -1328,7 +1338,7 @@ namespace BenchmarksDriver
 
                     clientJob = JsonConvert.DeserializeObject<ClientJob>(responseContent);
 
-                    if (clientJob.State == ClientState.Running || clientJob.State == ClientState.Completed)
+                    if (clientJob.State == ClientJobState.Running || clientJob.State == ClientJobState.Completed)
                     {
                         break;
                     }
@@ -1361,7 +1371,7 @@ namespace BenchmarksDriver
 
                     clientJob = JsonConvert.DeserializeObject<ClientJob>(responseContent);
 
-                    if (clientJob.State == ClientState.Completed)
+                    if (clientJob.State == ClientJobState.Completed)
                     {
                         Log($"Scenario {scenarioName} completed on benchmark client");
                         LogVerbose($"Output: {clientJob.Output}");

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -170,8 +170,6 @@ namespace BenchmarksDriver
                 CommandOptionType.SingleValue);
             var jobsOptions = app.Option("-j|--jobs",
                 "The path or url to the jobs definition.", CommandOptionType.SingleValue);
-            var sendDelayOption = app.Option("-- sendDelay",
-                "Delay in minutes between sends for long running connection tests", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -553,10 +551,6 @@ namespace BenchmarksDriver
                 if (span > TimeSpan.Zero)
                 {
                     _clientJob.SpanId = new Guid().ToString();
-                }
-                if (sendDelayOption.HasValue())
-                {
-                    _clientJob.SendDelay = TimeSpan.FromMinutes(int.Parse(sendDelayOption.Value()));
                 }
 
                 switch (headers)


### PR DESCRIPTION
This is still very WIP. Just want some initial feedback.

The initial idea is to have SpanIds associated with jobs that we want to be run by the same worker.This means I had to change the worker internals to to not be tied to a single client job instance but instead make it such that a single worker instance can be started multiple times with different jobs.

This is work to allow us to do more stress testing : https://github.com/aspnet/SignalR/issues/1700

Roast Me.