### PR TITLE
Use OSS package versions consistent with aspnet/Mvc and Microsoft.AspNetcore.All/App 2.1.2

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
 New-Item -ItemType Directory -Force -Path .\.build
 wget "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile ".\.build\dotnet-install.ps1"
-.\.build\dotnet-install.ps1 -Channel 2.1.300 -SkipNonVersionedFiles -Version 2.1.300
+.\.build\dotnet-install.ps1 -Channel 2.1.302 -SkipNonVersionedFiles -Version 2.1.302
 dotnet build -c Release

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 mkdir -p ./.build
 wget -P ./.build/ "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
 chmod +x ./.build/dotnet-install.sh
-./.build/dotnet-install.sh --channel 2.1.300 --skip-non-versioned-files --version 2.1.300
+./.build/dotnet-install.sh --channel 2.1.302 --skip-non-versioned-files --version 2.1.302
 dotnet build -c Release

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,16 +1,18 @@
 <Project>
   <PropertyGroup Label="Package Versions">
-    <AspNetCoreVersion>2.1.0</AspNetCoreVersion>
+    <AspNetCoreVersion>2.1.2</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <JsonNetVersion>11.0.2</JsonNetVersion>
     <JilVersion>2.15.4</JilVersion>
     <SignalRVersion>1.1.0-*</SignalRVersion>
+    <MicrosoftNETSdkRazorPackageVersion212>2.1.1</MicrosoftNETSdkRazorPackageVersion212>
     <NETStandardImplicitPackageVersion>2.0.0</NETStandardImplicitPackageVersion>
     <NETCoreAppImplicitPackageVersion>2.0.0</NETCoreAppImplicitPackageVersion>
+
     <!-- Default values that are set to RuntimeFrameworkVersion if none is specified in BenchmarksRuntimeFrameworkVersion c.f. Directory.Build.Targets -->
-    <!-- Directory.Build.targets comes last, even after the csproj values, so setting RuntimeFrameworkVersion in the csproj has no effect --> 
+    <!-- Directory.Build.targets comes last, even after the csproj values, so setting RuntimeFrameworkVersion in the csproj has no effect -->
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview1-26424-04</MicrosoftNETCoreApp22PackageVersion>
     <DefaultTargetFramework>netcoreapp2.1</DefaultTargetFramework>
 
@@ -23,13 +25,15 @@
     <BenchmarksNETStandardImplicitPackageVersion>$(NETStandardImplicitPackageVersion)</BenchmarksNETStandardImplicitPackageVersion>
     <BenchmarksNETCoreAppImplicitPackageVersion>$(NETCoreAppImplicitPackageVersion)</BenchmarksNETCoreAppImplicitPackageVersion>
     <BenchmarksRuntimeFrameworkVersion>$(RuntimeFrameworkVersion)</BenchmarksRuntimeFrameworkVersion>
+
     <MongoDbVersion>2.6.1</MongoDbVersion>
     <DapperVersion>1.50.5</DapperVersion>
     <NpgsqlVersion20>3.2.7</NpgsqlVersion20>
-    <NpgsqlVersion21>4.0.0</NpgsqlVersion21>
-    <MySqlConnectorVersion>0.40.4</MySqlConnectorVersion>
+    <NpgsqlVersion21>4.0.2</NpgsqlVersion21>
+    <MySqlConnectorVersion>0.43.0</MySqlConnectorVersion>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.0</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
-    <PomeloEntityFrameworkCoreMySqlVersion>2.0.1</PomeloEntityFrameworkCoreMySqlVersion>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.1.1</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
+    <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
+    <PomeloEntityFrameworkCoreMySqlVersion21>2.1.1</PomeloEntityFrameworkCoreMySqlVersion21>
   </PropertyGroup>
 </Project>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -17,7 +16,6 @@
     <PackageReference Include="Dapper" Version="$(DapperVersion)" />
     <PackageReference Include="Jil" Version="$(JilVersion)" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbVersion)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion)" />
     <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
   </ItemGroup>
 
