### PR TITLE
[Caching] remove one additional interface call and a branch

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -73,11 +73,9 @@ namespace PlatformBenchmarks
             {
                 var id = random.Next(1, 10001);
                 var key = cacheKeys[id];
-                var data = cache.Get<CachedWorld>(key);
-
-                if (data != null)
+                if (cache.TryGetValue(key, out object cached))
                 {
-                    result[i] = data;
+                    result[i] = (CachedWorld)cached;
                 }
                 else
                 {


### PR DESCRIPTION
This is a very tiny improvement that gives... +1-2k RPS

The `Get<T>` method is an extension method that uses `IMemoryCache` interface:

https://github.com/dotnet/runtime/blob/69d61271f900afd7ae6dea7f0c5e57d43090f9dd/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs#L18-L21

By using `MemoryCache.TryGetValue` instead, we remove one interface method invocation and a branch