### PR TITLE
Use Npgsql 5.0.0-ci.20201101T161311 in platform benchmarks

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/NuGet.config
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/NuGet.config
@@ -11,6 +11,7 @@
     <add key="entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
     <add key="aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
     <add key="aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="Npgsql-Unstable" value="https://www.myget.org/F/npgsql-unstable/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
     
-    <PackageReference Include="Npgsql" Version="5.0.0-ci.20201026T091725" />
+    <PackageReference Include="Npgsql" Version="5.0.0-ci.20201101T161311" />
     <PackageReference Include="Microsoft.Crank.EventSources" Version="0.1.0-alpha.20501.1" />
   </ItemGroup>
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <None Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
     
-    <PackageReference Include="Npgsql" Version="5.0.0-alpha1" />
+    <PackageReference Include="Npgsql" Version="5.0.0-ci.20201026T091725" />
     <PackageReference Include="Microsoft.Crank.EventSources" Version="0.1.0-alpha.20501.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This is the latest Npgsql CI package, closer to what will actually be released as 5.0.