### PR TITLE
Using smaller routes

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/AsciiString.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/AsciiString.cs
@@ -12,6 +12,8 @@ namespace PlatformBenchmarks
 
         public AsciiString(string s) => _data = Encoding.ASCII.GetBytes(s);
 
+        private AsciiString(byte[] b) => _data = b;
+
         public int Length => _data.Length;
 
         public ReadOnlySpan<byte> AsSpan() => _data;
@@ -30,6 +32,14 @@ namespace PlatformBenchmarks
         public static bool operator ==(AsciiString a, AsciiString b) => a.Equals(b);
         public static bool operator !=(AsciiString a, AsciiString b) => !a.Equals(b);
         public override bool Equals(object other) => (other is AsciiString) && Equals((AsciiString)other);
+
+        public static AsciiString operator +(AsciiString a, AsciiString b)
+        {
+            var result = new byte[a.Length + b.Length];
+            a._data.CopyTo(result, 0);
+            b._data.CopyTo(result, a.Length);
+            return new AsciiString(result);
+        }
 
         public override int GetHashCode()
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
@@ -10,6 +10,12 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
+        private readonly static AsciiString _fortunesPreamble =
+            _http11OK +
+            _headerServer + _crlf +
+            _headerContentTypeHtml + _crlf +
+            _headerContentLength;
+
         private async Task Fortunes(PipeWriter pipeWriter)
         {
             OutputFortunes(pipeWriter, await Db.LoadFortunesRows());
@@ -19,26 +25,13 @@ namespace PlatformBenchmarks
         {
             var writer = GetWriter(pipeWriter);
 
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
-
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeHtml);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
+            writer.Write(_fortunesPreamble);
 
             var lengthWriter = writer;
             writer.Write(_contentLengthGap);
 
-            // End of headers
-            writer.Write(_eoh);
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
 
             var bodyStart = writer.Buffered;
             // Body

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -7,30 +7,28 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
+        private static readonly uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions).Length;
+
+        private readonly static AsciiString _jsonPreamble =
+            _http11OK +
+            _headerServer + _crlf +
+            _headerContentTypeJson + _crlf +
+            _headerContentLength + _jsonPayloadSize.ToString();
+
         private static void Json(ref BufferWriter<WriterAdapter> writer)
         {
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
-
-            // Server headers
-            writer.Write(_headerServer);
+            writer.Write(_jsonPreamble);
 
             // Date header
             writer.Write(DateHeader.HeaderBytes);
 
-            // Content-Type header
-            writer.Write(_headerContentTypeJson);
+            writer.Commit();
 
-            // Content-Length header
-            writer.Write(_headerContentLength);
-            var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions);
-            writer.WriteNumeric((uint)jsonPayload.Length);
-
-            // End of headers
-            writer.Write(_eoh);
-
-            // Body
-            writer.Write(jsonPayload);
+            using var utf8jsonWriter = new Utf8JsonWriter(writer.Output);
+            JsonSerializer.Serialize(
+                utf8jsonWriter,
+                new JsonMessage { message = "Hello, World!" },
+                SerializerOptions);
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
@@ -18,25 +18,14 @@ namespace PlatformBenchmarks
         {
             var writer = GetWriter(pipeWriter);
 
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
+            writer.Write(_dbPreamble);
 
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeJson);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
+            // Content-Length
             var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(rows, SerializerOptions);
             writer.WriteNumeric((uint)jsonPayload.Length);
 
-            // End of headers
-            writer.Write(_eoh);
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
 
             // Body
             writer.Write(jsonPayload);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Plaintext.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Plaintext.cs
@@ -5,26 +5,18 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
+        private readonly static AsciiString _plaintextPreamble =
+            _http11OK +
+            _headerServer + _crlf +
+            _headerContentTypeText + _crlf +
+            _headerContentLength + _plainTextBody.Length.ToString();
+
         private static void PlainText(ref BufferWriter<WriterAdapter> writer)
         {
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
-
-            // Server headers
-            writer.Write(_headerServer);
+            writer.Write(_plaintextPreamble);
 
             // Date header
             writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeText);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
-            writer.WriteNumeric((uint)_plainTextBody.Length);
-
-            // End of headers
-            writer.Write(_eoh);
 
             // Body
             writer.Write(_plainTextBody);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
@@ -18,25 +18,14 @@ namespace PlatformBenchmarks
         {
             var writer = GetWriter(pipeWriter);
 
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
+            writer.Write(_dbPreamble);
 
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeJson);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
+            // Content-Length
             var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(row, SerializerOptions);
             writer.WriteNumeric((uint)jsonPayload.Length);
 
