### PR TITLE
Fix null ref in timer

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -413,8 +413,6 @@ namespace BenchmarkServer
                                 var lastMonitorTime = startMonitorTime;
                                 var oldCPUTime = TimeSpan.Zero;
 
-                                disposed = false;
-
                                 timer = new Timer(_ =>
                                 {
                                     // If we couldn't get the lock it means one of 2 things are true:
@@ -532,6 +530,8 @@ namespace BenchmarkServer
                                         Monitor.Exit(executionLock);
                                     }
                                 }, null, TimeSpan.FromTicks(0), TimeSpan.FromSeconds(1));
+
+                                disposed = false;
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
@sebastienros 

The previous timer callback could be in progress when the timer is disposed and set to null.
And if the `disposed = false;` is run before the callback checks for disposed and before `timer = new Timer` then it can null ref when doing `timer.Change(Timeout.Infinite, Timeout.Infinite);`