### PR TITLE
Checking NET5_0

### DIFF
--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
 using System.Text.Json;
 using System.Text.Json.Serialization;
 #else
@@ -24,7 +24,7 @@ namespace Benchmarks.Middleware
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
         private static readonly UTF8Encoding _encoding = new UTF8Encoding(false);
         private const int _bufferSize = 27;
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0 && !NET5_0
         private static readonly JsonSerializer _json = new JsonSerializer();
 #endif
         private readonly RequestDelegate _next;
@@ -39,7 +39,7 @@ namespace Benchmarks.Middleware
                 httpContext.Response.ContentType = "application/json";
                 httpContext.Response.ContentLength = _bufferSize;
 
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0 && !NET5_0
                 var syncIOFeature = httpContext.Features.Get<IHttpBodyControlFeature>();
                 if (syncIOFeature != null)
                 {

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -12,7 +12,7 @@ using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.HttpSys;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0 && !NET5_0
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 #endif
 using Microsoft.Extensions.Configuration;
@@ -94,7 +94,7 @@ namespace Benchmarks
                     .AddSingleton<Scenarios>()
                     .Configure<LoggerFilterOptions>(options =>
                     {
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
                         if (Boolean.TryParse(config["DisableScopes"], out var disableScopes) && disableScopes)
                         {
                             Console.WriteLine($"LoggerFilterOptions.CaptureScopes = false");
@@ -124,7 +124,7 @@ namespace Benchmarks
                     {
                         Listen(options, config, "http://localhost:5000/");
                     }
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NETCOREAPP5_0 && !NET5_0
 
                     var kestrelThreadPoolDispatchingValue = config["KestrelThreadPoolDispatching"];
                     if (kestrelThreadPoolDispatchingValue != null)
@@ -189,7 +189,7 @@ namespace Benchmarks
             {
                 webHostBuilder = webHostBuilder.UseHttpSys();
             }
-#if NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#if NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
             else if (String.Equals(Server, "IISInProcess", StringComparison.OrdinalIgnoreCase))
             {
                 webHostBuilder = webHostBuilder.UseIIS();

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Data.Common;
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
 using Microsoft.Data.SqlClient;
 #else
 using System.Data.SqlClient;
@@ -96,7 +96,7 @@ namespace Benchmarks
 
                 case DatabaseServer.MySql:
 
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
                     throw new NotSupportedException("EF/MySQL is unsupported on netcoreapp3.0 until a provider is available");
 #else
                     services.AddEntityFrameworkMySql();
@@ -168,7 +168,7 @@ namespace Benchmarks
                         .AddRazorViewEngine();
                 }
             }
-#elif NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#elif NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
             if (Scenarios.Any("Endpoint"))
             {
                 services.AddRouting();
@@ -323,7 +323,7 @@ namespace Benchmarks
             {
                 app.UseMvc();
             }
-#elif NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0
+#elif NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0
             if (Scenarios.Any("EndpointPlaintext"))
             {
                 app.UseRouting();

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -112,7 +112,7 @@ namespace PlatformBenchmarks
 
             if (state == State.StartLine)
             {
-#if NETCOREAPP5_0
+#if NET5_0
                 if (Parser.ParseRequestLine(new ParsingAdapter(this), ref reader))
                 {
                     state = State.Headers;
@@ -197,7 +197,7 @@ namespace PlatformBenchmarks
 
             if (state == State.StartLine)
             {
-#if NETCOREAPP5_0
+#if NET5_0
                 if (Parser.ParseRequestLine(new ParsingAdapter(this), ref reader))
                 {
                     state = State.Headers;
@@ -246,7 +246,7 @@ namespace PlatformBenchmarks
         }
 #endif
 
-#if NETCOREAPP5_0
+#if NET5_0
 
         public void OnStaticIndexedHeader(int index)
         {
@@ -311,7 +311,7 @@ namespace PlatformBenchmarks
             public ParsingAdapter(BenchmarkApplication requestHandler)
                 => RequestHandler = requestHandler;
 
-#if NETCOREAPP5_0
+#if NET5_0
             public void OnStaticIndexedHeader(int index) 
                 => RequestHandler.OnStaticIndexedHeader(index);
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.HttpConnection.cs
@@ -112,7 +112,7 @@ namespace PlatformBenchmarks
 
             if (state == State.StartLine)
             {
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
                 if (Parser.ParseRequestLine(new ParsingAdapter(this), ref reader))
                 {
                     state = State.Headers;
@@ -197,7 +197,7 @@ namespace PlatformBenchmarks
 
             if (state == State.StartLine)
             {
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
                 if (Parser.ParseRequestLine(new ParsingAdapter(this), ref reader))
                 {
                     state = State.Headers;
@@ -246,7 +246,7 @@ namespace PlatformBenchmarks
         }
 #endif
 
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
 
         public void OnStaticIndexedHeader(int index)
         {
@@ -311,7 +311,7 @@ namespace PlatformBenchmarks
             public ParsingAdapter(BenchmarkApplication requestHandler)
                 => RequestHandler = requestHandler;
 
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
             public void OnStaticIndexedHeader(int index) 
                 => RequestHandler.OnStaticIndexedHeader(index);
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -62,7 +62,7 @@ namespace PlatformBenchmarks
         private int _queries;
 #endif
 
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
         public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
         {
             var requestType = RequestType.NotRecognized;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -62,7 +62,7 @@ namespace PlatformBenchmarks
         private int _queries;
 #endif
 
-#if NETCOREAPP5_0
+#if NET5_0
         public void OnStartLine(HttpVersionAndMethod versionAndMethod, TargetOffsetPathLength targetPath, Span<byte> startLine)
         {
             var requestType = RequestType.NotRecognized;

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -28,7 +28,7 @@ namespace PlatformBenchmarks
                        options.IOQueueCount = threadCount;
                     }
 
-#if NETCOREAPP5_0
+#if NET5_0
                     options.WaitForDataBeforeAllocatingBuffer = false;
 #endif
                 });

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -28,7 +28,7 @@ namespace PlatformBenchmarks
                        options.IOQueueCount = threadCount;
                     }
 
-#if NET5_0
+#if NETCOREAPP5_0 || NET5_0
                     options.WaitForDataBeforeAllocatingBuffer = false;
 #endif
                 });


### PR DESCRIPTION
PR for visibility, since sdk preview-7 it seem the NET COREAPP5_0 directive is not used anymore.
Our benchmarks were using it. Checking both since we still use older sdks in some circumstances. 

@benaadams @adamsitnik @halter73 