### PR TITLE
Make Fortunes message required for EF Core

### DIFF
--- a/src/Benchmarks/Data/Fortune.cs
+++ b/src/Benchmarks/Data/Fortune.cs
@@ -21,6 +21,7 @@ namespace Benchmarks.Data
         [Column("message")]
         [StringLength(2048)]
         [IgnoreDataMember]
+        [Required]
         public string Message { get; set; }
         
         public int CompareTo(object obj)


### PR DESCRIPTION
Makes EF Core skip the IsDBNull check

RPS: 91,423 -> 92,696 (~1.4%)

/cc @ajcvickers 