### PR TITLE
Use async IO (async ish)

### DIFF
--- a/src/Benchmarks/Middleware/JilMiddleware.cs
+++ b/src/Benchmarks/Middleware/JilMiddleware.cs
@@ -26,7 +26,7 @@ namespace Benchmarks.Middleware
             _next = next;
         }
 
-        public Task Invoke(HttpContext httpContext)
+        public async Task Invoke(HttpContext httpContext)
         {
             if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
             {
@@ -37,11 +37,12 @@ namespace Benchmarks.Middleware
                 using (var sw = new StreamWriter(httpContext.Response.Body, _encoding, bufferSize: _bufferSize))
                 {
                     JSON.Serialize(new JsonMessage() { message = "Hello, World!" }, sw);
-                    return sw.FlushAsync();
+
+                    await sw.FlushAsync();
                 }
             }
 
-            return _next(httpContext);
+            await _next(httpContext);
         }
     }
 

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -26,7 +26,7 @@ namespace Benchmarks.Middleware
             _next = next;
         }
 
-        public Task Invoke(HttpContext httpContext)
+        public async Task Invoke(HttpContext httpContext)
         {
             if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
             {
@@ -37,12 +37,12 @@ namespace Benchmarks.Middleware
                 using (var sw = new StreamWriter(httpContext.Response.Body, _encoding, bufferSize: _bufferSize))
                 {
                     _json.Serialize(sw, new { message = "Hello, World!" });
-                }
 
-                return Task.CompletedTask;
+                    await sw.FlushAsync();
+                }
             }
 
-            return _next(httpContext);
+            await _next(httpContext);
         }
     }
 


### PR DESCRIPTION
- The extra state machine might regress performance slightly but we recently removed the ability to do sync IO by default on request/response body streams.
- This PR does a proper async flush on the StreamWriter since the write is tiny should always complete synchronously.