### PR TITLE
Add gRPC proxy scenarios to dashboards

### DIFF
--- a/build/job-variables.yml
+++ b/build/job-variables.yml
@@ -49,6 +49,8 @@ variables:
 
 - name: proxyJobs
   value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/proxy.benchmarks.yml
+- name: proxyGRPCJobs
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/proxy.grpc.benchmarks.yml
 
 - name: h2loadConnectionsCount # Default value for h2load. Should be redefined for each job
   value: 28

--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -96,7 +96,7 @@ parameters:
       requiresServerHttp2: true
       requiresDownstreamHttp2: true
     - displayName: gRPC (h2 - h2)
-      arguments: --variable connections=1 --variable streams=100 --variable serverScheme=https --variable serverProtocol=grpc --variable downstreamScheme=https --variable downstreamProtocol=grpc
+      arguments: --variable connections=1 --variable streams=100 --variable serverScheme=https --variable serverProtocol=grpc --variable downstreamScheme=https --variable downstreamProtocol=grpc --property serverProtocol=grpc --property downstreamProtocol=grpc
       requiresGRPC: true
 # We need to find a way to tell the proxy that the downstream server is expecting h2c and not http/1.1
 #    - displayName: h2 - h2c
@@ -110,19 +110,20 @@ steps:
     - ${{ each protocol in parameters.protocols }}:
       # doesn't requiresServerHttps or supportsServerHttps AND doesn't requiresServerHttp2 or supportsServerHttp2
       - ${{ if and( or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2) ), or( not( protocol.requiresDownstreamHttp2), s.supportsDownstreamHttp2) ), or( not( protocol.requiresServerGRPC), s.supportsGRPC) ) }}:
-        # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
-        - ${{ if and( not(s.requiresServerGRPC), or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) ) }}:
-          - task: PublishToAzureServiceBus@1
-            condition: succeededOrFailed()
-            displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
-            inputs:
-              connectedServiceName: ${{ parameters.connection }}
-              waitForCompletion: true
-              messageBody: |
-                {
-                  "name": "crank",
-                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
-                }
+        - ${{ if not(s.requiresGRPC) }}:
+          # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
+          - ${{ if or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) }}:
+            - task: PublishToAzureServiceBus@1
+              condition: succeededOrFailed()
+              displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
+              inputs:
+                connectedServiceName: ${{ parameters.connection }}
+                waitForCompletion: true
+                messageBody: |
+                  {
+                    "name": "crank",
+                    "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
+                  }
         - ${{ if s.requiresGRPC }}:
           - task: PublishToAzureServiceBus@1
             condition: succeededOrFailed()
@@ -133,5 +134,5 @@ steps:
               messageBody: |
                 {
                   "name": "crank",
-                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }}-grpc --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}-grpc\"" ]
+                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }}-grpc --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
                 }

--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -24,6 +24,9 @@ parameters:
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     supportsGRPC: true
+  - displayName: YARP gRPC
+    arguments: --scenario proxy-yarp-grpc        $(proxyJobs) --property proxy=yarp --application.channel edge --application.framework net6.0
+    supportsGRPC: true
   - displayName: YARP-net50
     arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp-net50 --application.framework net5.0
     supportsServerHttps: true
@@ -41,6 +44,9 @@ parameters:
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsGRPC: true
+  - displayName: NGinx gRPC
+    arguments: --scenario proxy-nginx-grpc       $(proxyJobs) --property proxy=nginx --variable warmup=0
+    supportsGRPC: true
   - displayName: HAProxy
     arguments: --scenario proxy-haproxy     $(proxyJobs) --property proxy=haproxy
   - displayName: Envoy
@@ -48,6 +54,8 @@ parameters:
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
+  - displayName: Envoy gRPC
+    arguments: --scenario proxy-envoy-grpc       $(proxyJobs) --property proxy=envoy
     supportsGRPC: true
 
 - name: payloads
