### PR TITLE
Bump Npgsql and EF versions for 6.0.0-preview4

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,15 +27,15 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <NpgsqlVersion>5.0.3</NpgsqlVersion>
-    <NpgsqlVersion60>6.0.0-preview3</NpgsqlVersion60>
+    <NpgsqlVersion>5.0.5</NpgsqlVersion>
+    <NpgsqlVersion60>6.0.0-preview4</NpgsqlVersion60>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.2</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion22>2.2.4</NpgsqlEntityFrameworkCorePostgreSQLVersion22>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.0.1</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.11</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.0-preview3</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.6</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.0-preview4</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
     <PomeloEntityFrameworkCoreMySqlVersion22>2.2.0</PomeloEntityFrameworkCoreMySqlVersion22>
@@ -43,14 +43,14 @@
     <PomeloEntityFrameworkCoreMySqlVersion31>3.1.1</PomeloEntityFrameworkCoreMySqlVersion31>
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqlServerVersion30>
     <MicrosoftEntityFrameworkCoreSqlServerVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqlServerVersion31>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.4</MicrosoftEntityFrameworkCoreSqlServerVersion50>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.0-preview.3.21201.2</MicrosoftEntityFrameworkCoreSqlServerVersion60>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.6</MicrosoftEntityFrameworkCoreSqlServerVersion50>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.0-preview.4.21253.1</MicrosoftEntityFrameworkCoreSqlServerVersion60>
     <MicrosoftEntityFrameworkCoreSqliteVersion21>2.1.14</MicrosoftEntityFrameworkCoreSqliteVersion21>
     <MicrosoftEntityFrameworkCoreSqliteVersion22>2.2.6</MicrosoftEntityFrameworkCoreSqliteVersion22>
     <MicrosoftEntityFrameworkCoreSqliteVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqliteVersion30>
     <MicrosoftEntityFrameworkCoreSqliteVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqliteVersion31>
-    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.4</MicrosoftEntityFrameworkCoreSqliteVersion50>
-    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.0-preview.3.21201.2</MicrosoftEntityFrameworkCoreSqliteVersion60>
+    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.6</MicrosoftEntityFrameworkCoreSqliteVersion50>
+    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.0-preview.4.21253.1</MicrosoftEntityFrameworkCoreSqliteVersion60>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -21,14 +21,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net5.0'">
-    <PackageReference Include="Npgsql" Version="5.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.5" />
+    <PackageReference Include="Npgsql" Version="5.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Npgsql" Version="6.0.0-preview3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview3" />
+    <PackageReference Include="Npgsql" Version="6.0.0-preview4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview4" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">


### PR DESCRIPTION
This brings in EF improvements like the logging caching.

/cc @ajcvickers

Scenario              | main branch | preview4 branch | Change
--------------------- | ----------- | --------------- | ------
Database, fortunes_ef | 252,837     | 280,714         | 11%
Database, dapper_ef   | 301,985     | 298,825         | -1%
Platform, fortunes_ef | 326,713     | 377,474         | 15.5%
Platform, fortunes    | 471,718     | 476,191         | 0.9%

<details>
<summary>Detail run results</summary>

### Database benchmarks, fortunes_ef, main branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 27      |
| Cores usage (%)     | 752     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 2,091   |
| Start Time (ms)     | 352     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 98                              |
| Cores usage (%)       | 2,730                           |
| Working Set (MB)      | 468                             |
| Private Memory (MB)   | 1,586                           |
| Build Time (ms)       | 5,382                           |
| Start Time (ms)       | 191                             |
| Published Size (KB)   | 105,574                         |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.3+e0671e7 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 15         |
| Cores usage (%)        | 423        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 933        |
| Requests/sec           | 252,837    |
| Requests               | 30,511,155 |
| Mean latency (ms)      | 1.10       |
| Max latency (ms)       | 32.29      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 331.20     |
| Latency 50th (ms)      | 0.89       |
| Latency 75th (ms)      | 1.30       |
| Latency 90th (ms)      | 1.68       |
| Latency 99th (ms)      | 5.48       |
```

### Database benchmarks, fortunes_ef, preview4 branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit preview4

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 29      |
| Cores usage (%)     | 803     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,799   |
| Start Time (ms)     | 335     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 97                              |
| Cores usage (%)       | 2,707                           |
| Working Set (MB)      | 468                             |
| Private Memory (MB)   | 1,586                           |
| Build Time (ms)       | 12,926                          |
| Start Time (ms)       | 202                             |
| Published Size (KB)   | 105,632                         |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.3+e0671e7 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 17         |
| Cores usage (%)        | 480        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 971        |
| Requests/sec           | 280,714    |
| Requests               | 33,713,583 |
| Mean latency (ms)      | 0.99       |
| Max latency (ms)       | 25.57      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 365.96     |
| Latency 50th (ms)      | 0.81       |
| Latency 75th (ms)      | 1.17       |
| Latency 90th (ms)      | 1.52       |
| Latency 99th (ms)      | 4.44       |
```

### Database benchmarks, fortunes_ef, main branch


```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_dapper --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 29      |
| Cores usage (%)     | 813     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,696   |
| Start Time (ms)     | 350     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,695                           |
| Working Set (MB)      | 447                             |
| Private Memory (MB)   | 1,573                           |
| Build Time (ms)       | 5,224                           |
| Start Time (ms)       | 187                             |
| Published Size (KB)   | 105,599                         |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.5+4dc663a |
| .NET Runtime Version  | 6.0.0-preview.6.21304.4+0d7c498 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 18         |
| Cores usage (%)        | 512        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 387        |
| Requests/sec           | 301,985    |
| Requests               | 36,268,216 |
| Mean latency (ms)      | 0.91       |
| Max latency (ms)       | 20.89      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 393.69     |
| Latency 50th (ms)      | 0.75       |
| Latency 75th (ms)      | 1.09       |
| Latency 90th (ms)      | 1.44       |
| Latency 99th (ms)      | 3.57       |
```

