### PR TITLE
Fix typo for aspnet-citrine-win

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -28,7 +28,7 @@ Each profile defines a set of machines, private IPs and ports that are used to r
 |  `aspnet-perf-lin` | INTEL, 12 cores | Ubuntu 18.04, Kernel 4.x |
 |  `aspnet-perf-win` | INTEL, 12 cores | Windows Server 2016 |
 |  `aspnet-citrine-lin` | INTEL, 28 cores | Ubuntu 18.04, Kernel 4.x |
-|  `aspnet-citrine-lin` | INTEL, 28 cores | Windows Server 2016 |
+|  `aspnet-citrine-win` | INTEL, 28 cores | Windows Server 2016 |
 |  `aspnet-citrine-arm` | ARM64, 32 cores | Ubuntu 18.04, Kernel 4.x |
 |  `aspnet-citrine-amd` | AMD, 48 cores | Ubuntu 18.04, Kernel 4.x |
 


### PR DESCRIPTION
I believe this is what was intended