### PR TITLE
kill all processes that were not running before BenchmarkServer started

### DIFF
--- a/src/BenchmarksServer/ProcessUtil.cs
+++ b/src/BenchmarksServer/ProcessUtil.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -212,7 +213,21 @@ namespace BenchmarkServer
             }
         }
 
-        public static void KillTree(this Process process, TimeSpan timeout)
+        internal static void TryKillAllProcesses(HashSet<int> except)
+        {
+            foreach(var process in Process.GetProcesses().Where(process => !except.Contains(process.Id)))
+            {
+                Log.WriteLine($"Trying to kill {process.Id} {process.ProcessName}");
+
+                try
+                {
+                    process.KillTree(TimeSpan.FromSeconds(3));
+                }
+                catch { } // swallow the exception on purpose
+            }
+        }
+
+        internal static void KillTree(this Process process, TimeSpan timeout)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/BenchmarksServer/ProcessUtil.cs
+++ b/src/BenchmarksServer/ProcessUtil.cs
@@ -217,10 +217,10 @@ namespace BenchmarkServer
         {
             foreach(var process in Process.GetProcesses().Where(process => !except.Contains(process.Id)))
             {
-                Log.WriteLine($"Trying to kill {process.Id} {process.ProcessName}");
-
                 try
                 {
+                    Log.WriteLine($"Trying to kill {process.Id} {process.ProcessName}");
+
                     process.KillTree(TimeSpan.FromSeconds(3));
                 }
                 catch { } // swallow the exception on purpose

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -582,9 +582,6 @@ namespace BenchmarkServer
                                             Log.WriteLine($"Process started: {process.Id}");
 
                                             workingDirectory = process.StartInfo.WorkingDirectory;
-
-
-
                                         }
                                         else
                                         {
@@ -1121,7 +1118,7 @@ namespace BenchmarkServer
                                     }
                                     else if (OperatingSystem == OperatingSystem.Linux)
                                     {
-                                        // TODO: Stop perfcollect
+                                        await StopPerfcollectAsync(perfCollectProcess);
                                     }
                                 }
 
@@ -1229,7 +1226,6 @@ namespace BenchmarkServer
                             }
                             else if (!String.IsNullOrEmpty(dockerImage))
                             {
-
                                 DockerCleanUp(dockerContainerId, dockerImage, job);
                             }
 
@@ -1383,7 +1379,7 @@ namespace BenchmarkServer
                 return;
             }
 
-            if (perfCollectProcess.HasExited)
+            if (perfCollectProcess == null || perfCollectProcess.HasExited)
             {
                 Log.WriteLine($"PerfCollect is not running");
                 return;
@@ -1436,7 +1432,6 @@ namespace BenchmarkServer
             Log.WriteLine($"Process has stopped");
 
             perfCollectProcess = null;
-
         }
 
         private static void ConvertLines(string path)


### PR DESCRIPTION
When:

* BenchmarkServer fails
* After we try to Stop the Job

The goal is to basically force kill all hanging processes that may have remained alive after job execution

Fixes #1446