### PR TITLE
Update DB provider versions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,15 +27,18 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <NpgsqlVersion30>4.1.0</NpgsqlVersion30>
+    <NpgsqlVersion>4.1.3</NpgsqlVersion>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.2</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion22>2.2.4</NpgsqlEntityFrameworkCorePostgreSQLVersion22>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.0.0</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.1</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.0-preview1-ci.20200210T155600</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
     <PomeloEntityFrameworkCoreMySqlVersion22>2.2.0</PomeloEntityFrameworkCoreMySqlVersion22>
-    <PomeloEntityFrameworkCoreMySqlVersion30>2.2.0</PomeloEntityFrameworkCoreMySqlVersion30>
+    <PomeloEntityFrameworkCoreMySqlVersion30>3.0.1</PomeloEntityFrameworkCoreMySqlVersion30>
+    <PomeloEntityFrameworkCoreMySqlVersion31>3.1.1</PomeloEntityFrameworkCoreMySqlVersion31>
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>3.0.0</MicrosoftEntityFrameworkCoreSqlServerVersion30>
     
     <!-- Using 2.2 EF version for netcoreapp3.0 benchmarks as it doesn't work with current providers -->

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -81,12 +81,9 @@
     <FrameworkReference Update="Microsoft.WindowsDesktop.App" RuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppPackageVersion)" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion30)" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion30)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.1" />
-
-    <!-- The EF provider doesn't handle 3.0
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion30)" />
-    -->
 
   </ItemGroup>
 
@@ -102,13 +99,10 @@
     <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
     <FrameworkReference Update="Microsoft.WindowsDesktop.App" RuntimeFrameworkVersion="$(MicrosoftWindowsDesktopAppPackageVersion)" />
 
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion30)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion31)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
-
-    <!-- The EF provider doesn't handle 3.0
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion30)" />
-    -->
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion31)" />
 
   </ItemGroup>
   
@@ -123,9 +117,9 @@
       
     <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
 
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion30)" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion30)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion30)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion50)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion31)" />
 
     <!-- The EF provider doesn't handle 3.0
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion30)" />


### PR DESCRIPTION
* Start using Npgsql.EntityFrameworkCore.PostgreSQL CI versions for 5.0
* Use Pomelo.EntityFrameworkCore.MySql on netcoreapp3.0/3.1
* Npgsql 4.1.0 -> 4.1.3

Note: currently, building Benchmarks fails so hard to be sure this works (Unable to find a stable package Microsoft.AspNetCore.Server.IntegrationTesting.IIS with version (>= 3.0.0))