### PR TITLE
use Sockets as default transport for PlatformBenchmarks 

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -21,7 +21,14 @@ namespace PlatformBenchmarks
 
             Console.WriteLine($"Transport: {webHost}");
 
-            if (string.Equals(webHost, "Sockets", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(webHost, "LinuxTransport", StringComparison.OrdinalIgnoreCase))
+            {
+                builder.UseLinuxTransport(options =>
+                {
+                    options.ApplicationSchedulingMode = PipeScheduler.Inline;
+                });
+            }
+            else
             {
                 builder.UseSockets(options =>
                 {
@@ -35,13 +42,6 @@ namespace PlatformBenchmarks
 
                     Console.WriteLine($"Options: WaitForData={options.WaitForDataBeforeAllocatingBuffer}, IOQueue={options.IOQueueCount}");
 #endif
-                });
-            }
-            else if (string.Equals(webHost, "LinuxTransport", StringComparison.OrdinalIgnoreCase))
-            {
-                builder.UseLinuxTransport(options =>
-                {
-                    options.ApplicationSchedulingMode = PipeScheduler.Inline;
                 });
             }
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkConfigurationHelpers.cs
@@ -19,6 +19,8 @@ namespace PlatformBenchmarks
             // Handle the transport type
             var webHost = builder.GetSetting("KestrelTransport");
 
+            Console.WriteLine($"Transport: {webHost}");
+
             if (string.Equals(webHost, "Sockets", StringComparison.OrdinalIgnoreCase))
             {
                 builder.UseSockets(options =>
@@ -30,6 +32,8 @@ namespace PlatformBenchmarks
 
 #if NETCOREAPP5_0 || NET5_0
                     options.WaitForDataBeforeAllocatingBuffer = false;
+
+                    Console.WriteLine($"Options: WaitForData={options.WaitForDataBeforeAllocatingBuffer}, IOQueue={options.IOQueueCount}");
 #endif
                 });
             }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Program.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Net;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -39,6 +40,8 @@ namespace PlatformBenchmarks
 
         public static IWebHost BuildWebHost(string[] args)
         {
+            Console.WriteLine($"Args: {string.Join(' ', args)}");
+
             var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
                 .AddEnvironmentVariables()


### PR DESCRIPTION
I was working on the last experiment for Sockets for 5.0 and I realized that Driver**2** does not pass sockets as a transport option by default (like the old driver does).

This explains why we were getting 1150k for JSON with the new driver and 1200k with the old one.

@sebastienros I think that we should just use Sockets by default. What do you think?

@roji this could be the source of some driver differences for other benchmarks as well