### PR TITLE
Fix command to autodetect server IP

### DIFF
--- a/docker/benchmarks/run-server.sh
+++ b/docker/benchmarks/run-server.sh
@@ -40,7 +40,7 @@ done
 if [ -z "$server_ip" ]
 then
     # tries to get the ip from the available NICs, but it's recommended to set it manually to use the fastest one
-    server_ip=$(ip route get 1 | awk '{print $NF;exit}')
+    server_ip=$(ip route get 1 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
 
     echo "Using server_ip=$server_ip"
 fi


### PR DESCRIPTION
- `ip route` command output changed
- Ubuntu16: `1.0.0.0 via 1.2.3.4 dev eth0  src 5.6.7.8`
- Ubuntu18: `1.0.0.0 via 1.2.3.4 dev eth0  src 5.6.7.8 uid 0`
- New `awk` command works on both outputs