### PR TITLE
More db platform benchmarks

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
@@ -26,20 +26,62 @@ scenarios:
   fortunesplatform:
     db:
       job: postgresql
-
     application:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-
+      environmentVariables:
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
       job: bombardier
       variables:
         presetHeaders: html
         path: /fortunes
-        warmup: 5 
-        duration: 10
-        serverPort: 5000
+        
+  single_query:
+    db:
+      job: postgresql
+    application:
+      job: platformbenchmarks
+      buildArguments: 
+        - "/p:IsDatabase=true"
+      environmentVariables:
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
+    load:
+      job: bombardier
+      variables:
+        presetHeaders: json
+        path: /db
+
+  multiple_queries:
+    db:
+      job: postgresql
+    application:
+      job: platformbenchmarks
+      buildArguments: 
+        - "/p:IsDatabase=true"
+      environmentVariables:
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+    load:
+      job: bombardier
+      variables:
+        presetHeaders: json
+        path: /queries/queries=20
+  
+  updates:
+    db:
+      job: postgresql
+    application:
+      job: platformbenchmarks
+      buildArguments: 
+        - "/p:IsDatabase=true"
+      environmentVariables:
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+    load:
+      job: bombardier
+      variables:
+        presetHeaders: json
+        path: /updates/queries=20
 
 profiles:
   aspnet-citrine:
@@ -53,12 +95,15 @@ profiles:
       application:
         endpoints: 
           - http://asp-citrine-lin:5001
+        variables:
+          databaseServer: 10.0.0.106
         environmentVariables:
           database: PostgreSQL
-          connectionstring: Server=10.0.0.106;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
       load:
         variables:
           connections: 512
+          warmup: 5 
+          duration: 10
+          serverPort: 5000
         endpoints: 
           - http://asp-citrine-win:5001
-

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
@@ -23,7 +23,7 @@ jobs:
     readyStateText: PostgreSQL init process complete
 
 scenarios:
-  fortunesplatform:
+  fortunes:
     db:
       job: postgresql
     application:
@@ -33,7 +33,7 @@ scenarios:
       environmentVariables:
         connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
-      job: bombardier
+      job: wrk
       variables:
         presetHeaders: html
         path: /fortunes
@@ -48,7 +48,7 @@ scenarios:
       environmentVariables:
         connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
-      job: bombardier
+      job: wrk
       variables:
         presetHeaders: json
         path: /db
@@ -63,7 +63,7 @@ scenarios:
       environmentVariables:
         connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
-      job: bombardier
+      job: wrk
       variables:
         presetHeaders: json
         path: /queries/queries=20
@@ -78,7 +78,7 @@ scenarios:
       environmentVariables:
         connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
-      job: bombardier
+      job: wrk
       variables:
         presetHeaders: json
         path: /updates/queries=20
@@ -106,4 +106,4 @@ profiles:
           duration: 10
           serverPort: 5000
         endpoints: 
-          - http://asp-citrine-win:5001
+          - http://asp-citrine-load:5001

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
@@ -99,6 +99,8 @@ profiles:
           databaseServer: 10.0.0.106
         environmentVariables:
           database: PostgreSQL
+        options:
+          displayOutput: true
       load:
         variables:
           connections: 512

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/benchmarks.fortunes.yml
@@ -23,7 +23,7 @@ jobs:
     readyStateText: PostgreSQL init process complete
 
 scenarios:
-  fortunes:
+  fortunesplatform:
     db:
       job: postgresql
     application:


### PR DESCRIPTION
Changes:

* added remaining platform db benchmarks and connection string per benchmark (multiplexing enabled only for fortunes and single query where it helps)
* switch from bombardier to wrk for better RPS and doing what TE is doing
* display app output to see the connection string that is used

@roji PTAL