### PR TITLE
Fix IIS benchmark regression

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1647,15 +1647,7 @@ namespace BenchmarkServer
                 arguments += $" --threadCount {job.KestrelThreadCount.Value}";
             }
 
-            if (iis)
-            {
-                Log.WriteLine($"Generating application host config for '{executable} {arguments}'");
-
-                var apphost = GenerateApplicationHostConfig(job, "published", executable, arguments, hostname);
-                arguments = $"-h \"{apphost}\"";
-                executable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"System32\inetsrv\w3wp.exe");
-            }
-            else
+            if (!iis)
             {
                 arguments += $" --server.urls {serverUrl}";
             }
@@ -1665,6 +1657,15 @@ namespace BenchmarkServer
             if (!job.NoArguments)
             {
                 commandLine += $" {arguments}";
+            }
+
+            if (iis)
+            {
+                Log.WriteLine($"Generating application host config for '{executable} {commandLine}'");
+
+                var apphost = GenerateApplicationHostConfig(job, "published", executable, commandLine, hostname);
+                commandLine = $"-h \"{apphost}\"";
+                executable = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"System32\inetsrv\w3wp.exe");
             }
 
             Log.WriteLine($"Invoking executable: {executable}, with arguments: {commandLine}");


### PR DESCRIPTION
It is passing `published\Benchmarks.dll` to w3wp.exe:

```
[12:47:17.307] Generating application host config for 'C:\Users\Administrator\AppData\Local\Temp\BenchmarksServer\x242h3sv.c2s\dotnet.exe  --nonInteractive true --scenarios PlaintextNonPipelined --server IISInProcess'
[12:47:17.308] Invoking executable: C:\Windows\System32\inetsrv\w3wp.exe, with arguments: published\Benchmarks.dll  -h "C:\Users\Administrator\AppData\Local\Temp\BenchmarksServer\x242h3sv.c2s\dotnet.exe.apphost.config"
```

https://github.com/aspnet/Benchmarks/issues/497