@@ -26,24 +24,30 @@
 
     <!-- Sockets where only available as a preview package for 2.0 -->
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.0.0-preview2-final" />
+
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion20)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion20)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion20)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.1' or $(TargetFramework) == 'netcoreapp2.2'">
     <!-- Temporary fix for MVC compiled views -->
-    <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />
+    <PackageReference Condition="'$(BenchmarksAspNetCoreVersion)' != '2.1.2'" Include="Microsoft.NET.Sdk.Razor" Version="$(BenchmarksAspNetCoreVersion)" PrivateAssets="All" />
+    <!-- Override Razor SDK version when using Microsoft.AspNetCore.App 2.1.2. This package lacks a 2.1.2 version. -->
+    <PackageReference Condition="'$(BenchmarksAspNetCoreVersion)' == '2.1.2'" Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion212)" PrivateAssets="All" />
 
     <PackageReference Include="Microsoft.AspNetCore.App" Version="$(BenchmarksAspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="$(BenchmarksAspNetCoreVersion)" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="$(BenchmarksAspNetCoreVersion)" />
-
-    <!-- IIS -->
-    <PackageReference Condition="$(TargetFramework) == 'netcoreapp2.2'" Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="$(BenchmarksAspNetCoreVersion)" />
-
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion21)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion21)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion21)" />
+  </ItemGroup>
+
+  <!-- IIS -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="$(BenchmarksAspNetCoreVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -51,5 +55,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -51,15 +51,15 @@ namespace Benchmarks
 
             // Common DB services
             services.AddSingleton<IRandom, DefaultRandom>();
-            services.AddEntityFrameworkSqlServer();
 
             var appSettings = Configuration.Get<AppSettings>();
 
             Console.WriteLine($"Database: {appSettings.Database}");
-            
+
             switch (appSettings.Database)
             {
                 case DatabaseServer.PostgreSql:
+                    services.AddEntityFrameworkNpgsql();
                      var settings = new NpgsqlConnectionStringBuilder(appSettings.ConnectionString);
                      if (!settings.NoResetOnClose)
                          throw new ArgumentException("No Reset On Close=true must be specified for Npgsql");
@@ -75,6 +75,7 @@ namespace Benchmarks
                     break;
 
                 case DatabaseServer.SqlServer:
+                    services.AddEntityFrameworkSqlServer();
                     services.AddDbContextPool<ApplicationDbContext>(options => options.UseSqlServer(appSettings.ConnectionString));
 
                     if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
@@ -84,6 +85,7 @@ namespace Benchmarks
                     break;
 
                 case DatabaseServer.MySql:
+                    services.AddEntityFrameworkMySql();
                     services.AddDbContextPool<ApplicationDbContext>(options => options.UseMySql(appSettings.ConnectionString));
 
                     if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
@@ -91,7 +93,10 @@ namespace Benchmarks
                         services.AddSingleton<DbProviderFactory>(MySql.Data.MySqlClient.MySqlClientFactory.Instance);
                     }
                     break;
+
                 case DatabaseServer.MongoDb:
+                    // Reviewers: Is this actually needed for Mongo scenarios?
+                    services.AddEntityFrameworkSqlServer();
 
                     var mongoClient = new MongoClient(appSettings.ConnectionString);
                     var mongoDatabase = mongoClient.GetDatabase("hello_world");
@@ -99,7 +104,6 @@ namespace Benchmarks
                     services.AddSingleton(mongoDatabase);
                     services.AddSingleton(sp => mongoDatabase.GetCollection<Fortune>("fortune"));
                     services.AddSingleton(sp => mongoDatabase.GetCollection<World>("world"));
-
                     break;
             }
 
@@ -323,7 +327,7 @@ namespace Benchmarks
             }
 
             app.UseAutoShutdown();
