### PR TITLE
Fix BenchmarkDotNet results formatting on Linux

### DIFF
--- a/src/BenchmarksDriver/BenchmarkDotNetUtils.cs
+++ b/src/BenchmarksDriver/BenchmarkDotNetUtils.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+
+namespace BenchmarksDriver
+{
+    internal static class BenchmarkDotNetUtils
+    {
+        internal static void WriteMarkdownResultTableToConsole(string markdownFileContent)
+        {
+            var lines = markdownFileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            foreach(var line in lines.Where(line => !line.StartsWith("```")))
+            {
+                // BDN uses "**" for getting the text bold when Benchmark uses Params, it looks bad in console
+                // we need to trim every line to avoid some weird whitespace issues for Linux results
+                Console.WriteLine(line.Replace("**", string.Empty).Trim());
+            }
+        }
+    }
+}

--- a/src/BenchmarksDriver/BenchmarkDotNetUtils.cs
+++ b/src/BenchmarksDriver/BenchmarkDotNetUtils.cs
@@ -1,11 +1,95 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using BenchmarksDriver.Serializers;
+using CsvHelper;
+using CsvHelper.TypeConversion;
+using Newtonsoft.Json.Linq;
 
 namespace BenchmarksDriver
 {
     internal static class BenchmarkDotNetUtils
     {
-        internal static void WriteMarkdownResultTableToConsole(string markdownFileContent)
+        internal static async Task DownloadResultFiles(Uri serverJobUri, HttpClient httpClient, BenchmarkDotNetSerializer serializer)
+        {
+            await DownloadFiles(serverJobUri, "report.csv", httpClient, (fileName, fileContent) => ParseCSVResults(fileName, fileContent, serializer));
+            await DownloadFiles(serverJobUri, "report-github.md", httpClient, (fileName, fileContent) => WriteMarkdownResultTableToConsole(fileContent));
+        }
+
+        private static async Task DownloadFiles(Uri serverJobUri, string extension, HttpClient httpClient, Action<string, string> contentHandler)
+        {
+            var uri = $"{serverJobUri}/list?path={HttpUtility.UrlEncode("BenchmarkDotNet.Artifacts/results/*-")}{extension}";
+            var response = await httpClient.GetStringAsync(uri);
+            var fileNames = JArray.Parse(response).ToObject<string[]>();
+
+            foreach (var fileName in fileNames)
+            {
+                try
+                {
+                    uri = $"{serverJobUri}/download?path={HttpUtility.UrlEncode(fileName)}";
+
+                    Program.LogVerbose($"Downloading file {fileName} from {uri}");
+
+                    var fileContent = await httpClient.DownloadFileContentAsync(uri);
+
+                    contentHandler(fileName, fileContent);
+                }
+                catch (Exception e)
+                {
+                    Program.Log($"Error while downloading file {fileName} from {uri}, skipping ...");
+                    Program.LogVerbose(e.Message);
+
+                    continue;
+                }
+            }
+        }
+
+        private static void ParseCSVResults(string fileName, string csvFileContent, BenchmarkDotNetSerializer serializer)
+        {
+            using (var sr = new StringReader(csvFileContent))
+            {
+                using (var csv = new CsvReader(sr))
+                {
+                    var isRecordBad = false;
+
+                    csv.Configuration.BadDataFound = context =>
+                    {
+                        isRecordBad = true;
+                    };
+
+                    csv.Configuration.RegisterClassMap<CsvResultMap>();
+                    csv.Configuration.TypeConverterOptionsCache.AddOptions(typeof(double), new TypeConverterOptions { NumberStyle = NumberStyles.AllowThousands | NumberStyles.AllowDecimalPoint });
+
+                    var localResults = new List<CsvResult>();
+
+                    while (csv.Read())
+                    {
+                        if (!isRecordBad)
+                        {
+                            localResults.Add(csv.GetRecord<CsvResult>());
+                        }
+
+                        isRecordBad = false;
+                    }
+
+                    var className = Path.GetFileNameWithoutExtension(fileName).Split('.').LastOrDefault().Split('-', 2).FirstOrDefault();
+
+                    foreach (var result in localResults)
+                    {
+                        result.Class = className;
+                    }
+
+                    serializer.CsvResults.AddRange(localResults);
+                }
+            }
+        }
+
+        private static void WriteMarkdownResultTableToConsole(string markdownFileContent)
         {
             var lines = markdownFileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
 

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1582,7 +1582,7 @@ namespace BenchmarksDriver
                                         {
                                             // Download markdown file for output
                                             uri = serverJobUri + "/download?path=" + HttpUtility.UrlEncode(markdownFilename);
-                                            QuietLog(await DownloadFileContent(uri));
+                                            BenchmarkDotNetUtils.WriteMarkdownResultTableToConsole(await DownloadFileContent(uri));
                                         }
                                         catch (Exception e)
                                         {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1515,7 +1515,7 @@ namespace BenchmarksDriver
 
                                         try
                                         {
-                                            csvContent = await DownloadFileContent(uri, serverJobUri);
+                                            csvContent = await DownloadFileContent(uri);
                                         }
                                         catch (Exception e)
                                         {
@@ -1582,7 +1582,7 @@ namespace BenchmarksDriver
                                         {
                                             // Download markdown file for output
                                             uri = serverJobUri + "/download?path=" + HttpUtility.UrlEncode(markdownFilename);
-                                            QuietLog(await DownloadFileContent(uri, serverJobUri));
+                                            QuietLog(await DownloadFileContent(uri));
                                         }
                                         catch (Exception e)
                                         {
@@ -2487,7 +2487,7 @@ namespace BenchmarksDriver
             return;
         }
 
-        private static async Task<string> DownloadFileContent(string uri, Uri serverJobUri)
+        private static async Task<string> DownloadFileContent(string uri)
         {
             using (var downloadStream = await _httpClient.GetStreamAsync(uri))
             {

--- a/src/BenchmarksDriver/Program.cs
+++ b/src/BenchmarksDriver/Program.cs
@@ -1521,6 +1521,7 @@ namespace BenchmarksDriver
                                         {
                                             Log($"Error while downloading file {csvFilename}, skipping ...");
                                             Log(e.Message);
+                                            continue;
                                         }
 
                                         var className = Path.GetFileNameWithoutExtension(csvFilename).Split('.').LastOrDefault().Split('-', 2).FirstOrDefault();

--- a/src/BenchmarksDriver/WebUtils.cs
+++ b/src/BenchmarksDriver/WebUtils.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace BenchmarksDriver
+{
+    internal static class WebUtils
+    {
+        internal static async Task<string> DownloadFileContentAsync(this HttpClient httpClient, string uri)
+        {
+            using (var downloadStream = await httpClient.GetStreamAsync(uri))
+            {
+                using (var stringReader = new StreamReader(downloadStream))
+                {
+                    return await stringReader.ReadToEndAsync();
+                }
+            }
+        }
+
+        internal static async Task DownloadFileAsync(this HttpClient httpClient, string uri, Uri serverJobUri, string destinationFileName)
+        {
+            using (var downloadStream = await httpClient.GetStreamAsync(uri))
+            using (var fileStream = File.Create(destinationFileName))
+            {
+                var downloadTask = downloadStream.CopyToAsync(fileStream);
+
+                while (!downloadTask.IsCompleted)
+                {
+                    // Ping server job to keep it alive while downloading the file
+                    Program.LogVerbose($"GET {serverJobUri}/touch...");
+                    await httpClient.GetAsync(serverJobUri + "/touch");
+
+                    await Task.Delay(1000);
+                }
+
+                await downloadTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Anytime I was trying to run some BDN benchmarks on Linux machine I was getting a strangely formatted output:

![obraz](https://user-images.githubusercontent.com/6011991/60105910-88d9a700-9764-11e9-938a-276518aea662.png)

So I have fixed it:

![obraz](https://user-images.githubusercontent.com/6011991/60105961-a0189480-9764-11e9-8f0e-367276a40122.png)

/cc @sebastienros @roji 
