### PR TITLE
retry SQL connection + fix StartMeasurement crash

### DIFF
--- a/src/BenchmarksDriver2/JobSerializer.cs
+++ b/src/BenchmarksDriver2/JobSerializer.cs
@@ -55,13 +55,18 @@ namespace BenchmarksDriver.Serializers
                 END
                 ";
 
-            using (var connection = new SqlConnection(connectionString))
-            {
-                await connection.OpenAsync();
+            await RetryOnExceptionAsync(5, () => InitializeDatabaseInternalAsync(connectionString, createCmd), 5000);
 
-                using (var command = new SqlCommand(createCmd, connection))
+            static async Task InitializeDatabaseInternalAsync(string connectionString, string createCmd)
+            {
+                using (var connection = new SqlConnection(connectionString))
                 {
-                    await command.ExecuteNonQueryAsync();
+                    await connection.OpenAsync();
+
+                    using (var command = new SqlCommand(createCmd, connection))
+                    {
+                        await command.ExecuteNonQueryAsync();
+                    }
                 }
             }
         }

--- a/src/BenchmarksServer/Startup.cs
+++ b/src/BenchmarksServer/Startup.cs
@@ -1223,7 +1223,7 @@ namespace BenchmarkServer
                                         }
                                         catch
                                         {
-                                            Log.WriteLine($"/shutdown endpoint failed...");
+                                            Log.WriteLine($"/shutdown endpoint failed... ({job.Url}/shutdown)");
                                         }
                                     }
 
@@ -3668,7 +3668,9 @@ EventPipeEventSource source = null;
                         Log.WriteLine("[ERROR] Failed to create measurements event pipe client");
                         return;
                     }
-                    
+
+                    source = new EventPipeEventSource(binaryReader);
+
                     source.Dynamic.All += (eventData) =>
                     {
                         // We only track event counters for System.Runtime


### PR DESCRIPTION
a) retry SQL connection initialization upon error
sometimes SQL server might not be running and can start with a delay (trigger)
introduce the same retry mechanism upon connection as other SQL operations

b) fix event registration crash
StartMeasurement was using a null EventPipeEventSource and was crashing