### PR TITLE
Remove multiplexing timeout with Npgsql

### DIFF
--- a/scenarios/database.benchmarks.yml
+++ b/scenarios/database.benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
     arguments: "--nonInteractive true --scenarios {{scenario}} --urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --server {{server}} --kestrelTransport {{transport}} --protocol {{protocol}}"
     environmentVariables:
       database: PostgresQL
-      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
+      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000
 
   postgresql:
     source:

--- a/scenarios/platform.benchmarks.yml
+++ b/scenarios/platform.benchmarks.yml
@@ -18,7 +18,7 @@ jobs:
     framework: net5.0
     environmentVariables:
       database: PostgreSQL
-      connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Delay Us=500;Write Coalescing Buffer Threshold Bytes=1000
+      connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000
   
   postgresql:
     source:


### PR DESCRIPTION
The Npgsql multiplexing implementation has a timeout features, which waits for more commands to be executed before flushing the current packet; the idea was to sacrifice some latency to increase the number of commands per packet, thus reducing system calls, TCP fragmentation, etc.

This provided a benefit when I benchmarked last year, but I am unable to reproduce it now. In addition, it causes a significant regression on AMD - so we'll be removing this from 6.0.

For benchmarks and results, see https://github.com/npgsql/npgsql/issues/3749#issuecomment-843955819 and below.
