### PR TITLE
Platform TechEmpower/FrameworkBenchmarks sync

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private async Task Fortunes(PipeWriter pipeWriter)
+        {
+            OutputFortunes(pipeWriter, await Db.LoadFortunesRows());
+        }
+
+        private void OutputFortunes(PipeWriter pipeWriter, List<Fortune> model)
+        {
+            var writer = GetWriter(pipeWriter);
+
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeHtml);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+
+            var lengthWriter = writer;
+            writer.Write(_contentLengthGap);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            var bodyStart = writer.Buffered;
+            // Body
+            writer.Write(_fortunesTableStart);
+            foreach (var item in model)
+            {
+                writer.Write(_fortunesRowStart);
+                writer.WriteNumeric((uint)item.Id);
+                writer.Write(_fortunesColumn);
+                writer.WriteUtf8String(HtmlEncoder.Encode(item.Message));
+                writer.Write(_fortunesRowEnd);
+            }
+            writer.Write(_fortunesTableEnd);
+            lengthWriter.WriteNumeric((uint)(writer.Buffered - bodyStart));
+
+            writer.Commit();
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text.Json;
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private static void Json(ref BufferWriter<WriterAdapter> writer)
+        {
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeJson);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions);
+            writer.WriteNumeric((uint)jsonPayload.Length);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            // Body
+            writer.Write(jsonPayload);
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Pipelines;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private async Task MultipleQueries(PipeWriter pipeWriter, int count)
+        {
+            OutputMultipleQueries(pipeWriter, await Db.LoadMultipleQueriesRows(count));
+        }
+
+        private static void OutputMultipleQueries(PipeWriter pipeWriter, World[] rows)
+        {
+            var writer = GetWriter(pipeWriter);
+
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeJson);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(rows, SerializerOptions);
+            writer.WriteNumeric((uint)jsonPayload.Length);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            // Body
+            writer.Write(jsonPayload);
+            writer.Commit();
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Plaintext.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Plaintext.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private static void PlainText(ref BufferWriter<WriterAdapter> writer)
+        {
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeText);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            writer.WriteNumeric((uint)_plainTextBody.Length);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            // Body
+            writer.Write(_plainTextBody);
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Pipelines;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private async Task SingleQuery(PipeWriter pipeWriter)
+        {
+            OutputSingleQuery(pipeWriter, await Db.LoadSingleQueryRow());
+        }
+
+        private static void OutputSingleQuery(PipeWriter pipeWriter, World row)
+        {
+            var writer = GetWriter(pipeWriter);
+
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeJson);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(row, SerializerOptions);
+            writer.WriteNumeric((uint)jsonPayload.Length);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            // Body
+            writer.Write(jsonPayload);
+            writer.Commit();
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO.Pipelines;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PlatformBenchmarks
+{
+    public partial class BenchmarkApplication
+    {
+        private async Task Updates(PipeWriter pipeWriter, int count)
+        {
+            OutputUpdates(pipeWriter, await Db.LoadMultipleUpdatesRows(count));
+        }
+
+        private static void OutputUpdates(PipeWriter pipeWriter, World[] rows)
+        {
+            var writer = GetWriter(pipeWriter);
+
+            // HTTP 1.1 OK
+            writer.Write(_http11OK);
+
+            // Server headers
+            writer.Write(_headerServer);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            // Content-Type header
+            writer.Write(_headerContentTypeJson);
+
+            // Content-Length header
+            writer.Write(_headerContentLength);
+            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(rows, SerializerOptions);
+            writer.WriteNumeric((uint)jsonPayload.Length);
+
+            // End of headers
+            writer.Write(_eoh);
+
+            // Body
+            writer.Write(jsonPayload);
+            writer.Commit();
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -54,26 +54,24 @@ namespace PlatformBenchmarks
             _requestType = requestType;
         }
 
-        public void ProcessRequest()
+        private void ProcessRequest(ref BufferWriter<WriterAdapter> writer)
         {
             if (_requestType == RequestType.PlainText)
             {
-                PlainText(Writer);
+                PlainText(ref writer);
             }
             else if (_requestType == RequestType.Json)
             {
-                Json(Writer);
+                Json(ref writer);
             }
             else
             {
-                Default(Writer);
+                Default(ref writer);
             }
         }
 
-        private static void PlainText(PipeWriter pipeWriter)
+        private static void PlainText(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -95,13 +93,10 @@ namespace PlatformBenchmarks
 
             // Body
             writer.Write(_plainTextBody);
-            writer.Commit();
         }
 
-        private static void Json(PipeWriter pipeWriter)
+        private static void Json(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -124,13 +119,10 @@ namespace PlatformBenchmarks
 
             // Body
             writer.Write(jsonPayload);
-            writer.Commit();
         }
 
-        private static void Default(PipeWriter pipeWriter)
+        private static void Default(ref BufferWriter<WriterAdapter> writer)
         {
-            var writer = GetWriter(pipeWriter);
-
             // HTTP 1.1 OK
             writer.Write(_http11OK);
 
@@ -145,7 +137,6 @@ namespace PlatformBenchmarks
 
             // End of headers
             writer.Write(_crlf);
-            writer.Commit();
         }
 
         private enum RequestType

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers.Text;
 using System.IO.Pipelines;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -23,37 +23,77 @@ namespace PlatformBenchmarks
         private readonly static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
         private readonly static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
         private readonly static AsciiString _headerContentTypeJson = "Content-Type: application/json\r\n";
+        private readonly static AsciiString _headerContentTypeHtml = "Content-Type: text/html; charset=UTF-8\r\n";
 
         private readonly static AsciiString _plainTextBody = "Hello, World!";
 
         private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions();
 
+        private readonly static AsciiString _fortunesTableStart = "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>";
+        private readonly static AsciiString _fortunesRowStart = "<tr><td>";
+        private readonly static AsciiString _fortunesColumn = "</td><td>";
+        private readonly static AsciiString _fortunesRowEnd = "</td></tr>";
+        private readonly static AsciiString _fortunesTableEnd = "</table></body></html>";
+        private readonly static AsciiString _contentLengthGap = new string(' ', 4);
+
+        public static RawDb Db { get; set; }
+
         public static class Paths
         {
-            public readonly static AsciiString Plaintext = "/plaintext";
+            public readonly static AsciiString SingleQuery = "/db";
             public readonly static AsciiString Json = "/json";
+            public readonly static AsciiString Fortunes = "/fortunes";
+            public readonly static AsciiString Plaintext = "/plaintext";
+            public readonly static AsciiString Updates = "/updates/queries=";
+            public readonly static AsciiString MultipleQueries = "/queries/queries=";
         }
 
         private RequestType _requestType;
-
+#if DATABASE
+        private int _queries;
+#endif
         public void OnStartLine(HttpMethod method, HttpVersion version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
         {
             var requestType = RequestType.NotRecognized;
             if (method == HttpMethod.Get)
             {
-                if (Paths.Plaintext.Length <= path.Length && path.StartsWith(Paths.Plaintext))
-                {
-                    requestType = RequestType.PlainText;
-                }
-                else if (Paths.Json.Length <= path.Length && path.StartsWith(Paths.Json))
+                var pathLength = path.Length;
+#if !DATABASE
+                if (Paths.Json.Length <= pathLength && path.StartsWith(Paths.Json))
                 {
                     requestType = RequestType.Json;
                 }
+                else if (Paths.Plaintext.Length <= pathLength && path.StartsWith(Paths.Plaintext))
+                {
+                    requestType = RequestType.PlainText;
+                }
+#else
+                if (Paths.SingleQuery.Length <= pathLength && path.StartsWith(Paths.SingleQuery))
+                {
+                    requestType = RequestType.SingleQuery;
+                }
+                else if (Paths.Fortunes.Length <= pathLength && path.StartsWith(Paths.Fortunes))
+                {
+                    requestType = RequestType.Fortunes;
+                }
+                else if (Paths.Updates.Length <= pathLength && path.StartsWith(Paths.Updates))
+                {
+                    _queries = ParseQueries(path, Paths.Updates.Length);
+                    requestType = RequestType.Updates;
+                }
+                else if (Paths.MultipleQueries.Length <= pathLength && path.StartsWith(Paths.MultipleQueries))
+                {
+                    _queries = ParseQueries(path, Paths.MultipleQueries.Length);
+                    requestType = RequestType.MultipleQueries;
+                }
+#endif
             }
 
             _requestType = requestType;
         }
 
+
+#if !DATABASE
         private void ProcessRequest(ref BufferWriter<WriterAdapter> writer)
         {
             if (_requestType == RequestType.PlainText)
@@ -69,58 +109,57 @@ namespace PlatformBenchmarks
                 Default(ref writer);
             }
         }
-
-        private static void PlainText(ref BufferWriter<WriterAdapter> writer)
+#else
+        private static int ParseQueries(Span<byte> path, int pathLength)
         {
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
+            if (!Utf8Parser.TryParse(path.Slice(pathLength), out int queries, out _) || queries < 1)
+            {
+                queries = 1;
+            }
+            else if (queries > 500)
+            {
+                queries = 500;
+            }
 
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeText);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
-            writer.WriteNumeric((uint)_plainTextBody.Length);
-
-            // End of headers
-            writer.Write(_eoh);
-
-            // Body
-            writer.Write(_plainTextBody);
+            return queries;
         }
 
-        private static void Json(ref BufferWriter<WriterAdapter> writer)
+        private Task ProcessRequestAsync()
         {
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
+            Task task;
+            var requestType = _requestType;
+            if (requestType == RequestType.Fortunes)
+            {
+                task = Fortunes(Writer);
+            }
+            else if (requestType == RequestType.SingleQuery)
+            {
+                task = SingleQuery(Writer);
+            }
+            else if (requestType == RequestType.Updates)
+            {
+                task = Updates(Writer, _queries);
+            }
+            else if (requestType == RequestType.MultipleQueries)
+            {
+                task = MultipleQueries(Writer, _queries);
+            }
+            else
+            {
+                Default(Writer);
+                task = Task.CompletedTask;
+            }
 
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeJson);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
-            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions);
-            writer.WriteNumeric((uint)jsonPayload.Length);
-
-            // End of headers
-            writer.Write(_eoh);
-
-            // Body
-            writer.Write(jsonPayload);
+            return task;
         }
 
