### PR TITLE
create writer once per request, reduce the number of calls to pipe.GetSpan and pipe.Advance

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -54,26 +54,24 @@ namespace PlatformBenchmarks
             _requestType = requestType;
         }
 
-        public void ProcessRequest()
+        private void ProcessRequest(ref BufferWriter<WriterAdapter> writer)
         {
             if (_requestType == RequestType.PlainText)
             {
-                PlainText(Writer);
+                PlainText(ref writer);
             }
             else if (_requestType == RequestType.Json)
             {
-                Json(Writer);
+                Json(ref writer);
             }
             else
             {
-                Default(Writer);
+                Default(ref writer);
             }
         }
 
-        private static void PlainText(PipeWriter pipeWriter)
+        private static void PlainText(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -95,13 +93,10 @@ namespace PlatformBenchmarks
 
             // Body
             writer.Write(_plainTextBody);
-            writer.Commit();
         }
 
-        private static void Json(PipeWriter pipeWriter)
+        private static void Json(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -124,13 +119,10 @@ namespace PlatformBenchmarks
 
             // Body
             writer.Write(jsonPayload);
-            writer.Commit();
         }
 
-        private static void Default(PipeWriter pipeWriter)
+        private static void Default(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -145,7 +137,6 @@ namespace PlatformBenchmarks
 
             // End of headers
             writer.Write(_crlf);
-            writer.Commit();
         }
 
         private enum RequestType

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
@@ -17,7 +17,7 @@ namespace PlatformBenchmarks
         {
             _buffered = 0;
             _output = output;
-            _span = output.GetSpan();
+            _span = output.GetSpan(sizeHint: 16 * 160);
         }
 
         public Span<byte> Span => _span;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/IHttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/IHttpConnection.cs
@@ -11,7 +11,7 @@ namespace PlatformBenchmarks
     {
         PipeReader Reader { get; set; }
         PipeWriter Writer { get; set; }
+
         Task ExecuteAsync();
-        ValueTask OnReadCompletedAsync();
     }
 }


### PR DESCRIPTION
+200k RPS for Plaintext (from 8.2kk to 8.5kk) and no regression for JsonPlatform ;)

the gain is from:

* creating the writer once which calls `pipe.GetSpan` which might acquire a lock 
* delaying the commit which calls `pipe.Advance` which always takes a lock

@davidfowl 

