### PR TITLE
EF Core microbenchmarks now run release/3.1 instead of 3.0...

### DIFF
--- a/build/scenarios-efcore.sh
+++ b/build/scenarios-efcore.sh
@@ -21,7 +21,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT=$DIR/..
 SESSION=`date '+%Y%m%d%H%M%S'`
 
-efcoreJobs="-r EntityFrameworkCore@release/3.0 --description Benchmarks --arg --perflab --no-global-json --server-timeout 00:45:00 -t EFCoreBenchmarks --sdk 3.0.100-preview8-013656 --aspnetcoreversion 3.0 --runtimeversion 3.0"
+efcoreJobs="-r EntityFrameworkCore@release/3.1 --description Benchmarks --arg --perflab --no-global-json --server-timeout 00:45:00 -t EFCoreBenchmarks --sdk 3.0.100 --aspnetcoreversion 3.0 --runtimeversion 3.0"
 
 jobs=(
 


### PR DESCRIPTION
We should have done this a *long* time ago :cry: 

Not sure if the switches below are correct for 3.1. 

/cc @ajcvickers 