### PR TITLE
Update Npgsql and Npgsql EF versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,11 +27,11 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <NpgsqlVersion30>4.1.0</NpgsqlVersion30>
+    <NpgsqlVersion30>4.1.2</NpgsqlVersion30>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.2</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion22>2.2.4</NpgsqlEntityFrameworkCorePostgreSQLVersion22>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.0.0</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.1.0-preview3</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
     <PomeloEntityFrameworkCoreMySqlVersion22>2.2.0</PomeloEntityFrameworkCoreMySqlVersion22>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -78,9 +78,6 @@
     <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion30)" />
-    <!-- The following is required because of https://github.com/npgsql/npgsql/issues/2583.
-         To be removed when EFCore.PG 3.0.0-preview9 is released, depending on Npgsql 4.1.0-preview2 -->
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion30)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion30)" />
 
     <!-- The EF provider doesn't handle 3.0


### PR DESCRIPTION
@sebastienros this changes the benchmarks to use EF Core 3.1 preview3. I can't see 3.1 being tested in general at the moment (e.g. no TFM) so I'm assuming we can use the 3.0 target to do this.

/cc @ajcvickers