### PR TITLE
Remove default headers from h2load for gRPC

### DIFF
--- a/build/scenarios-grpc.sh
+++ b/build/scenarios-grpc.sh
@@ -35,8 +35,8 @@ trend="--description Trend/Latest"
 jobs=(
 
   # GRPC ASP.NET Core
-  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c --headers None --no-startup-latency"
-  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2 --headers None --no-startup-latency"
+  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c --headers None"
+  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2 --headers None"
   "-n GrpcUnary-GrpcCore --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2"
@@ -54,7 +54,7 @@ jobs=(
   "-n GrpcPingPongStreaming-1MB-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2"
 
   # GRPC C-core
-  "-n GrpcUnary-h2load --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c --headers None --no-startup-latency"
+  "-n GrpcUnary-h2load --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c --headers None"
   "-n GrpcUnary-GrpcCore --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-1MB-GrpcCore --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"

--- a/build/scenarios-grpc.sh
+++ b/build/scenarios-grpc.sh
@@ -35,8 +35,8 @@ trend="--description Trend/Latest"
 jobs=(
 
   # GRPC ASP.NET Core
-  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c --no-startup-latency"
-  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2 --no-startup-latency"
+  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c --headers None --no-startup-latency"
+  "-n GrpcUnary-h2load --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2 --headers None --no-startup-latency"
   "-n GrpcUnary-GrpcCore --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2"
@@ -54,7 +54,7 @@ jobs=(
   "-n GrpcPingPongStreaming-1MB-GrpcNetClient --webHost KestrelSockets $trend $grpcManagedJobs --connections 64 --warmup 5 -m h2"
 
   # GRPC C-core
-  "-n GrpcUnary-h2load --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c --no-startup-latency"
+  "-n GrpcUnary-h2load --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c --headers None --no-startup-latency"
   "-n GrpcUnary-GrpcCore --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-GrpcNetClient --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"
   "-n GrpcUnary-1MB-GrpcCore --webHost CCore $trend $grpcNativeJobs --connections 64 --warmup 5 -m h2c"


### PR DESCRIPTION
`connection: Keep-Alive` header that is added by default is not valid in HTTP/2.

Also enable startup latency tests. These should now work.