### PR TITLE
Fix exception when running with a baseline without a description

### DIFF
--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1951,23 +1951,18 @@ namespace BenchmarksDriver
             }
         }
 
-        private static List<KeyValuePair<string, string>> BuildFields(Statistics average)
-        {
-            var fields = new List<KeyValuePair<string, string>>();
-            if (!String.IsNullOrEmpty(average.Description))
+        private static List<KeyValuePair<string, string>> BuildFields(Statistics average) 
+            => new List<KeyValuePair<string, string>>
             {
-                fields.Add(new KeyValuePair<string, string>("Description", average.Description));
-            }
-
-            fields.Add(new KeyValuePair<string, string>("RPS", $"{average.RequestsPerSecond:n0}"));
-            fields.Add(new KeyValuePair<string, string>("CPU (%)", $"{average.Cpu}"));
-            fields.Add(new KeyValuePair<string, string>("Memory (MB)", $"{average.WorkingSet:n0}"));
-            fields.Add(new KeyValuePair<string, string>("Avg. Latency (ms)", $"{average.LatencyOnLoad}"));
-            fields.Add(new KeyValuePair<string, string>("Startup (ms)", $"{average.StartupMain}"));
-            fields.Add(new KeyValuePair<string, string>("First Request (ms)", $"{average.FirstRequest}"));
-            fields.Add(new KeyValuePair<string, string>("Latency (ms)", $"{average.Latency}"));
-            return fields;
-        }
+                new KeyValuePair<string, string>("Description", average.Description),
+                new KeyValuePair<string, string>("RPS", $"{average.RequestsPerSecond:n0}"),
+                new KeyValuePair<string, string>("CPU (%)", $"{average.Cpu}"),
+                new KeyValuePair<string, string>("Memory (MB)", $"{average.WorkingSet:n0}"),
+                new KeyValuePair<string, string>("Avg. Latency (ms)", $"{average.LatencyOnLoad}"),
+                new KeyValuePair<string, string>("Startup (ms)", $"{average.StartupMain}"),
+                new KeyValuePair<string, string>("First Request (ms)", $"{average.FirstRequest}"),
+                new KeyValuePair<string, string>("Latency (ms)", $"{average.Latency}")
+            };
 
         private static async Task<int> UploadFileAsync(string filename, ServerJob serverJob, string uri)
         {


### PR DESCRIPTION
The first run was executed with `--save baseline` but without `--description`, so the resulting baseline.bench.json has an empty Description node.

The second run was executed with `-diff baseline` and with a `--description` (required when using `-diff`, but not when using `--save`). The run failed with:

```
[09:02:45.507] System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at BenchmarksDriver.Program.Run(Uri serverUri, Uri clientUri, String sqlConnectionString, ServerJob serverJob, String session, String description, Int32 iterations, Int32 exclude, String shutdownEndpoint, TimeSpan span, List`1 downloadFiles, Boolean fetch, String fetchDestination, Boolean collectR2RLog, String traceDestination, CommandOption outputFileOption
, CommandOption sourceOption, CommandOption scriptFileOption, CommandOption markdownOption, CommandOption writeToFileOption, Nullable`1 requiredOperatingSystem, CommandOption saveOption, CommandOption diffOption) in /home/roji/projects/Benchmarks/src/BenchmarksDriver/Program.cs:line 1672                                                                          
```

This PR changes `BuildFields()` to always generate a description, even if it's null or empty. A better fix may be more appropriate but this does unblock me.