-            // End of headers
-            writer.Write(_eoh);
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
 
             // Body
             writer.Write(jsonPayload);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
@@ -18,25 +18,14 @@ namespace PlatformBenchmarks
         {
             var writer = GetWriter(pipeWriter);
 
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
+            writer.Write(_dbPreamble);
 
-            // Server headers
-            writer.Write(_headerServer);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Type header
-            writer.Write(_headerContentTypeJson);
-
-            // Content-Length header
-            writer.Write(_headerContentLength);
+            // Content-Length
             var jsonPayload = JsonSerializer.SerializeToUtf8Bytes(rows, SerializerOptions);
             writer.WriteNumeric((uint)jsonPayload.Length);
 
-            // End of headers
-            writer.Write(_eoh);
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
 
             // Body
             writer.Write(jsonPayload);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -18,7 +18,7 @@ namespace PlatformBenchmarks
         private readonly static AsciiString _crlf = "\r\n";
         private readonly static AsciiString _eoh = "\r\n\r\n"; // End Of Headers
         private readonly static AsciiString _http11OK = "HTTP/1.1 200 OK\r\n";
-        private readonly static AsciiString _headerServer = "Server: Custom";
+        private readonly static AsciiString _headerServer = "Server: K";
         private readonly static AsciiString _headerContentLength = "Content-Length: ";
         private readonly static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
         private readonly static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
@@ -57,17 +57,20 @@ namespace PlatformBenchmarks
             var requestType = RequestType.NotRecognized;
             if (method == HttpMethod.Get)
             {
-                var pathLength = path.Length;
 #if !DATABASE
-                if (Paths.Json.Length <= pathLength && path.StartsWith(Paths.Json))
+                if (path.Length >= 2 && path[0] == '/')
                 {
-                    requestType = RequestType.Json;
-                }
-                else if (Paths.Plaintext.Length <= pathLength && path.StartsWith(Paths.Plaintext))
-                {
-                    requestType = RequestType.PlainText;
+                    if (path[1] == 'j')
+                    {
+                        requestType = RequestType.Json;
+                    }
+                    else if (path[1] == 'p')
+                    {
+                        requestType = RequestType.PlainText;
+                    }
                 }
 #else
+                var pathLength = path.Length;
                 if (Paths.SingleQuery.Length <= pathLength && path.StartsWith(Paths.SingleQuery))
                 {
                     requestType = RequestType.SingleQuery;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -41,9 +41,9 @@ namespace PlatformBenchmarks
         public static class Paths
         {
             public readonly static AsciiString SingleQuery = "/db";
-            public readonly static AsciiString Json = "/json";
+            public readonly static AsciiString Json = "/j";
             public readonly static AsciiString Fortunes = "/fortunes";
-            public readonly static AsciiString Plaintext = "/plaintext";
+            public readonly static AsciiString Plaintext = "/p";
             public readonly static AsciiString Updates = "/updates/queries=";
             public readonly static AsciiString MultipleQueries = "/queries/queries=";
         }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -20,7 +20,7 @@ namespace PlatformBenchmarks
         private readonly static AsciiString _http11OK = "HTTP/1.1 200 OK\r\n";
         private readonly static AsciiString _headerServer = "Server: K";
         private readonly static AsciiString _headerContentLength = "Content-Length: ";
-        private readonly static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
+        private readonly static AsciiString _headerContentLengthZero = "Content-Length: 0";
         private readonly static AsciiString _headerContentTypeText = "Content-Type: text/plain";
         private readonly static AsciiString _headerContentTypeJson = "Content-Type: application/json";
         private readonly static AsciiString _headerContentTypeHtml = "Content-Type: text/html; charset=UTF-8";

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -21,9 +21,15 @@ namespace PlatformBenchmarks
         private readonly static AsciiString _headerServer = "Server: K";
         private readonly static AsciiString _headerContentLength = "Content-Length: ";
         private readonly static AsciiString _headerContentLengthZero = "Content-Length: 0\r\n";
-        private readonly static AsciiString _headerContentTypeText = "Content-Type: text/plain\r\n";
-        private readonly static AsciiString _headerContentTypeJson = "Content-Type: application/json\r\n";
-        private readonly static AsciiString _headerContentTypeHtml = "Content-Type: text/html; charset=UTF-8\r\n";
+        private readonly static AsciiString _headerContentTypeText = "Content-Type: text/plain";
+        private readonly static AsciiString _headerContentTypeJson = "Content-Type: application/json";
+        private readonly static AsciiString _headerContentTypeHtml = "Content-Type: text/html; charset=UTF-8";
+
+        private readonly static AsciiString _dbPreamble =
+            _http11OK +
+            _headerServer + _crlf +
+            _headerContentTypeJson + _crlf +
+            _headerContentLength;
 
         private readonly static AsciiString _plainTextBody = "Hello, World!";
 
@@ -163,22 +169,18 @@ namespace PlatformBenchmarks
             writer.Commit();
         }
 #endif
+        private readonly static AsciiString _defaultPreamble =
+            _http11OK +
+            _headerServer + _crlf +
+            _headerContentTypeText + _crlf +
+            _headerContentLengthZero;
+
         private static void Default(ref BufferWriter<WriterAdapter> writer)
         {
-            // HTTP 1.1 OK
-            writer.Write(_http11OK);
-
-            // Server headers
-            writer.Write(_headerServer);
+            writer.Write(_defaultPreamble);
 
             // Date header
             writer.Write(DateHeader.HeaderBytes);
-
-            // Content-Length 0
-            writer.Write(_headerContentLengthZero);
-
-            // End of headers
-            writer.Write(_crlf);
         }
 
         private enum RequestType

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BufferWriter.cs
@@ -24,6 +24,8 @@ namespace PlatformBenchmarks
 
         public int Buffered => _buffered;
 
+        public T Output => _output;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Commit()
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/DateHeader.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/DateHeader.cs
@@ -23,18 +23,24 @@ namespace PlatformBenchmarks
             SetDateValues(DateTimeOffset.UtcNow);
         }, null, 1000, 1000);
 
