### PR TITLE
Run SQL off of the main loop

### DIFF
--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1080,7 +1080,6 @@ namespace BenchmarksDriver
                                     // Headers
                                     foreach (var field in fields)
                                     {
-                                        
                                         var size = Math.Max(field.Key.Length, field.Value.Length);
                                         header.Append("| ").Append(field.Key.PadLeft(size)).Append(" ");
                                         separator.Append("| ").Append(new String('-', size)).Append(" ");
@@ -1113,16 +1112,26 @@ namespace BenchmarksDriver
                                 {
                                     Log("Writing results to SQL...");
 
-                                    await serializer.WriteJobResultsToSqlAsync(
-                                        serverJob: serverJob,
-                                        clientJob: clientJob,
-                                        connectionString: sqlConnectionString,
-                                        tableName: _tableName,
-                                        path: serverJob.Path,
-                                        session: session,
-                                        description: description,
-                                        statistics: average,
-                                        longRunning: span > TimeSpan.Zero);
+                                    _ = Task.Run(async () =>
+                                    {
+                                        try
+                                        {
+                                            await serializer.WriteJobResultsToSqlAsync(
+                                                serverJob: serverJob,
+                                                clientJob: clientJob,
+                                                connectionString: sqlConnectionString,
+                                                tableName: _tableName,
+                                                path: serverJob.Path,
+                                                session: session,
+                                                description: description,
+                                                statistics: average,
+                                                longRunning: span > TimeSpan.Zero);
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            Log("Error writing results to SQL: " + ex);
+                                        }
+                                    });
                                 }
                             }
                         }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1145,14 +1145,7 @@ namespace BenchmarksDriver
                     if (!sqlTask.IsCompleted)
                     {
                         Log("Job finished, waiting for SQL to complete.");
-                        try
-                        {
-                            await sqlTask;
-                        }
-                        catch (Exception ex)
-                        {
-                            Log($"SQL threw an exception: {ex}");
-                        }
+                        await sqlTask;
                     }
 
                     Log($"Stopping scenario {scenario} on benchmark server...");

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1142,7 +1142,18 @@ namespace BenchmarksDriver
                         spanLoop = spanLoop + 1;
                     } while (DateTime.UtcNow - startTime < span);
 
-                    await sqlTask;
+                    if (!sqlTask.IsCompleted)
+                    {
+                        Log("Job finished, waiting for SQL to complete.");
+                        try
+                        {
+                            await sqlTask;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log($"SQL threw an exception: {ex}");
+                        }
+                    }
 
                     Log($"Stopping scenario {scenario} on benchmark server...");
 


### PR DESCRIPTION
Since this was in the main driver loop, if the SQL query was too slow or timed out it could cause the server to close because the driver hasn't communicated in 30 seconds