### Database benchmarks, fortunes_ef, preview4 branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/database.benchmarks.yml --scenario fortunes_dapper --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit preview4

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 29      |
| Cores usage (%)     | 820     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,694   |
| Start Time (ms)     | 334     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,693                           |
| Working Set (MB)      | 444                             |
| Private Memory (MB)   | 1,561                           |
| Build Time (ms)       | 8,559                           |
| Start Time (ms)       | 200                             |
| Published Size (KB)   | 105,657                         |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.5+4dc663a |
| .NET Runtime Version  | 6.0.0-preview.6.21304.4+0d7c498 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 19         |
| Cores usage (%)        | 519        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 358        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 386        |
| Requests/sec           | 298,825    |
| Requests               | 35,888,717 |
| Mean latency (ms)      | 0.92       |
| Max latency (ms)       | 24.02      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 389.57     |
| Latency 50th (ms)      | 0.76       |
| Latency 75th (ms)      | 1.10       |
| Latency 90th (ms)      | 1.46       |
| Latency 99th (ms)      | 3.76       |
```

### Platform benchmarks, fortunes_ef, main branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 30      |
| Cores usage (%)     | 827     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,725   |
| Start Time (ms)     | 342     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 97                              |
| Cores usage (%)       | 2,722                           |
| Working Set (MB)      | 508                             |
| Private Memory (MB)   | 1,614                           |
| Build Time (ms)       | 3,692                           |
| Start Time (ms)       | 1,562                           |
| Published Size (KB)   | 90,622                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.3+e0671e7 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 20         |
| Cores usage (%)        | 573        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 678        |
| Requests/sec           | 326,713    |
| Requests               | 39,238,133 |
| Mean latency (ms)      | 1.69       |
| Max latency (ms)       | 44.93      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 424.06     |
| Latency 50th (ms)      | 1.49       |
| Latency 75th (ms)      | 1.81       |
| Latency 90th (ms)      | 2.20       |
| Latency 99th (ms)      | 7.79       |
```

### Platform benchmarks, fortunes_ef, preview4 branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit preview4

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 32      |
| Cores usage (%)     | 898     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,951   |
| Start Time (ms)     | 357     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 97                              |
| Cores usage (%)       | 2,706                           |
| Working Set (MB)      | 509                             |
| Private Memory (MB)   | 1,621                           |
| Build Time (ms)       | 3,759                           |
| Start Time (ms)       | 1,649                           |
| Published Size (KB)   | 90,678                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.3+e0671e7 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 24         |
| Cores usage (%)        | 668        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 717        |
| Requests/sec           | 377,474    |
| Requests               | 45,334,377 |
| Mean latency (ms)      | 1.45       |
| Max latency (ms)       | 37.37      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 489.94     |
| Latency 50th (ms)      | 1.29       |
| Latency 75th (ms)      | 1.58       |
| Latency 90th (ms)      | 1.95       |
| Latency 99th (ms)      | 6.35       |
```

### Platform benchmarks, fortunes, main branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 37      |
| Cores usage (%)     | 1,031   |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,779   |
| Start Time (ms)     | 331     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 95                              |
| Cores usage (%)       | 2,674                           |
| Working Set (MB)      | 452                             |
| Private Memory (MB)   | 1,579                           |
| Build Time (ms)       | 3,656                           |
| Start Time (ms)       | 1,502                           |
| Published Size (KB)   | 90,622                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.3+e0671e7 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 855        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 72         |
| Requests/sec           | 471,718    |
| Requests               | 56,652,895 |
| Mean latency (ms)      | 1.14       |
| Max latency (ms)       | 29.08      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 612.27     |
| Latency 50th (ms)      | 1.03       |
| Latency 75th (ms)      | 1.23       |
| Latency 90th (ms)      | 1.54       |
| Latency 99th (ms)      | 4.22       |

```

### Platform benchmarks, fortunes, preview4 branch

```
dotnet run --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --variable warmup=45 --variable duration=120 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit preview4

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 37      |
| Cores usage (%)     | 1,038   |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,739   |
| Start Time (ms)     | 349     |
| Published Size (KB) | 914,270 |


| application           |                                 |
| --------------------- | ------------------------------- |
| CPU Usage (%)         | 96                              |
| Cores usage (%)       | 2,701                           |
| Working Set (MB)      | 462                             |
| Private Memory (MB)   | 1,594                           |
| Build Time (ms)       | 10,322                          |
| Start Time (ms)       | 1,373                           |
| Published Size (KB)   | 90,683                          |
| .NET Core SDK Version | 6.0.100-preview.6.21276.12      |
| ASP.NET Core Version  | 6.0.0-preview.6.21304.4+ef40046 |
| .NET Runtime Version  | 6.0.0-preview.6.21304.4+0d7c498 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 870        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 72         |
| Requests/sec           | 476,191    |
| Requests               | 57,190,414 |
| Mean latency (ms)      | 1.12       |
| Max latency (ms)       | 21.23      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 618.07     |
| Latency 50th (ms)      | 1.02       |
| Latency 75th (ms)      | 1.22       |
| Latency 90th (ms)      | 1.51       |
| Latency 99th (ms)      | 3.87       |
```

</details>




