### PR TITLE
Set EF DbContext pool size to 1024 (instead of default 128)

### DIFF
--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -75,7 +75,7 @@ namespace Benchmarks
                     if (settings.Enlist)
                         throw new ArgumentException("Enlist=false must be specified for Npgsql");
 
-                    services.AddDbContextPool<ApplicationDbContext>(options => options.UseNpgsql(appSettings.ConnectionString));
+                    services.AddDbContextPool<ApplicationDbContext>(options => options.UseNpgsql(appSettings.ConnectionString), 1024);
 
                     if (Scenarios.Any("Raw") || Scenarios.Any("Dapper"))
                     {


### PR DESCRIPTION
Improvement: 69,653 RPS -> 73,718 RPS (5.8%)

![DbContext_getting_created](https://user-images.githubusercontent.com/1862641/107586790-eacc7600-6c00-11eb-8981-647b374bf6fa.png)

:astonished::astonished::astonished::astonished::astonished:

![TheFirstRule](https://user-images.githubusercontent.com/1862641/107586994-47c82c00-6c01-11eb-8b52-5a583a6e938c.jpg)

/cc @ajcvickers