### PR TITLE
Add YARP scenario for NET 5.0

### DIFF
--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -23,7 +23,7 @@ parameters:
     supportsServerHttps: true
     supportsServerHttp2: true
   - displayName: YARP-net50
-    arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp --application.channel edge --application.framework net5.0
+    arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp-net50 --application.framework net5.0
   - displayName: HttpClient
     arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient --application.channel edge --application.framework net6.0
     supportsServerHttps: true

--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -22,6 +22,8 @@ parameters:
     arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp --application.channel edge --application.framework net6.0
     supportsServerHttps: true
     supportsServerHttp2: true
+  - displayName: YARP-net50
+    arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp --application.channel edge --application.framework net5.0
   - displayName: HttpClient
     arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient --application.channel edge --application.framework net6.0
     supportsServerHttps: true


### PR DESCRIPTION
Intentionally leaving out `supportsServerHttps` and `supportsServerHttp2` to reduce the number of combinations ran for 5.0.
If need be we can add them in the future.