### PR TITLE
set WaitForDataBeforeAllocatingBuffer to false for PlatformBenchmarks

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -33,6 +33,10 @@ namespace PlatformBenchmarks
                 {
                     options.IOQueueCount = theadCount.Value;
                 }
+
+#if NETCOREAPP5_0
+                options.WaitForDataBeforeAllocatingBuffer = false;
+#endif
             });
 
             return builder;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -15,23 +15,11 @@ namespace PlatformBenchmarks
         {
             builder.UseConfiguration(configuration);
 
-            // Handle the transport type
-            var webHost = builder.GetSetting("KestrelTransport");
-
-            // Handle the thread count
-            var threadCountRaw = builder.GetSetting("threadCount");
-            int? theadCount = null;
-
-            if (!string.IsNullOrEmpty(threadCountRaw) && Int32.TryParse(threadCountRaw, out var value))
-            {
-                theadCount = value;
-            }
-
             builder.UseSockets(options =>
             {
-                if (theadCount.HasValue)
+                if (int.TryParse(builder.GetSetting("threadCount"), out int threadCount))
                 {
-                    options.IOQueueCount = theadCount.Value;
+                    options.IOQueueCount = threadCount;
                 }
 
 #if NETCOREAPP5_0


### PR DESCRIPTION
It's a follow up of https://github.com/dotnet/aspnetcore/pull/19396

It gives +15k RPS for JSON and something around +30k RPS for Plaintext at a cost of 2MB of increased working set (for 256 connections)

/cc @tmds @sebastienros 