### PR TITLE
Update JSON platform benchmarks to use JSON source generator

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
@@ -10,7 +10,11 @@ namespace PlatformBenchmarks
     {
         private async Task Caching(PipeWriter pipeWriter, int count)
         {
+#if NET6_0_OR_GREATER
             OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count), SerializerContext.CachedWorldArray);
+#else
+            OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count));
+#endif
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
@@ -10,7 +10,7 @@ namespace PlatformBenchmarks
     {
         private async Task Caching(PipeWriter pipeWriter, int count)
         {
-            OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count));
+            OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count), SerializerContext.CachedWorldArray);
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Buffers;
 using System.Text.Json;
 
@@ -9,7 +8,7 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
-        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions).Length;
+        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerContext.JsonMessage).Length;
 
         private readonly static AsciiString _jsonPreamble =
             _http11OK +
@@ -30,7 +29,8 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(bodyWriter);
 
             // Body
-            JsonSerializer.Serialize<JsonMessage>(utf8JsonWriter, new JsonMessage { message = "Hello, World!" }, SerializerOptions);
+            JsonSerializer.Serialize(utf8JsonWriter, new JsonMessage { message = "Hello, World!" }, SerializerContext.JsonMessage);
+            utf8JsonWriter.Flush();
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -8,7 +8,14 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
-        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerContext.JsonMessage).Length;
+        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(
+            new JsonMessage { message = "Hello, World!" },
+#if NET6_0_OR_GREATER
+            SerializerContext.JsonMessage
+#else
+            SerializerOptions
+#endif
+            ).Length;
 
         private readonly static AsciiString _jsonPreamble =
             _http11OK +
@@ -29,8 +36,15 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(bodyWriter);
 
             // Body
-            JsonSerializer.Serialize(utf8JsonWriter, new JsonMessage { message = "Hello, World!" }, SerializerContext.JsonMessage);
-            utf8JsonWriter.Flush();
+            JsonSerializer.Serialize(
+                utf8JsonWriter,
+                new JsonMessage { message = "Hello, World!" },
+#if NET6_0_OR_GREATER
+                SerializerContext.JsonMessage
+#else
+                SerializerOptions
+#endif
+                );
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
@@ -3,8 +3,10 @@
 
 using System.IO.Pipelines;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization.Metadata;
