### PR TITLE
Use the runtime version that ASP.NET Core uses

### DIFF
--- a/build/scenarios.sh
+++ b/build/scenarios.sh
@@ -195,7 +195,7 @@ do
     for job in "${jobs[@]}"
     do
         echo "New job  on '$s': $job"
-        dotnet $ROOT/.build/BenchmarksDriver/BenchmarksDriver.dll -s $s -c $BENCHMARKS_CLIENT $job --session $SESSION -q "$BENCHMARKS_SQL" $BENCHMARKS_ARGS --sdk latest --self-contained --runtimeversion "3.0.0-*" --collect-counters
+        dotnet $ROOT/.build/BenchmarksDriver/BenchmarksDriver.dll -s $s -c $BENCHMARKS_CLIENT $job --session $SESSION -q "$BENCHMARKS_SQL" $BENCHMARKS_ARGS --sdk latest --self-contained --runtimeversion "Latest" --collect-counters
         # error code in $?
     done
 done


### PR DESCRIPTION
We're currently pulling in 5.0 bits because of this code:

https://github.com/aspnet/Benchmarks/blob/061edf3fd25369dfe0e029f3b166259e5bbe07df/src/BenchmarksServer/Startup.cs#L1463 which uses https://dotnetcli.blob.core.windows.net/dotnet/Runtime/master/latest.version to get the latest 3.0 version.

This is a patch until we fix it properly by using BAR to resolve the right versions and assets.