### PR TITLE
Enable H2-H2 benchmarks on .NET 5.0 proxy runs

### DIFF
--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -19,11 +19,13 @@ parameters:
   type: object
   default: 
   - displayName: YARP
-    arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp --application.channel edge --application.framework net6.0
+    arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp --application.channel edge --application.framework net6.0
     supportsServerHttps: true
     supportsServerHttp2: true
   - displayName: YARP-net50
-    arguments: --scenario proxy-yarp        $(proxyJobs)  --property proxy=yarp-net50 --application.framework net5.0
+    arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp-net50 --application.framework net5.0
+    supportsServerHttps: true
+    supportsServerHttp2: true
   - displayName: HttpClient
     arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient --application.channel edge --application.framework net6.0
     supportsServerHttps: true
@@ -95,14 +97,16 @@ steps:
     - ${{ each protocol in parameters.protocols }}:
       # doesn't requiresServerHttps or supportsServerHttps AND doesn't requiresServerHttp2 or supportsServerHttp2
       - ${{ if and( or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2) ) }}:
-        - task: PublishToAzureServiceBus@1
-          condition: succeededOrFailed()
-          displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
-          inputs:
-            connectedServiceName: ${{ parameters.connection }}
-            waitForCompletion: true
-            messageBody: |
-              {
-                "name": "crank",
-                "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
-              }
+        # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
+        - ${{ if or( not( eq( s.displayName, "YARP-net50")), in( protocol.displayName, "http - http", "h2 - h2") ) }}:
+          - task: PublishToAzureServiceBus@1
+            condition: succeededOrFailed()
+            displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
+            inputs:
+              connectedServiceName: ${{ parameters.connection }}
+              waitForCompletion: true
+              messageBody: |
+                {
+                  "name": "crank",
+                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
+                }


### PR DESCRIPTION
Core of the change is adding:
`if or( not( eq( s.displayName, "YARP-net50")), in( protocol.displayName, "http - http", "h2 - h2") )`

So trying to filter net50 runs that aren't either http-http or h2-h2.

cc: @alnikola 

[Without whitespace changes](https://github.com/aspnet/Benchmarks/pull/1635/files?diff=split&w=1)