### PR TITLE
specify the project file name when running dotnet publish to avoid issues when the folder contains a solution file

### DIFF
--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1781,10 +1781,11 @@ namespace BenchmarkServer
             }
 
             var outputFolder = Path.Combine(benchmarkedApp, "published");
+            var projectFileName = Path.GetFileName(FormatPathSeparators(job.Source.Project));
 
             var startPublish = DateTime.UtcNow;
 
-            var arguments = $"publish -c Release -o {outputFolder} {buildParameters}";
+            var arguments = $"publish {projectFileName} -c Release -o {outputFolder} {buildParameters}";
 
             Log.WriteLine($"Publishing application in {outputFolder} with: \n {arguments}");
 


### PR DESCRIPTION
While building the performance culture in CoreFX I have noticed that most of the devs can now easily run the performance repo microbenchmarks on their machine, however very few run Linux vs Windows comparison.

@sebastienros has recently shown me how to run BenchmarkDotNet benchmarks using this amazing repository and infrastructure.

I think that it would be great if we could use it to quickly compare .NET Core performance on Linux vs Windows on the same hardware. Disclaimer: I don't want the entire CoreFX Team to start pushing a lot of jobs to the ASP.NET Perf infra, I just want to make it easy for the Team to measure the OS difference quickly when needed. 

I have already introduced some changes to the performance repository to make it possible:

https://github.com/dotnet/performance/pull/591
https://github.com/dotnet/performance/pull/592
https://github.com/dotnet/performance/pull/594

The last problem that remains active is addressed by this PR.

If we run `dotnet publish` in given folder without specifying the project name:
- if the folder does not contain a `.sln` file, but a `.csproj` only, dotnet publish publishes only the `.csproj` (99.9% of the cases, worked for everyone so far)
- if the folder contains a `.sln` file, dotnet publish tries to publish all projects in given solution, including test projects etc. This is the problem in the performance repo where we have a solution file and a project file in the same folder. dotnet publish tries to publish a self-contained version of xunit test project and it fails.

![obraz](https://user-images.githubusercontent.com/6011991/60354964-b9704980-99cd-11e9-8e48-6b9bb6a9fa8a.png)


```log
  "Command dotnet publish -c Release -o /tmp/BenchmarksServer/iprzluxi.olr/performance/src/benchmarks/micro/published /p:BenchmarksAspNetCoreVersion=3.0.0-preview7.19325.1 /p:MicrosoftAspNetCoreAllPackageVersion=3.0.0-preview7.19325.1 /p:MicrosoftAspNetCoreAppPackageVersion=3.0.0-preview7.19325.1 /p:BenchmarksNETStandardImplicitPackageVersion=3.0.0-preview7.19325.1 /p:BenchmarksNETCoreAppImplicitPackageVersion=3.0.0-preview7.19325.1 /p:BenchmarksRuntimeFrameworkVersion=3.0.0-preview7-27825-02 /p:BenchmarksTargetFramework=netcoreapp3.0 /p:MicrosoftNETCoreAppPackageVersion=3.0.0-preview7-27825-02 /p:NETCoreAppMaximumVersion=99.9 /p:MicrosoftNETCoreApp30PackageVersion=3.0.0-preview7-27825-02 /p:MicrosoftNETPlatformLibrary=Microsoft.NETCore.App --framework netcoreapp3.0 --self-contained -r linux-x64  returned exit code 1 
Microsoft (R) Build Engine version 16.3.0-preview-19321-02+a5a222491 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 498.44 ms for /tmp/BenchmarksServer/iprzluxi.olr/performance/src/tools/Reporting/Reporting/Reporting.csproj.
  Restore completed in 689.74 ms for /tmp/BenchmarksServer/iprzluxi.olr/performance/src/harness/BenchmarkDotNet.Extensions/BenchmarkDotNet.Extensions.csproj.
  Restore completed in 1.33 sec for /tmp/BenchmarksServer/iprzluxi.olr/performance/src/benchmarks/micro/MicroBenchmarks.csproj.
  Restore completed in 1.46 sec for /tmp/BenchmarksServer/iprzluxi.olr/performance/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj.
  Reporting -> /tmp/BenchmarksServer/iprzluxi.olr/performance/artifacts/bin/Reporting/Debug/netcoreapp3.0/Reporting.dll
  BenchmarkDotNet.Extensions -> /tmp/BenchmarksServer/iprzluxi.olr/performance/artifacts/bin/BenchmarkDotNet.Extensions/Release/netcoreapp3.0/linux-x64/BenchmarkDotNet.Extensions.dll
  BenchmarkDotNet.Extensions -> /tmp/BenchmarksServer/iprzluxi.olr/performance/src/benchmarks/micro/published/
  BenchmarkDotNet.Extensions -> /tmp/BenchmarksServer/iprzluxi.olr/performance/artifacts/bin/BenchmarkDotNet.Extensions/Release/netcoreapp3.0/BenchmarkDotNet.Extensions.dll
  MicroBenchmarks -> /tmp/BenchmarksServer/iprzluxi.olr/performance/artifacts/bin/MicroBenchmarks/Release/netcoreapp3.0/linux-x64/MicroBenchmarks.dll
  MicroBenchmarks -> /tmp/BenchmarksServer/iprzluxi.olr/performance/src/benchmarks/micro/published/
/tmp/BenchmarksServer/qt1c15ni.vyi/sdk/3.0.100-preview7-012605/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(131,5): error NETSDK1067: Self-contained applications are required to use the application host. Either set SelfContained to false or set UseAppHost to true. [/tmp/BenchmarksServer/iprzluxi.olr/performance/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj]
```

The solution is to provide the project name when doing `dotnet publish $projectName`. 

This should not be an issue, because this particular command expects user to provide the path via `--project-file` when running BenchmarkDriver. It's already used to get the `WorkingDirectory` for `dotnet publish`

https://github.com/aspnet/Benchmarks/blob/0969d6318d84b15db3e51d97f3f96fc262f42ac4/src/BenchmarksServer/Startup.cs#L1423-L1424 

https://github.com/aspnet/Benchmarks/blob/0969d6318d84b15db3e51d97f3f96fc262f42ac4/src/BenchmarksServer/Startup.cs#L1792-L1793