@@ -110,29 +118,16 @@ steps:
     - ${{ each protocol in parameters.protocols }}:
       # doesn't requiresServerHttps or supportsServerHttps AND doesn't requiresServerHttp2 or supportsServerHttp2
       - ${{ if and( or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2) ), or( not( protocol.requiresDownstreamHttp2), s.supportsDownstreamHttp2) ), or( not( protocol.requiresServerGRPC), s.supportsGRPC) ) }}:
-        - ${{ if not(s.requiresGRPC) }}:
-          # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
-          - ${{ if or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) }}:
-            - task: PublishToAzureServiceBus@1
-              condition: succeededOrFailed()
-              displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
-              inputs:
-                connectedServiceName: ${{ parameters.connection }}
-                waitForCompletion: true
-                messageBody: |
-                  {
-                    "name": "crank",
-                    "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
-                  }
-        - ${{ if s.requiresGRPC }}:
+        # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
+        - ${{ if or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) }}:
           - task: PublishToAzureServiceBus@1
             condition: succeededOrFailed()
-            displayName: ${{ s.displayName }} ${{ protocol.displayName }}
+            displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
             inputs:
               connectedServiceName: ${{ parameters.connection }}
               waitForCompletion: true
               messageBody: |
                 {
                   "name": "crank",
-                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }}-grpc --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
+                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
                 }

--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -69,13 +69,13 @@ parameters:
 
     # no headers, different body sizes, 100 B response
     - displayName: "100 B - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/100B.txt --variable verb=POST --property payload=100 --property body=100 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/100B.txt --variable verb=POST --property payload=100 --property body=100 --property headers=none
     - displayName: "1 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/1KB.txt --variable verb=POST --property payload=100 --property body=1024 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/1KB.txt --variable verb=POST --property payload=100 --property body=1024 --property headers=none
     - displayName: "10 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/10KB.txt --variable verb=POST --property payload=100 --property body=10240 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/10KB.txt --variable verb=POST --property payload=100 --property body=10240 --property headers=none
     - displayName: "100 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/100KB.txt --variable verb=POST --property payload=100 --property body=102400 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/100KB.txt --variable verb=POST --property payload=100 --property body=102400 --property headers=none
 
 - name: protocols
   type: object

--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -22,24 +22,33 @@ parameters:
     arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp --application.channel edge --application.framework net6.0
     supportsServerHttps: true
     supportsServerHttp2: true
+    supportsDownstreamHttp2: true
+    supportsGRPC: true
   - displayName: YARP-net50
     arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp-net50 --application.framework net5.0
     supportsServerHttps: true
     supportsServerHttp2: true
+    supportsDownstreamHttp2: true
+    supportsGRPC: true
   - displayName: HttpClient
     arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient --application.channel edge --application.framework net6.0
     supportsServerHttps: true
     supportsServerHttp2: true
+    supportsDownstreamHttp2: true
+    supportsGRPC: true
   - displayName: NGinx
     arguments: --scenario proxy-nginx       $(proxyJobs) --property proxy=nginx --variable warmup=0
     supportsServerHttps: true
     supportsServerHttp2: true
+    supportsGRPC: true
   - displayName: HAProxy
     arguments: --scenario proxy-haproxy     $(proxyJobs) --property proxy=haproxy
   - displayName: Envoy
     arguments: --scenario proxy-envoy       $(proxyJobs) --property proxy=envoy
     supportsServerHttps: true
     supportsServerHttp2: true
+    supportsDownstreamHttp2: true
+    supportsGRPC: true
 
 - name: payloads
   type: object
@@ -60,13 +69,13 @@ parameters:
 
     # no headers, different body sizes, 100 B response
     - displayName: "100 B - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/100B.txt --variable verb=POST --property payload=100 --property body=100 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/100B.txt --variable verb=POST --property payload=100 --property body=100 --property headers=none
     - displayName: "1 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/1KB.txt --variable verb=POST --property payload=100 --property body=1024 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/1KB.txt --variable verb=POST --property payload=100 --property body=1024 --property headers=none
     - displayName: "10 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/10KB.txt --variable verb=POST --property payload=100 --property body=10240 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/10KB.txt --variable verb=POST --property payload=100 --property body=10240 --property headers=none
     - displayName: "100 KB - 100 B - No Headers"
