### PR TITLE
fix BombardierClient bug that I've introduced today

### DIFF
--- a/src/BombardierClient/Program.cs
+++ b/src/BombardierClient/Program.cs
@@ -38,11 +38,13 @@ namespace BombardierClient
             Console.WriteLine("args: " + String.Join(' ', args));
 
             // Extracting parameters
-            int warmup = 0, duration = 0, requests = 0;
-
             var argsList = args.ToList();
 
-            if (!(TryGetArgumentValue("-d", argsList, out duration) || TryGetArgumentValue("-n", argsList, out requests)))
+            TryGetArgumentValue("-w", argsList, out int warmup);
+            TryGetArgumentValue("-d", argsList, out int duration);
+            TryGetArgumentValue("-n", argsList, out int requests);
+
+            if (duration == 0 && requests == 0)
             {
                 Console.WriteLine("Couldn't find valid -d and -n arguments (integers)");
                 return;


### PR DESCRIPTION
@sebastienros I am sorry, I am an idiot

In #1535 I've introduced a bug:

Calling the program with following arguments:

```cmd
-w 0 -d 15 -n 0
```

Would cause `TryGetArgumentValue("-d", argsList, out duration)` to be executed, but not `TryGetArgumentValue("-n", argsList, out requests)`. So `-n 0` would not get removed from args list and it would be sent to bombardier and it would give an error like this:

![obraz](https://user-images.githubusercontent.com/6011991/83549865-42f59900-a506-11ea-97c8-dc2096197554.png)

 