-            
+
             app.RunDebugInfoPage();
         }
     }

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -100,9 +99,9 @@ namespace BenchmarksDriver
                 "WebHost (e.g., KestrelLibuv, KestrelSockets, HttpSys). Default is KestrelSockets.",
                 CommandOptionType.SingleValue);
             var aspnetCoreVersionOption = app.Option("--aspnetCoreVersion",
-                "ASP.NET Core packages version (Current, Latest, or custom value). Current is the latest public version (2.0.*), Latest is the currently developped one. Default is Latest (2.1-*).", CommandOptionType.SingleValue);
+                "ASP.NET Core packages version (Current, Latest, or custom value). Current is the latest public version (2.0.*), Latest is the currently developed one. Default is Latest (2.2-*).", CommandOptionType.SingleValue);
             var runtimeVersionOption = app.Option("--runtimeVersion",
-                ".NET Core Runtime version (Current, Latest, Edge or custom value). Current is the latest public version, Latest is the one enlisted, Edge is the latest available. Default is Latest (2.1.0-*).", CommandOptionType.SingleValue);
+                ".NET Core Runtime version (Current, Latest, Edge or custom value). Current is the latest public version, Latest is the one enlisted, Edge is the latest available. Default is Latest (2.2.0-*).", CommandOptionType.SingleValue);
             var argumentsOption = app.Option("--arguments",
                 "Arguments to pass to the application. (e.g., \"--raw true\")", CommandOptionType.SingleValue);
             var noArgumentsOptions = app.Option("--no-arguments",
@@ -933,7 +932,7 @@ namespace BenchmarksDriver
                             await Task.Delay(1000);
                         }
                     }
-                    System.Threading.Thread.Sleep(200);  // Make it clear on traces when startup has finished and warmup begins.  
+                    System.Threading.Thread.Sleep(200);  // Make it clear on traces when startup has finished and warmup begins.
 
                     TimeSpan latencyNoLoad = TimeSpan.Zero, latencyFirstRequest = TimeSpan.Zero;
 
@@ -951,7 +950,7 @@ namespace BenchmarksDriver
                         _clientJob.SkipStartupLatencies = false;
 
                         _clientJob.Duration = duration;
-                        System.Threading.Thread.Sleep(200);  // Make it clear on traces when warmup stops and measuring begins. 
+                        System.Threading.Thread.Sleep(200);  // Make it clear on traces when warmup stops and measuring begins.
                     }
 
 
