### PR TITLE
Add TE scenarios for ASP.NET

### DIFF
--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -3,7 +3,7 @@ imports:
   - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
 
 jobs:
-  aspnetbenchmarks:
+  aspnet:
     source:
       repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
       branchOrCommit: master

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -3,6 +3,13 @@ imports:
   - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
 
 jobs:
+  aspnetbenchmarks:
+    source:
+      repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
+      branchOrCommit: master
+      dockerContextDirectory: frameworks/CSharp/aspnetcore/
+    readyStateText: Application started.
+
   nodejs:
     source:
       repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
@@ -251,4 +258,34 @@ scenarios:
       variables:
         presetHeaders: json
         path: /json
+        serverPort: 8080
+
+  fortunes:
+    db:
+      job: postgresql
+    application:
+      job: aspnetbenchmarks
+      source:
+          dockerFile: frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
+          dockerImageName: aspcore-mw-ado-pg
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes/raw
+        serverPort: 8080
+
+  fortunes_mysql:
+    db:
+      job: mysql
+    application:
+      job: aspnetbenchmarks
+      source:
+          dockerFile: frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
+          dockerImageName: aspcore-mw-ado-my
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes/raw
         serverPort: 8080

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -260,7 +260,7 @@ scenarios:
         path: /json
         serverPort: 8080
 
-  fortunes:
+  fortunes_aspnet:
     db:
       job: postgresql
     application:

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -275,7 +275,7 @@ scenarios:
         path: /fortunes/raw
         serverPort: 8080
 
-  fortunes_mysql:
+  fortunes_mysql_aspnet:
     db:
       job: mysql
     application:

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -279,7 +279,7 @@ scenarios:
     db:
       job: mysql
     application:
-      job: aspnetbenchmarks
+      job: aspnet
       source:
           dockerFile: frameworks/CSharp/aspnetcore/aspcore-mw-ado-my.dockerfile
           dockerImageName: aspcore-mw-ado-my

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -264,7 +264,7 @@ scenarios:
     db:
       job: postgresql
     application:
-      job: aspnetbenchmarks
+      job: aspnet
       source:
           dockerFile: frameworks/CSharp/aspnetcore/aspcore-mw-ado-pg.dockerfile
           dockerImageName: aspcore-mw-ado-pg


### PR DESCRIPTION
To support running TechEmpower scenarios on Crank (see #1676), this adds scenarios for ASP.NET in scenarios/te.benchmarks.yml, for both PG and MySQL.