+#endif
 
 namespace PlatformBenchmarks
 {
@@ -12,10 +14,18 @@ namespace PlatformBenchmarks
     {
         private async Task MultipleQueries(PipeWriter pipeWriter, int count)
         {
+#if NET6_0_OR_GREATER
             OutputMultipleQueries(pipeWriter, await RawDb.LoadMultipleQueriesRows(count), SerializerContext.WorldArray);
+#else
+            OutputMultipleQueries(pipeWriter, await RawDb.LoadMultipleQueriesRows(count));
+#endif
         }
 
+#if NET6_0_OR_GREATER
         private static void OutputMultipleQueries<TWord>(PipeWriter pipeWriter, TWord[] rows, JsonTypeInfo<TWord[]> jsonTypeInfo)
+#else
+        private static void OutputMultipleQueries<TWord>(PipeWriter pipeWriter, TWord[] rows)
+#endif
         {
             var writer = GetWriter(pipeWriter, sizeHint: 160 * rows.Length); // in reality it's 152 for one
 
@@ -33,8 +43,15 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(utf8JsonWriter, rows, jsonTypeInfo);
-            utf8JsonWriter.Flush();
+            JsonSerializer.Serialize(
+                utf8JsonWriter,
+                rows,
+#if NET6_0_OR_GREATER
+                jsonTypeInfo
+#else
+                SerializerOptions
+#endif
+                );
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
@@ -32,7 +32,8 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize<World>(utf8JsonWriter, row, SerializerOptions);
+            JsonSerializer.Serialize(utf8JsonWriter, row, SerializerContext.World);
+            utf8JsonWriter.Flush();
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
@@ -32,8 +32,15 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(utf8JsonWriter, row, SerializerContext.World);
-            utf8JsonWriter.Flush();
+            JsonSerializer.Serialize(
+                utf8JsonWriter,
+                row,
+#if NET6_0_OR_GREATER
+                SerializerContext.World
+#else
+                SerializerOptions
+#endif
+                );
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
@@ -32,8 +32,15 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(utf8JsonWriter, rows, SerializerContext.WorldArray);
-            utf8JsonWriter.Flush();
+            JsonSerializer.Serialize(
+                utf8JsonWriter,
+                rows,
+#if NET6_0_OR_GREATER
+                SerializerContext.WorldArray
+#else
+                SerializerOptions
+#endif
+                );
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
@@ -32,7 +32,8 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize<World[]>(utf8JsonWriter, rows, SerializerOptions);
+            JsonSerializer.Serialize(utf8JsonWriter, rows, SerializerContext.WorldArray);
+            utf8JsonWriter.Flush();
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers.Text;
 using System.IO.Pipelines;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -34,7 +35,7 @@ namespace PlatformBenchmarks
 
         private readonly static AsciiString _plainTextBody = "Hello, World!";
 
-        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions();
+        private static readonly JsonContext SerializerContext = JsonContext.Default;
 
         private readonly static AsciiString _fortunesTableStart = "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>";
         private readonly static AsciiString _fortunesRowStart = "<tr><td>";
@@ -49,6 +50,14 @@ namespace PlatformBenchmarks
 
         [ThreadStatic]
         private static Utf8JsonWriter t_writer;
+
+        [JsonSerializable(typeof(JsonMessage), GenerationMode = JsonSourceGenerationMode.Serialization)]
+        [JsonSerializable(typeof(CachedWorld[]), GenerationMode = JsonSourceGenerationMode.Serialization)]
+        [JsonSerializable(typeof(World[]), GenerationMode = JsonSourceGenerationMode.Serialization)]
+        [JsonSerializable(typeof(World), GenerationMode = JsonSourceGenerationMode.Serialization)]
+        private partial class JsonContext : JsonSerializerContext
+        {
+        }
 
         public static class Paths
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -35,8 +35,6 @@ namespace PlatformBenchmarks
 
         private readonly static AsciiString _plainTextBody = "Hello, World!";
 
-        private static readonly JsonContext SerializerContext = JsonContext.Default;
-
         private readonly static AsciiString _fortunesTableStart = "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>";
         private readonly static AsciiString _fortunesRowStart = "<tr><td>";
         private readonly static AsciiString _fortunesColumn = "</td><td>";
@@ -51,13 +49,19 @@ namespace PlatformBenchmarks
         [ThreadStatic]
         private static Utf8JsonWriter t_writer;
 
-        [JsonSerializable(typeof(JsonMessage), GenerationMode = JsonSourceGenerationMode.Serialization)]
-        [JsonSerializable(typeof(CachedWorld[]), GenerationMode = JsonSourceGenerationMode.Serialization)]
-        [JsonSerializable(typeof(World[]), GenerationMode = JsonSourceGenerationMode.Serialization)]
-        [JsonSerializable(typeof(World), GenerationMode = JsonSourceGenerationMode.Serialization)]
+#if NET6_0_OR_GREATER
+        private static readonly JsonContext SerializerContext = JsonContext.Default;
+
+        [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
+        [JsonSerializable(typeof(JsonMessage))]
+        [JsonSerializable(typeof(CachedWorld[]))]
+        [JsonSerializable(typeof(World[]))]
         private partial class JsonContext : JsonSerializerContext
         {
         }
+#else
+        private static readonly JsonSerializerOptions SerializerOptions = new();
+#endif
 
         public static class Paths
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -33,7 +33,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="System.Text.Json" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="Npgsql" Version="6.0.0-preview4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview4" />
   </ItemGroup>

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21316.4" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.78" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21316.4" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
@@ -34,6 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21326.4" />
     <PackageReference Include="Npgsql" Version="6.0.0-preview4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview4" />
   </ItemGroup>

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="System.Text.Json" Version="6.0.0-preview.7.21326.4" />
+    <PackageReference Include="System.Text.Json" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="Npgsql" Version="6.0.0-preview4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview4" />
   </ItemGroup>


### PR DESCRIPTION
| Profile | Scenario | RPS (Before) | RPS (After) | RPS % increase | Max alloc rate (Before) (b/sec) | Max alloc rate (After) (b/sec) | Max alloc rate % decrease | Latency (Before) (ms) | Latency (After) (ms) | Latency % decrease | Start time + first request (Before) (ms) | Start time (After) | % Start time decrease |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| aspnet-citrine-lin | json | 1,232,440 | 1,265,521 | 2.684187466 | 41,672,184 | 12,429,712 | 70.17264082 | 0.57 | 0.51 | 10.52631579 | 246 | 262 | -6.504065041 |
| | multiple\_queries | 23,452 | 23,434 | -0.07675251578 | 752,562,891 | 727,026,011 | 3.393321715 | 10.92 | 11.01 | -0.8241758242 | 1725 | 1735 | -0.5797101449 |
| | single\_query | 397,556 | 402,294 | 1.191781787 | 1,084,997,824 | 1,098,367,805 | -1.232258785 | 0.66 | 0.66 | 0 | 1940 | 1831 | 5.618556701 |
| | updates | 18,276 | 18,478 | 1.105274677 | 1,072,226,685 | 1,067,972,931 | 0.3967215198 | 14 | 13.86 | 1 | 1955 | 1961 | -0.3069053708 |

We see a small increase in RPS and a big drop in max alloc rate for the `json` benchmark. There's also a small increase in RPS for the `single_query` benchmark. Otherwise, the rest of the benchmarks don't change substantially.

Benchmarks were run in 6 iterations; excluding the worst two and the best result; then taking the mean.
Benchmarks had 30s warmup.
Benchmarks run on `aspnet-citrine-lin` profile.

```
crank --config platform.benchmarks.yml --scenario json --profile aspnet-citrine-lin --variable warmup=30 --iterations 6 --exclude 2:1 --exclude-order "load:wrk/rps/mean;http/rps/mean" --application.options.collectCounters true
```


FYI @sebastienros @adamsitnik @eerhardt @steveharter @ericstj @stephentoub @jkotas @davidfowl 