### PR TITLE
ProcessRequest is not async method

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -60,7 +60,7 @@ namespace PlatformBenchmarks
 
                     if (_state == State.Body)
                     {
-                        await ProcessRequestAsync();
+                        ProcessRequest();
 
                         _state = State.StartLine;
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -54,7 +54,7 @@ namespace PlatformBenchmarks
             _requestType = requestType;
         }
 
-        public ValueTask ProcessRequestAsync()
+        public void ProcessRequest()
         {
             if (_requestType == RequestType.PlainText)
             {
@@ -68,8 +68,6 @@ namespace PlatformBenchmarks
             {
                 Default(Writer);
             }
-
-            return default;
         }
 
         private static void PlainText(PipeWriter pipeWriter)


### PR DESCRIPTION
while working on https://github.com/dotnet/runtime/issues/33669 I've realized that `ProcessRequestAsync` is not really an async method, so we can remove this one extra `await`

It gives an extra +20-40k for Plaintext RPS

@sebastienros PTAL