### PR TITLE
Remove duplicate DotNetCliTool config file

### DIFF
--- a/src/BenchmarksDriver/DotnetToolSettings.xml
+++ b/src/BenchmarksDriver/DotnetToolSettings.xml
@@ -1,5 +1,0 @@
-<DotNetCliTool>
-  <Commands>
-    <Command Name="benchmarks" EntryPoint="BenchmarksDriver.dll" Runner="dotnet" />
-  </Commands>
-</DotNetCliTool>


### PR DESCRIPTION
Fixes the following:

```
C:\dev\aspnet> git clone git@github.com:aspnet/Benchmarks.git
Cloning into 'Benchmarks'...
remote: Enumerating objects: 172, done.
remote: Counting objects: 100% (172/172), done.
remote: Compressing objects: 100% (137/137), done.
remote: Total 5899 (delta 75), reused 117 (delta 34), pack-reused 5727
Receiving objects: 100% (5899/5899), 2.01 MiB | 13.75 MiB/s, done.
Resolving deltas: 100% (4134/4134), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'src/BenchmarksDriver/DotNetToolSettings.xml'
  'src/BenchmarksDriver/DotnetToolSettings.xml'
```