### PR TITLE
Tune maximum connection pool size for Npgsql, enable multiplexing for non-platform benchmarks

### DIFF
--- a/scenarios/database.benchmarks.yml
+++ b/scenarios/database.benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
     arguments: "--nonInteractive true --scenarios {{scenario}} --urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --server {{server}} --kestrelTransport {{transport}} --protocol {{protocol}}"
     environmentVariables:
       database: PostgresQL
-      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
 
   postgresql:
     source:

--- a/scenarios/platform.benchmarks.yml
+++ b/scenarios/platform.benchmarks.yml
@@ -58,7 +58,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
       job: wrk
       variables:

--- a/scenarios/platform.benchmarks.yml
+++ b/scenarios/platform.benchmarks.yml
@@ -16,7 +16,10 @@ jobs:
       project: src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
     readyStateText: Application started.
     framework: net5.0
-
+    environmentVariables:
+      database: PostgreSQL
+      connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
+  
   postgresql:
     source:
       repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
@@ -56,9 +59,6 @@ scenarios:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-      environmentVariables:
-        database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
       job: wrk
       variables:
@@ -73,9 +73,6 @@ scenarios:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-      environmentVariables:
-        database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
     load:
       job: wrk
       variables:
@@ -89,9 +86,6 @@ scenarios:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-      environmentVariables:
-        database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -105,9 +99,6 @@ scenarios:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-      environmentVariables:
-        database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -121,9 +112,6 @@ scenarios:
       job: platformbenchmarks
       buildArguments: 
         - "/p:IsDatabase=true"
-      environmentVariables:
-        database: PostgreSQL
-        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -73,8 +73,8 @@ namespace Benchmarks
                 case DatabaseServer.PostgreSql:
                     services.AddEntityFrameworkNpgsql();
                     var settings = new NpgsqlConnectionStringBuilder(appSettings.ConnectionString);
-                    if (!settings.NoResetOnClose)
-                        throw new ArgumentException("No Reset On Close=true must be specified for Npgsql");
+                    if (!settings.NoResetOnClose && !settings.Multiplexing)
+                        throw new ArgumentException("No Reset On Close=true Or Multiplexing=true implies must be specified for Npgsql");
                     if (settings.Enlist)
                         throw new ArgumentException("Enlist=false must be specified for Npgsql");
 


### PR DESCRIPTION
During offline conversations with @roji I noticed the TE Npgsql max pool size being at 256. As I was recently doing some tuning of my own https://twitter.com/NinoFloris/status/1381651573978316809 I experienced first hand how reducing max pool size can have a very positive effect on perf. @roji then tested a matrix of max pool sizes in the perf lab and landed on 18 connections for a 4% increase in RPS on platform fortunes. (from ~444,239 to ~461,284)

This PR reflects the changes to the connection strings in many of the places referring to this 256 max though I skipped orchard and mono. I'm not too familiar with the repo structure and all its yamls so I welcome a thorough review of the touched/missing files.