### PR TITLE
Plaintext, Json, eagerly create SequenceReader

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -79,7 +79,7 @@ namespace PlatformBenchmarks
 
             while (true)
             {
-                if (!ParseHttpRequest(ref reader, in buffer, isCompleted))
+                if (!ParseHttpRequest(ref reader, isCompleted))
                 {
                     return false;
                 }
@@ -106,13 +106,17 @@ namespace PlatformBenchmarks
             return true;
         }
 
-        private bool ParseHttpRequest(ref SequenceReader<byte> reader, in ReadOnlySequence<byte> buffer, bool isCompleted)
+        private bool ParseHttpRequest(ref SequenceReader<byte> reader, bool isCompleted)
         {
             var state = _state;
 
             if (state == State.StartLine)
             {
-                var unconsumedSequence = buffer.Slice(reader.Position);
+#if NETCOREAPP5_0
+                var unconsumedSequence = reader.UnreadSequence;
+#else
+                var unconsumedSequence = reader.Sequence.Slice(reader.Position);
+#endif
                 if (Parser.ParseRequestLine(new ParsingAdapter(this), unconsumedSequence, out var consumed, out _))
                 {
                     state = State.Headers;


### PR DESCRIPTION
Breaks 1.17M RPS on localhost for my 6 core machine running both client and server: 
wrk (WSL2) <-> Kestrel (Windows)
```
ben@Ben-Desktop:~/wrk$ wrk http://172.29.144.1/p -t 6 -c 256 -s ./scripts/pipeline.lua -- 16
Running 10s test @ http://172.29.144.1/p
  6 threads and 256 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.04ms    5.19ms 104.43ms   89.32%
    Req/Sec   197.43k    44.55k  576.00k    74.83%
  11838304 requests in 10.10s, 1.39GB read
Requests/sec: 1172409.14
Transfer/sec:    140.88MB
```

/cc @adamsitnik @sebastienros 