### PR TITLE
Use count=20 for Cached Queries benchmark as this number is used in the official Data table results

### DIFF
--- a/scenarios/platform.benchmarks.yml
+++ b/scenarios/platform.benchmarks.yml
@@ -114,7 +114,7 @@ scenarios:
       job: wrk
       variables:
         presetHeaders: json
-        path: /cached-worlds/100
+        path: /cached-worlds/20
 
   updates:
     db:


### PR DESCRIPTION
The [official requirements](https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview#caching) mention 100:

> The request handler will be exercised with counts of 1, 10, 20, 50, and 100. Note that these are higher than the counts used in Test #3.

But in the [final](https://www.techempower.com/benchmarks/#section=data-r19&hw=ph&test=cached-query) and [preview](https://www.techempower.com/benchmarks/#section=test&runid=032630e0-3a86-4eac-ae2d-517e8b9586ac&hw=ph&test=cached-query&a=2) results only `1, 5, 10, 15` and `20` are used:

![obraz](https://user-images.githubusercontent.com/6011991/99389300-204e1580-28d7-11eb-9f05-920e041ee52f.png)

So IMO we should switch from 100 to 20.

cc @sebastienros 
