### PR TITLE
Allow equals = in arguments passed to --trace-arguments parameter.

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1544,7 +1544,7 @@ namespace BenchmarkServer
                 {
                     foreach (var tuple in job.CollectArguments.Split(';'))
                     {
-                        var values = tuple.Split('=');
+                        var values = tuple.Split(new char[] { '=' }, 2);
                         perfViewArguments[values[0]] = values.Length > 1 ? values[1] : "";
                     }
                 }


### PR DESCRIPTION
Some PerfVIew arguments may need to pass strings with = characters in them.
Fix it so that this is allowed (add a count to the split that is used, so only the first = is treated specially).

@sebastienros 