### PR TITLE
Fix breaking change introduced to MVC apps for 3.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -41,7 +41,7 @@
     <!-- The Npqsql driver for EF Core 3.0 doesn't exist yet -->
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>2.2.0</MicrosoftEntityFrameworkCoreSqlServerVersion30>
     <MicrosoftAspNetCoreLibuvPackageVersion30>3.0.0-preview-19059-0308</MicrosoftAspNetCoreLibuvPackageVersion30>
-    <MicrosoftAspNetCoreMvcNewtonsoftJson30> 3.0.0-preview-19059-0308</MicrosoftAspNetCoreMvcNewtonsoftJson30>
+    <MicrosoftAspNetCoreMvcNewtonsoftJson30>3.0.0-preview-19059-0308</MicrosoftAspNetCoreMvcNewtonsoftJson30>
     
   </PropertyGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -40,7 +40,8 @@
 
     <!-- The Npqsql driver for EF Core 3.0 doesn't exist yet -->
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>2.2.0</MicrosoftEntityFrameworkCoreSqlServerVersion30>
-    <MicrosoftAspNetCoreLibuvPackageVersion30>3.0.0-preview-18577-0035</MicrosoftAspNetCoreLibuvPackageVersion30>
+    <MicrosoftAspNetCoreLibuvPackageVersion30>3.0.0-preview-19059-0308</MicrosoftAspNetCoreLibuvPackageVersion30>
+    <MicrosoftAspNetCoreMvcNewtonsoftJson30> 3.0.0-preview-19059-0308</MicrosoftAspNetCoreMvcNewtonsoftJson30>
     
   </PropertyGroup>
 </Project>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -65,6 +65,7 @@
     <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->
 
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="$(MicrosoftAspNetCoreLibuvPackageVersion30)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCoreMvcNewtonsoftJson30)" />
 
     <!-- This is not necessary when targetting Microsoft.NET.Sdk.Web on 3.x-->
     <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -62,10 +62,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
-    <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->
 
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="$(MicrosoftAspNetCoreLibuvPackageVersion30)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCoreMvcNewtonsoftJson30)" />
+
+    <!-- Using latest specified version -->
+    <PackageReference Condition="$(BenchmarksAspNetCoreVersion) != ''" Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="$(BenchmarksAspNetCoreVersion)" />
+    <PackageReference Condition="$(BenchmarksAspNetCoreVersion) != ''" Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(BenchmarksAspNetCoreVersion)" />
 
     <!-- This is not necessary when targetting Microsoft.NET.Sdk.Web on 3.x-->
     <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -61,11 +61,11 @@ namespace Benchmarks
             {
                 case DatabaseServer.PostgreSql:
                     services.AddEntityFrameworkNpgsql();
-                     var settings = new NpgsqlConnectionStringBuilder(appSettings.ConnectionString);
-                     if (!settings.NoResetOnClose)
-                         throw new ArgumentException("No Reset On Close=true must be specified for Npgsql");
-                     if (settings.Enlist)
-                         throw new ArgumentException("Enlist=false must be specified for Npgsql");
+                    var settings = new NpgsqlConnectionStringBuilder(appSettings.ConnectionString);
+                    if (!settings.NoResetOnClose)
+                        throw new ArgumentException("No Reset On Close=true must be specified for Npgsql");
+                    if (settings.Enlist)
+                        throw new ArgumentException("Enlist=false must be specified for Npgsql");
 
                     services.AddDbContextPool<ApplicationDbContext>(options => options.UseNpgsql(appSettings.ConnectionString));
 
@@ -151,7 +151,13 @@ namespace Benchmarks
 
                 if (Scenarios.MvcJson || Scenarios.Any("MvcDbSingle") || Scenarios.Any("MvcDbMulti"))
                 {
+#if NETCOREAPP2_1 || NETCOREAPP2_2
                     mvcBuilder.AddJsonFormatters();
+#elif NETCOREAPP3_0
+                    mvcBuilder.AddNewtonsoftJson();
+#else
+#error "Unsupported TFM"
+#endif
                 }
 
                 if (Scenarios.MvcViews || Scenarios.Any("MvcDbFortunes"))


### PR DESCRIPTION
- Added the new Newtonsoft JSON formatter package as a dependency in 3.0
- Matched the version of the Libuv package
- Fixed the code to call the new API in the netcoreapp3.0 case

cc @pranavkm 