@@ -1716,7 +1715,7 @@ namespace BenchmarksDriver
             using (ZipArchive archive = ZipFile.Open(destinationArchiveFileName, ZipArchiveMode.Create))
             {
                 string basePath = di.FullName;
-                
+
                 var ignoreFile = IgnoreFile.Parse(Path.Combine(sourceDirectoryName, ".gitignore"));
 
                 foreach (var gitFile in ignoreFile.ListDirectory(sourceDirectoryName))

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -32,7 +32,7 @@ namespace BenchmarkServer
 {
     public class Startup
     {
-        private static string CurrentAspNetCoreVersion = "2.1.0";
+        private static string CurrentAspNetCoreVersion = "2.1.2";
         private static string CurrentTargetFramework = "netcoreapp2.1";
 
         private const string PerfViewVersion = "P2.0.12";
@@ -140,7 +140,7 @@ namespace BenchmarkServer
                 ;
 
             var dotnetInstallFilename = Path.Combine(_dotnetInstallPath, Path.GetFileName(_dotnetInstallUrl));
-            
+
             Log.WriteLine($"Downloading dotnet-install to '{dotnetInstallFilename}'");
             DownloadFileAsync(_dotnetInstallUrl, dotnetInstallFilename, maxRetries: 5, timeout: 60).GetAwaiter().GetResult();
 
@@ -181,7 +181,7 @@ namespace BenchmarkServer
 
         public static int Main(string[] args)
         {
-            // Prevent unhandled exceptions in the benchmarked apps from displaying a popup that would block 
+            // Prevent unhandled exceptions in the benchmarked apps from displaying a popup that would block
             // the main process on Windows
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -372,8 +372,8 @@ namespace BenchmarkServer
                             // TODO: Race condition if DELETE is called during this code
                             try
                             {
-                                if (OperatingSystem == OperatingSystem.Linux && 
-                                    (job.WebHost == WebHost.IISInProcess || 
+                                if (OperatingSystem == OperatingSystem.Linux &&
+                                    (job.WebHost == WebHost.IISInProcess ||
                                     job.WebHost == WebHost.IISOutOfProcess)
                                     )
                                 {
@@ -481,7 +481,7 @@ namespace BenchmarkServer
                                             var output = new StringBuilder();
 
                                             // Get docker stats
-                                            var result = ProcessUtil.Run("docker", "container stats --no-stream --format \"{{.CPUPerc}}-{{.MemUsage}}\" " + dockerContainerId, 
+                                            var result = ProcessUtil.Run("docker", "container stats --no-stream --format \"{{.CPUPerc}}-{{.MemUsage}}\" " + dockerContainerId,
                                                 outputDataReceived: d => output.AppendLine(d),
                                                 log: false);
 
@@ -872,7 +872,7 @@ namespace BenchmarkServer
             Log.WriteLine($"Process has stopped");
 
             perfCollectProcess = null;
-            
+
         }
 
         private static async Task<(string containerId, string imageName)> DockerBuildAndRun(string path, ServerJob job, string hostname)
@@ -945,7 +945,7 @@ namespace BenchmarkServer
                 Log.WriteLine($"Waiting for application to startup...");
 
                 // Wait until the service is reachable to avoid races where the container started but isn't
-                // listening yet. If it keeps failing we ignore it. If the port is unreachable then clients 
+                // listening yet. If it keeps failing we ignore it. If the port is unreachable then clients
                 // will fail to connect and the job will be cleaned up properly
                 if (await WaitToListen(job, hostname, 30))
                 {
@@ -1512,7 +1512,7 @@ namespace BenchmarkServer
                         // Copy the response stream directly to the file stream
                         await response.Content.CopyToAsync(stream);
                         return Encoding.UTF8.GetString(stream.ToArray());
-                    }                    
+                    }
                 }
                 catch (OperationCanceledException)
                 {
@@ -1713,7 +1713,7 @@ namespace BenchmarkServer
             if (job.Collect && OperatingSystem == OperatingSystem.Linux)
             {
                 // c.f. https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/linux-performance-tracing.md#collecting-a-trace
-                // The Task library EventSource events are distorting the trace quite a bit.   
+                // The Task library EventSource events are distorting the trace quite a bit.
                 // It is better at least for now to turn off EventSource events when collecting linux data.
                 // Thus don’t set COMPlus_EnableEventLog = 1
                 process.StartInfo.Environment.Add("COMPlus_PerfMapEnabled", "1");
@@ -1734,9 +1734,9 @@ namespace BenchmarkServer
                     Log.WriteLine(e.Data);
                     standardOutput.AppendLine(e.Data);
 
-                    if (job.State == ServerState.Starting && 
+                    if (job.State == ServerState.Starting &&
                         ((!String.IsNullOrEmpty(job.ReadyStateText) && e.Data.IndexOf(job.ReadyStateText, StringComparison.OrdinalIgnoreCase) >= 0) ||
-                        e.Data.ToLowerInvariant().Contains("started") || 
+                        e.Data.ToLowerInvariant().Contains("started") ||
                         e.Data.ToLowerInvariant().Contains("listening")))
                     {
                         MarkAsRunning(hostname, benchmarksRepo, job, stopwatch, process);


### PR DESCRIPTION
- bump our 2.1.x versions (particularly important in `current` runs) to match OSS dependencies
- get slightly newer SDK to enable builds using our 2.1.2 packages

nits:
- add MySql and PostgreSql-specific services
- fix BenchmarksDriver help typos
- clean up IIS-related dependencies (new in 2.2)
- remove trailing whitespace
- remove an unused `using`