### PR TITLE
[Caching] remove implicit cast from CachedWord to Word (1.7%)

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO.Pipelines;
-using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace PlatformBenchmarks
@@ -11,31 +10,7 @@ namespace PlatformBenchmarks
     {
         private async Task Caching(PipeWriter pipeWriter, int count)
         {
-            OutputCachedWords(pipeWriter, await Db.LoadCachedQueries(count));
-        }
-
-        private static void OutputCachedWords(PipeWriter pipeWriter, CachedWorld[] rows)
-        {
-            var writer = GetWriter(pipeWriter, sizeHint: 160 * rows.Length); // in reality it's 152 for one
-
-            writer.Write(_dbPreamble);
-
-            var lengthWriter = writer;
-            writer.Write(_contentLengthGap);
-
-            // Date header
-            writer.Write(DateHeader.HeaderBytes);
-
-            writer.Commit();
-
-            Utf8JsonWriter utf8JsonWriter = t_writer ??= new Utf8JsonWriter(pipeWriter, new JsonWriterOptions { SkipValidation = true });
-            utf8JsonWriter.Reset(pipeWriter);
-
-            // Body
-            JsonSerializer.Serialize<CachedWorld[]>(utf8JsonWriter, rows, SerializerOptions);
-
-            // Content-Length
-            lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);
+            OutputMultipleQueries(pipeWriter, await Db.LoadCachedQueries(count));
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO.Pipelines;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace PlatformBenchmarks
@@ -10,7 +11,31 @@ namespace PlatformBenchmarks
     {
         private async Task Caching(PipeWriter pipeWriter, int count)
         {
-            OutputMultipleQueries(pipeWriter, await Db.LoadCachedQueries(count));
+            OutputCachedWords(pipeWriter, await Db.LoadCachedQueries(count));
+        }
+
+        private static void OutputCachedWords(PipeWriter pipeWriter, CachedWorld[] rows)
+        {
+            var writer = GetWriter(pipeWriter, sizeHint: 160 * rows.Length); // in reality it's 152 for one
+
+            writer.Write(_dbPreamble);
+
+            var lengthWriter = writer;
+            writer.Write(_contentLengthGap);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            writer.Commit();
+
+            Utf8JsonWriter utf8JsonWriter = t_writer ??= new Utf8JsonWriter(pipeWriter, new JsonWriterOptions { SkipValidation = true });
+            utf8JsonWriter.Reset(pipeWriter);
+
+            // Body
+            JsonSerializer.Serialize<CachedWorld[]>(utf8JsonWriter, rows, SerializerOptions);
+
+            // Content-Length
+            lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
@@ -14,7 +14,7 @@ namespace PlatformBenchmarks
             OutputMultipleQueries(pipeWriter, await Db.LoadMultipleQueriesRows(count));
         }
 
-        private static void OutputMultipleQueries(PipeWriter pipeWriter, World[] rows)
+        private static void OutputMultipleQueries<TWord>(PipeWriter pipeWriter, TWord[] rows)
         {
             var writer = GetWriter(pipeWriter, sizeHint: 160 * rows.Length); // in reality it's 152 for one
 
@@ -32,7 +32,7 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize<World[]>(utf8JsonWriter, rows, SerializerOptions);
+            JsonSerializer.Serialize<TWord[]>(utf8JsonWriter, rows, SerializerOptions);
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/CachedWorld.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/CachedWorld.cs
@@ -3,7 +3,7 @@
 
 namespace PlatformBenchmarks
 {
-    public sealed  class CachedWorld
+    public sealed class CachedWorld
     {
         public int Id { get; set; }
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/CachedWorld.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/CachedWorld.cs
@@ -1,17 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Runtime.InteropServices;
-
 namespace PlatformBenchmarks
 {
-    public class CachedWorld
+    public sealed  class CachedWorld
     {
         public int Id { get; set; }
 
         public int RandomNumber { get; set; }
 
-        public static implicit operator World(CachedWorld world) => new World { Id = world.Id, RandomNumber = world.RandomNumber };
         public static implicit operator CachedWorld(World world) => new CachedWorld { Id = world.Id, RandomNumber = world.RandomNumber };
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -63,9 +63,9 @@ namespace PlatformBenchmarks
             return result;
         }
 
-        public Task<World[]> LoadCachedQueries(int count)
+        public Task<CachedWorld[]> LoadCachedQueries(int count)
         {
-            var result = new World[count];
+            var result = new CachedWorld[count];
             var cacheKeys = _cacheKeys;
             var cache = _cache;
             var random = _random;
@@ -85,7 +85,7 @@ namespace PlatformBenchmarks
 
             return Task.FromResult(result);
 
-            static async Task<World[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, World[] result)
+            static async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
             {
                 using (var db = new NpgsqlConnection(rawdb._connectionString))
                 {
@@ -106,8 +106,7 @@ namespace PlatformBenchmarks
 
                         for (; i < result.Length; i++)
                         {
-                            var data = await rawdb._cache.GetOrCreateAsync<CachedWorld>(key, create);
-                            result[i] = data;
+                            result[i] = await rawdb._cache.GetOrCreateAsync<CachedWorld>(key, create);
 
                             id = rawdb._random.Next(1, 10001);
                             idParameter.TypedValue = id;


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/6011991/100481996-430dd480-30f6-11eb-94c5-9d68bb7c5e37.png)

| load                   |   before |     after |
| ---------------------- | ---------| --------- |
| CPU Usage (%)          |        22|        22 |
| Cores usage (%)        |       605|       615 |
| Working Set (MB)       |        48|        48 |
| Build Time (ms)        |     3,733|     3,973 |
| Start Time (ms)        |         0|         0 |
| Published Size (KB)    |    76,401|    76,401 |
| First Request (ms)     |        67|        66 |
| Requests/sec           |   268,293|   272,573 |
| Requests               | 4,051,004| 4,115,679 |
| Mean latency (ms)      |      1.11|      1.11 |
| Max latency (ms)       |     41.51|     42.72 |
| Bad responses          |         0|         0 |
| Socket errors          |         0|         0 |
| Read throughput (MB/s) |    844.32|    857.79 |
| Latency 50th (ms)      |      0.93|      0.91 |
| Latency 75th (ms)      |      1.03|      1.01 |
| Latency 90th (ms)      |      1.15|      1.14 |
| Latency 99th (ms)      |      8.74|      9.01 |