-        private static byte[] s_headerBytesMaster = new byte[prefixLength + dateTimeRLength + suffixLength];
-        private static byte[] s_headerBytesScratch = new byte[prefixLength + dateTimeRLength + suffixLength];
+        private static byte[] s_headerBytesMaster = new byte[prefixLength + dateTimeRLength + 2 * suffixLength];
+        private static byte[] s_headerBytesScratch = new byte[prefixLength + dateTimeRLength + 2 * suffixLength];
 
         static DateHeader()
         {
             var utf8 = Encoding.ASCII.GetBytes("\r\nDate: ").AsSpan();
+
             utf8.CopyTo(s_headerBytesMaster);
             utf8.CopyTo(s_headerBytesScratch);
             s_headerBytesMaster[suffixIndex] = (byte)'\r';
             s_headerBytesMaster[suffixIndex + 1] = (byte)'\n';
+            s_headerBytesMaster[suffixIndex + 2] = (byte)'\r';
+            s_headerBytesMaster[suffixIndex + 3] = (byte)'\n';
             s_headerBytesScratch[suffixIndex] = (byte)'\r';
             s_headerBytesScratch[suffixIndex + 1] = (byte)'\n';
+            s_headerBytesScratch[suffixIndex + 2] = (byte)'\r';
+            s_headerBytesScratch[suffixIndex + 3] = (byte)'\n';
+
             SetDateValues(DateTimeOffset.UtcNow);
             SyncDateTimer();
         }
@@ -47,7 +53,7 @@ namespace PlatformBenchmarks
         {
             lock (s_headerBytesScratch)
             {
-                if (!Utf8Formatter.TryFormat(value, s_headerBytesScratch.AsSpan(prefixLength), out int written, 'R'))
+                if (!Utf8Formatter.TryFormat(value, s_headerBytesScratch.AsSpan(prefixLength), out var written, 'R'))
                 {
                     throw new Exception("date time format failed");
                 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.json.json
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.json.json
@@ -10,10 +10,10 @@
     }
   },
   "JsonPlatform": {
-    "Path": "/json"
+    "Path": "/j"
   },
   "JsonPlatform-Mono": {
-    "Path": "/json",
+    "Path": "/j",
     "UseMonoRuntime": true
   }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.plaintext.json
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.plaintext.json
@@ -14,14 +14,14 @@
     "Port": 8080
   },
   "PlaintextPlatform": {
-    "Path": "/plaintext"
+    "Path": "/p"
   },
   "PlaintextPlatform-Mono": {
-    "Path": "/plaintext",
+    "Path": "/p",
     "UseMonoRuntime":  true
   },
   "PlaintextNonPipelinedPlatform": {
-    "Path": "/plaintext",
+    "Path": "/p",
     "ClientProperties": {
       "ScriptName": "",
       "PipelineDepth": 0


### PR DESCRIPTION
Plaintext
Before: 8,455,689 
After: 8,527,662 

3 runs