-      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/assets/100KB.txt --variable verb=POST --property payload=100 --property body=102400 --property headers=none
+      arguments: --variable path=/?s=100 --variable bodyFile=https://raw.githubusercontent.com/aspnet/Benchmarks/master/scenarios/assets/100KB.txt --variable verb=POST --property payload=100 --property body=102400 --property headers=none
 
 - name: protocols
   type: object
@@ -85,6 +94,10 @@ parameters:
     - displayName: h2 - h2
       arguments: --variable connections=28 --variable serverScheme=https --variable serverProtocol=http2 --variable downstreamScheme=https --variable downstreamProtocol=http2 --property serverProtocol=h2 --property downstreamProtocol=h2
       requiresServerHttp2: true
+      requiresDownstreamHttp2: true
+    - displayName: gRPC (h2 - h2)
+      arguments: --variable connections=1 --variable streams=100 --variable serverScheme=https --variable serverProtocol=grpc --variable downstreamScheme=https --variable downstreamProtocol=grpc
+      requiresGRPC: true
 # We need to find a way to tell the proxy that the downstream server is expecting h2c and not http/1.1
 #    - displayName: h2 - h2c
 #      arguments: --variable serverScheme=https --variable downstreamScheme=http --load.variables.transport http2 --downstream.variables.httpProtocol http2 --property serverProtocol=http --property downstreamProtocol=h2c
@@ -96,9 +109,9 @@ steps:
   - ${{ each payload in parameters.payloads }}:
     - ${{ each protocol in parameters.protocols }}:
       # doesn't requiresServerHttps or supportsServerHttps AND doesn't requiresServerHttp2 or supportsServerHttp2
-      - ${{ if and( or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2) ) }}:
+      - ${{ if and( or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2) ), or( not( protocol.requiresDownstreamHttp2), s.supportsDownstreamHttp2) ), or( not( protocol.requiresServerGRPC), s.supportsGRPC) ) }}:
         # For .NET 5.0, only run HTTP-HTTP and H2-H2 benchmarks
-        - ${{ if or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) }}:
+        - ${{ if and( not(s.requiresServerGRPC), or( not( eq( s.displayName, 'YARP-net50')), in( protocol.displayName, 'http - http', 'h2 - h2') ) ) }}:
           - task: PublishToAzureServiceBus@1
             condition: succeededOrFailed()
             displayName: ${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }}
@@ -109,4 +122,16 @@ steps:
                 {
                   "name": "crank",
                   "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}\"" ]
+                }
+        - ${{ if s.requiresGRPC }}:
+          - task: PublishToAzureServiceBus@1
+            condition: succeededOrFailed()
+            displayName: ${{ s.displayName }} ${{ protocol.displayName }}
+            inputs:
+              connectedServiceName: ${{ parameters.connection }}
+              waitForCompletion: true
+              messageBody: |
+                {
+                  "name": "crank",
+                  "args": [ "--table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }}-grpc --no-metadata --no-measurements --downstream.options.reuseBuild true --load.variables.warmup ${{ parameters.warmup }} --load.variables.duration ${{ parameters.duration }} ${{ s.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ protocol.displayName }} ${{ parameters.profile }}-grpc\"" ]
                 }

--- a/scenarios/proxy.grpc.benchmarks.yml
+++ b/scenarios/proxy.grpc.benchmarks.yml
@@ -12,7 +12,7 @@
     scenario: serverstreaming
     protocol: h2
     warmup: 5
-    duration: 5
+    duration: 15
     logLevel: none
     requestSize: 0
     responseSize: 100


### PR DESCRIPTION
It also disables running HTTP/2 - HTTP/2 on NGINX because it doesn't support that.