### PR TITLE
EF Core microbenchmarks now run master (5.0) instead of 3.1

### DIFF
--- a/build/scenarios-efcore.sh
+++ b/build/scenarios-efcore.sh
@@ -21,7 +21,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT=$DIR/..
 SESSION=`date '+%Y%m%d%H%M%S'`
 
-efcoreJobs="-r EntityFrameworkCore@release/3.1 --description Benchmarks --arg --perflab --no-global-json --server-timeout 00:45:00 -t EFCoreBenchmarks --aspnetcoreversion 3.1 --runtimeversion 3.1"
+efcoreJobs="-r EntityFrameworkCore@master --description Benchmarks --arg --perflab --no-global-json --server-timeout 00:45:00 -t EFCoreBenchmarks"
 
 jobs=(
 


### PR DESCRIPTION
Switch EF Core to master for the microbenchmarks.

I also updated the runtimeversion and the aspnetcoreversion to 5.0 - not sure if it's necessary etc.

I don't remember anymore if the system picks up the SDK from global.json (in EF Core we're currently on 5.0.100-alpha1-015536).

Let me know if this looks OK.