### PR TITLE
Fix README.md typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ This will create and run a Docker image containing PostgreSql and the Fortunes d
 On your computer,
 
 - Clone https://github.com/aspnet/benchmarks on the __master__ branch
-- Run `cd src/BenchmarkDriver`
+- Run `cd src/BenchmarksDriver`
 - Then run the following command after replacing the IP addresses to the ones you are using, 
 ```
-dotnet run -c Debug `
- --server "http://10.0.0.102:5001" `
- --client "http://10.0.0.101:5002" `
- --jobs "../Benchmarks/benchmarks.Json.json" `
+dotnet run -c Debug \
+ --server "http://10.0.0.102:5001" \
+ --client "http://10.0.0.101:5002" \
+ --jobs "../Benchmarks/benchmarks.Json.json" \
  -n Json
 ```
 


### PR DESCRIPTION
Fix wrong directory name.
Use backslashes to escape newline within bash script in fenced code.