+        private static void Default(PipeWriter pipeWriter)
+        {
+            var writer = GetWriter(pipeWriter);
+            Default(ref writer);
+            writer.Commit();
+        }
+#endif
         private static void Default(ref BufferWriter<WriterAdapter> writer)
         {
             // HTTP 1.1 OK
@@ -143,12 +182,11 @@ namespace PlatformBenchmarks
         {
             NotRecognized,
             PlainText,
-            Json
-        }
-
-        public struct JsonMessage
-        {
-            public string message { get; set; }
+            Json,
+            Fortunes,
+            SingleQuery,
+            Updates,
+            MultipleQueries
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferExtensions.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace PlatformBenchmarks
 {
@@ -18,6 +19,15 @@ namespace PlatformBenchmarks
 
         [ThreadStatic]
         private static byte[] _numericBytesScratch;
+
+        internal static void WriteUtf8String<T>(ref this BufferWriter<T> buffer, string text)
+             where T : struct, IBufferWriter<byte>
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(text);
+            buffer.Ensure(byteCount);
+            byteCount = Encoding.UTF8.GetBytes(text.AsSpan(), buffer.Span);
+            buffer.Advance(byteCount);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static unsafe void WriteNumeric<T>(ref this BufferWriter<T> buffer, uint number)

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
@@ -22,6 +22,8 @@ namespace PlatformBenchmarks
 
         public Span<byte> Span => _span;
 
+        public int Buffered => _buffered;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Commit()
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
@@ -17,7 +17,7 @@ namespace PlatformBenchmarks
         {
             _buffered = 0;
             _output = output;
-            _span = output.GetSpan();
+            _span = output.GetSpan(sizeHint: 16 * 160);
         }
 
         public Span<byte> Span => _span;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Configuration/AppSettings.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Configuration/AppSettings.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace PlatformBenchmarks
+{
+    public class AppSettings
+    {
+        public string ConnectionString { get; set; }
+
+        public DatabaseServer Database { get; set; } = DatabaseServer.None;
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Configuration/DatabaseServer.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Configuration/DatabaseServer.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+namespace PlatformBenchmarks
+{
+    public enum DatabaseServer
+    {
+        None,
+        SqlServer,
+        PostgreSql,
+        MySql
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace PlatformBenchmarks
+{
+    internal class BatchUpdateString
+    {
+        private const int MaxBatch = 500;
+
+        private static string[] _queries = new string[MaxBatch+1];
+
+        public static DatabaseServer DatabaseServer;
+
+        public static string Query(int batchSize)
+        {
+            if (_queries[batchSize] != null)
+            {
+                return _queries[batchSize];
+            }
+
+            var lastIndex = batchSize - 1;
+
+            var sb = StringBuilderCache.Acquire();
+
+            if (DatabaseServer == DatabaseServer.PostgreSql)
+            {
+                sb.Append("UPDATE world SET randomNumber = temp.randomNumber FROM (VALUES ");
+                Enumerable.Range(0, lastIndex).ToList().ForEach(i => sb.Append($"(@Id_{i}, @Random_{i}), "));
+                sb.Append($"(@Id_{lastIndex}, @Random_{lastIndex}) ORDER BY 1) AS temp(id, randomNumber) WHERE temp.id = world.id");
+            }
+            else
+            {
+                Enumerable.Range(0, batchSize).ToList().ForEach(i => sb.Append($"UPDATE world SET randomnumber = @Random_{i} WHERE id = @Id_{i};"));
+            }
+
+            return _queries[batchSize] = StringBuilderCache.GetStringAndRelease(sb);
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/Fortune.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/Fortune.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+
+namespace PlatformBenchmarks
+{
+    public class Fortune : IComparable<Fortune>, IComparable
+    {
+        public int Id { get; set; }
+
+        public string Message { get; set; }
+        
+        public int CompareTo(object obj)
+        {
+            return CompareTo((Fortune)obj);
+        }
+
+        public int CompareTo(Fortune other)
+        {
+            // Performance critical, using culture insensitive comparison
+            return String.CompareOrdinal(Message, other.Message);
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/JsonMessage.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/JsonMessage.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace PlatformBenchmarks
+{
+    public struct JsonMessage
+    {
+        public string message { get; set; }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/Random.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/Random.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace PlatformBenchmarks
+{
+    public class ConcurrentRandom
+    {
+        private static int nextSeed = 0;
+
+        // Random isn't thread safe
+        [ThreadStatic]
+        private static Random _random;
+
+        private static Random Random => _random ?? CreateRandom();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Random CreateRandom()
+        {
+            _random = new Random(Interlocked.Increment(ref nextSeed));
+            return _random;
+        }
+
+        public int Next(int minValue, int maxValue)
+        {
+            return Random.Next(minValue, maxValue);
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+namespace PlatformBenchmarks
+{
+    public class RawDb
+    {
+        private static readonly Comparison<World> WorldSortComparison = (a, b) => a.Id.CompareTo(b.Id);
+
+        private readonly ConcurrentRandom _random;
+        private readonly DbProviderFactory _dbProviderFactory;
+        private readonly string _connectionString;
+
+        public RawDb(ConcurrentRandom random, DbProviderFactory dbProviderFactory, AppSettings appSettings)
+        {
+            _random = random;
+            _dbProviderFactory = dbProviderFactory;
+            _connectionString = appSettings.ConnectionString;
+        }
+
+        public async Task<World> LoadSingleQueryRow()
+        {
+            using (var db = _dbProviderFactory.CreateConnection())
+            {
+                db.ConnectionString = _connectionString;
+                await db.OpenAsync();
+
+                using (var cmd = CreateReadCommand(db))
+                {
+                    return await ReadSingleRow(db, cmd);
+                }
+            }
+        }
+
+        async Task<World> ReadSingleRow(DbConnection connection, DbCommand cmd)
+        {
+            using (var rdr = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow))
+            {
+                await rdr.ReadAsync();
+
+                return new World
+                {
+                    Id = rdr.GetInt32(0),
+                    RandomNumber = rdr.GetInt32(1)
+                };
+            }
+        }
+
+        DbCommand CreateReadCommand(DbConnection connection)
+        {
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT id, randomnumber FROM world WHERE id = @Id";
+            var id = cmd.CreateParameter();
+            id.ParameterName = "@Id";
+            id.DbType = DbType.Int32;
+            id.Value = _random.Next(1, 10001);
+            cmd.Parameters.Add(id);
+
+            (cmd as MySql.Data.MySqlClient.MySqlCommand)?.Prepare();
+
+            return cmd;
+        }
+
+
+        public async Task<World[]> LoadMultipleQueriesRows(int count)
+        {
+            var result = new World[count];
+
+            using (var db = _dbProviderFactory.CreateConnection())
+            {
+                db.ConnectionString = _connectionString;
+                await db.OpenAsync();
+                using (var cmd = CreateReadCommand(db))
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        result[i] = await ReadSingleRow(db, cmd);
+                        cmd.Parameters["@Id"].Value = _random.Next(1, 10001);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public async Task<World[]> LoadMultipleUpdatesRows(int count)
+        {
+            using (var db = _dbProviderFactory.CreateConnection())
+            {
+                db.ConnectionString = _connectionString;
+                await db.OpenAsync();
+
+                using (var updateCmd = db.CreateCommand())
+                using (var queryCmd = CreateReadCommand(db))
+                {
+                    var results = new World[count];
+                    for (int i = 0; i < count; i++)
+                    {
+                        results[i] = await ReadSingleRow(db, queryCmd);
+                        queryCmd.Parameters["@Id"].Value = _random.Next(1, 10001);
+                    }
+
+                    updateCmd.CommandText = BatchUpdateString.Query(count);
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        var id = updateCmd.CreateParameter();
+                        id.ParameterName = $"@Id_{i}";
+                        id.DbType = DbType.Int32;
+                        updateCmd.Parameters.Add(id);
+
+                        var random = updateCmd.CreateParameter();
+                        random.ParameterName = $"@Random_{i}";
+                        random.DbType = DbType.Int32;
+                        updateCmd.Parameters.Add(random);
+
+                        var randomNumber = _random.Next(1, 10001);
+                        id.Value = results[i].Id;
+                        random.Value = randomNumber;
+                        results[i].RandomNumber = randomNumber;
+                    }
+
+                    await updateCmd.ExecuteNonQueryAsync();
+                    return results;
+                }
+            }
+        }
+
+        public async Task<List<Fortune>> LoadFortunesRows()
+        {
+            var result = new List<Fortune>();
+
+            using (var db = _dbProviderFactory.CreateConnection())
+            using (var cmd = db.CreateCommand())
+            {
+                cmd.CommandText = "SELECT id, message FROM fortune";
+
+                db.ConnectionString = _connectionString;
+                await db.OpenAsync();
+
+                (cmd as MySql.Data.MySqlClient.MySqlCommand)?.Prepare();
+
+                using (var rdr = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection))
+                {
+                    while (await rdr.ReadAsync())
+                    {
+                        result.Add(new Fortune
+                        {
+                            Id = rdr.GetInt32(0),
+                            Message = rdr.GetString(1)
+                        });
+                    }
+                }
+            }
+
+            result.Add(new Fortune { Message = "Additional fortune added at request time." });
+            result.Sort();
+
+            return result;
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/World.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/World.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace PlatformBenchmarks
+{
+    [StructLayout(LayoutKind.Sequential, Size = 8)]
+    public struct World
+    {
+        public int Id { get; set; }
+
+        public int RandomNumber { get; set; }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/IHttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/IHttpConnection.cs
@@ -11,7 +11,7 @@ namespace PlatformBenchmarks
     {
         PipeReader Reader { get; set; }
         PipeWriter Writer { get; set; }
+
         Task ExecuteAsync();
-        ValueTask OnReadCompletedAsync();
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,14 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestAssetProject>true</IsTestAssetProject>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(IsDatabase)' == 'true' ">$(DefineConstants);DATABASE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsDatabase)' == 'true'">
+    <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+    
+    <PackageReference Include="Npgsql" Version="4.1.2" />
+    <PackageReference Include="MySqlConnector" Version="0.62.0-beta5" />
+    <PackageReference Include="RedHat.AspNetCore.Server.Kestrel.Transport.Linux" Version="3.0.0-*" />
+  </ItemGroup>
+  
   <!-- These references are used when running on the Benchmarks Server -->
   <ItemGroup Condition="'$(BenchmarksTargetFramework)' != ''">
     <FrameworkReference Update="Microsoft.AspNetCore.App" RuntimeFrameworkVersion="$(MicrosoftAspNetCoreAppPackageVersion)" />

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Program.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Program.cs
@@ -5,33 +5,66 @@ using System;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+#if DATABASE
+using Npgsql;
+using MySql.Data.MySqlClient;
+#endif
 
 namespace PlatformBenchmarks
 {
     public class Program
     {
+        public static string[] Args;
+
         public static void Main(string[] args)
         {
+            Args = args;
+
             Console.WriteLine(BenchmarkApplication.ApplicationName);
+#if !DATABASE
             Console.WriteLine(BenchmarkApplication.Paths.Plaintext);
             Console.WriteLine(BenchmarkApplication.Paths.Json);
+#else
+            Console.WriteLine(BenchmarkApplication.Paths.Fortunes);
+            Console.WriteLine(BenchmarkApplication.Paths.SingleQuery);
+            Console.WriteLine(BenchmarkApplication.Paths.Updates);
+            Console.WriteLine(BenchmarkApplication.Paths.MultipleQueries);
+#endif
             DateHeader.SyncDateTimer();
 
-            BuildWebHost(args).Run();
+            var host = BuildWebHost(args);
+            var config = (IConfiguration)host.Services.GetService(typeof(IConfiguration));
+            BatchUpdateString.DatabaseServer = config.Get<AppSettings>().Database;
+            host.Run();
         }
 
         public static IWebHost BuildWebHost(string[] args)
         {
             var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
                 .AddEnvironmentVariables(prefix: "ASPNETCORE_")
                 .AddCommandLine(args)
                 .Build();
+
+            var appSettings = config.Get<AppSettings>();
+#if DATABASE
+            Console.WriteLine($"Database: {appSettings.Database}");
+
+            if (appSettings.Database == DatabaseServer.PostgreSql)
+            {
+                BenchmarkApplication.Db = new RawDb(new ConcurrentRandom(), NpgsqlFactory.Instance, appSettings);
+            }
+            else if (appSettings.Database == DatabaseServer.MySql)
+            {
+                BenchmarkApplication.Db = new RawDb(new ConcurrentRandom(), MySqlClientFactory.Instance, appSettings);
+            }
+#endif
 
             var host = new WebHostBuilder()
                 .UseBenchmarksConfiguration(config)
                 .UseKestrel((context, options) =>
                 {
-                    IPEndPoint endPoint = context.Configuration.CreateIPEndPoint();
+                    var endPoint = context.Configuration.CreateIPEndPoint();
 
                     options.Listen(endPoint, builder =>
                     {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/StringBuilderCache.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/StringBuilderCache.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved. 
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using System;
+using System.Text;
+
+namespace PlatformBenchmarks
+{
+    internal static class StringBuilderCache
+    {
+        private const int DefaultCapacity = 1386;
+        private const int MaxBuilderSize = DefaultCapacity * 3;
+
+        [ThreadStatic]
+        private static StringBuilder t_cachedInstance;
+
+        /// <summary>Get a StringBuilder for the specified capacity.</summary>
+        /// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
+        public static StringBuilder Acquire(int capacity = DefaultCapacity)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                StringBuilder sb = t_cachedInstance;
+                if (capacity < DefaultCapacity)
+                {
+                    capacity = DefaultCapacity;
+                }
+
+                if (sb != null)
+                {
+                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // when the requested size is larger than the current capacity
+                    if (capacity <= sb.Capacity)
+                    {
+                        t_cachedInstance = null;
+                        sb.Clear();
+                        return sb;
+                    }
+                }
+            }
+            return new StringBuilder(capacity);
+        }
+
+        public static void Release(StringBuilder sb)
+        {
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                t_cachedInstance = sb;
+            }
+        }
+
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            string result = sb.ToString();
+            Release(sb);
+            return result;
+        }
+    }
+}

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/appsettings.json
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-Benchmarks;Trusted_Connection=True;MultipleActiveResultSets=true"
+}


### PR DESCRIPTION
aspnet/Benchmarks is out of sync with TechEmpower/FrameworkBenchmarks so optimizations applied here aren't applicable there; this syncs the two repos to they are inline.

Includes @adamsitnik's approved PR https://github.com/aspnet/Benchmarks/pull/1470

Deadline is closing https://twitter.com/TFBenchmarks/status/1244634366510125058

> Round 19 will be running in April. We're still accepting last-minute pull requests for a few more days.

Corresponding TE sync https://github.com/TechEmpower/FrameworkBenchmarks/pull/5579

/cc @adamsitnik @sebastienros @halter73 