### PR TITLE
[DO NOT MERGE] Add Ai Auto-Collection to Benchmarks

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="$(DapperVersion)" />
     <PackageReference Include="Jil" Version="$(JilVersion)" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.0" />
     <PackageReference Include="MongoDB.Driver" Version="$(MongoDbVersion)" />
     <PackageReference Include="MySqlConnector" Version="$(MySqlConnectorVersion)" />
   </ItemGroup>

--- a/src/Benchmarks/Configuration/AppSettings.cs
+++ b/src/Benchmarks/Configuration/AppSettings.cs
@@ -5,6 +5,10 @@ namespace Benchmarks.Configuration
 {
     public class AppSettings
     {
+        public string AiInstrumenationKey { get; set; }
+
+        public bool EnableAi { get; set; }
+
         public string ConnectionString { get; set; }
 
         public DatabaseServer Database { get; set; } = DatabaseServer.None;

--- a/src/Benchmarks/Configuration/AppSettings.cs
+++ b/src/Benchmarks/Configuration/AppSettings.cs
@@ -5,7 +5,7 @@ namespace Benchmarks.Configuration
 {
     public class AppSettings
     {
-        public string AiInstrumenationKey { get; set; }
+        public string AiInstrumentationKey { get; set; }
 
         public bool EnableAi { get; set; }
 

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -57,6 +57,7 @@ namespace Benchmarks
             // Add AI Auto-Collection
             if (appSettings.EnableAi)
             {
+                Console.WriteLine("Using Application Insights");
                 services.AddApplicationInsightsTelemetry(appSettings.AiInstrumentationKey);
             }
 

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -57,7 +57,7 @@ namespace Benchmarks
             // Add AI Auto-Collection
             if (appSettings.EnableAi)
             {
-                services.AddApplicationInsightsTelemetry(appSettings.AiInstrumenationKey);
+                services.AddApplicationInsightsTelemetry(appSettings.AiInstrumentationKey);
             }
 
             Console.WriteLine($"Database: {appSettings.Database}");

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -53,6 +53,12 @@ namespace Benchmarks
             services.AddSingleton<IRandom, DefaultRandom>();
 
             var appSettings = Configuration.Get<AppSettings>();
+            
+            // Add AI Auto-Collection
+            if (appSettings.EnableAi)
+            {
+                services.AddApplicationInsightsTelemetry(appSettings.AiInstrumenationKey);
+            }
 
             Console.WriteLine($"Database: {appSettings.Database}");
 

--- a/src/Benchmarks/appsettings.json
+++ b/src/Benchmarks/appsettings.json
@@ -1,5 +1,3 @@
 ﻿{
-  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true",
-  "EnableAI": true,
-  "AiInstrumenationKey": "6a70388f-9193-463b-9117-4a88ba0e04c6"
+  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true"  
 }

--- a/src/Benchmarks/appsettings.json
+++ b/src/Benchmarks/appsettings.json
@@ -1,3 +1,5 @@
 ﻿{
-  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true"
+  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnet5-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true",
+  "EnableAI": true,
+  "AiInstrumenationKey": "6a70388f-9193-463b-9117-4a88ba0e04c6"
 }


### PR DESCRIPTION
PR to add AI ASP.NET auto-collection to Benchmarks app.
This PR can be used to compare benchmarks with/without AI (based on `EnableAi` setting) from the platform perspective.

The Instrumentation Key provided (in `AiInstrumentationKey` setting) is a temporary AI resource provisioned specifically for this purpose. We can think of changing this IKey / removing this resource after the test or switch to reading it from the environment variable to avoid exposing the IKey.

I do not expect that this PR is to be merged unless @sebastienros would think otherwise.

P.S. I validated that AI collects telemetry with this app if I run Benchmarks.dll locally in Kestrel/Sockets.