### PR TITLE
Revert "Update JSON platform benchmarks to use JSON source generator …

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Caching.cs
@@ -10,11 +10,7 @@ namespace PlatformBenchmarks
     {
         private async Task Caching(PipeWriter pipeWriter, int count)
         {
-#if NET6_0_OR_GREATER
-            OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count), SerializerContext.CachedWorldArray);
-#else
             OutputMultipleQueries(pipeWriter, await RawDb.LoadCachedQueries(count));
-#endif
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Json.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Buffers;
 using System.Text.Json;
 
@@ -8,14 +9,7 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
-        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(
-            new JsonMessage { message = "Hello, World!" },
-#if NET6_0_OR_GREATER
-            SerializerContext.JsonMessage
-#else
-            SerializerOptions
-#endif
-            ).Length;
+        private readonly static uint _jsonPayloadSize = (uint)JsonSerializer.SerializeToUtf8Bytes(new JsonMessage { message = "Hello, World!" }, SerializerOptions).Length;
 
         private readonly static AsciiString _jsonPreamble =
             _http11OK +
@@ -36,15 +30,7 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(bodyWriter);
 
             // Body
-            JsonSerializer.Serialize(
-                utf8JsonWriter,
-                new JsonMessage { message = "Hello, World!" },
-#if NET6_0_OR_GREATER
-                SerializerContext.JsonMessage
-#else
-                SerializerOptions
-#endif
-                );
+            JsonSerializer.Serialize<JsonMessage>(utf8JsonWriter, new JsonMessage { message = "Hello, World!" }, SerializerOptions);
         }
     }
 }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.MultipleQueries.cs
@@ -4,9 +4,6 @@
 using System.IO.Pipelines;
 using System.Text.Json;
 using System.Threading.Tasks;
-#if NET6_0_OR_GREATER
-using System.Text.Json.Serialization.Metadata;
-#endif
 
 namespace PlatformBenchmarks
 {
@@ -14,18 +11,10 @@ namespace PlatformBenchmarks
     {
         private async Task MultipleQueries(PipeWriter pipeWriter, int count)
         {
-#if NET6_0_OR_GREATER
-            OutputMultipleQueries(pipeWriter, await RawDb.LoadMultipleQueriesRows(count), SerializerContext.WorldArray);
-#else
             OutputMultipleQueries(pipeWriter, await RawDb.LoadMultipleQueriesRows(count));
-#endif
         }
 
-#if NET6_0_OR_GREATER
-        private static void OutputMultipleQueries<TWord>(PipeWriter pipeWriter, TWord[] rows, JsonTypeInfo<TWord[]> jsonTypeInfo)
-#else
         private static void OutputMultipleQueries<TWord>(PipeWriter pipeWriter, TWord[] rows)
-#endif
         {
             var writer = GetWriter(pipeWriter, sizeHint: 160 * rows.Length); // in reality it's 152 for one
 
@@ -43,15 +32,7 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(
-                utf8JsonWriter,
-                rows,
-#if NET6_0_OR_GREATER
-                jsonTypeInfo
-#else
-                SerializerOptions
-#endif
-                );
+            JsonSerializer.Serialize<TWord[]>(utf8JsonWriter, rows, SerializerOptions);
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.SingleQuery.cs
@@ -32,15 +32,7 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(
-                utf8JsonWriter,
-                row,
-#if NET6_0_OR_GREATER
-                SerializerContext.World
-#else
-                SerializerOptions
-#endif
-                );
+            JsonSerializer.Serialize<World>(utf8JsonWriter, row, SerializerOptions);
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.Updates.cs
@@ -32,15 +32,7 @@ namespace PlatformBenchmarks
             utf8JsonWriter.Reset(pipeWriter);
 
             // Body
-            JsonSerializer.Serialize(
-                utf8JsonWriter,
-                rows,
-#if NET6_0_OR_GREATER
-                SerializerContext.WorldArray
-#else
-                SerializerOptions
-#endif
-                );
+            JsonSerializer.Serialize<World[]>(utf8JsonWriter, rows, SerializerOptions);
 
             // Content-Length
             lengthWriter.WriteNumeric((uint)utf8JsonWriter.BytesCommitted);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/BenchmarkApplication.cs
@@ -5,7 +5,6 @@ using System;
 using System.Buffers.Text;
 using System.IO.Pipelines;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 
@@ -35,6 +34,8 @@ namespace PlatformBenchmarks
 
         private readonly static AsciiString _plainTextBody = "Hello, World!";
 
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions();
+
         private readonly static AsciiString _fortunesTableStart = "<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>";
         private readonly static AsciiString _fortunesRowStart = "<tr><td>";
         private readonly static AsciiString _fortunesColumn = "</td><td>";
@@ -48,20 +49,6 @@ namespace PlatformBenchmarks
 
         [ThreadStatic]
         private static Utf8JsonWriter t_writer;
-
-#if NET6_0_OR_GREATER
-        private static readonly JsonContext SerializerContext = JsonContext.Default;
-
-        [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
-        [JsonSerializable(typeof(JsonMessage))]
-        [JsonSerializable(typeof(CachedWorld[]))]
-        [JsonSerializable(typeof(World[]))]
-        private partial class JsonContext : JsonSerializerContext
-        {
-        }
-#else
-        private static readonly JsonSerializerOptions SerializerOptions = new();
-#endif
 
         public static class Paths
         {


### PR DESCRIPTION
…(#1683)"

This reverts commit bf3490fcc218d6e88af358547db639bb386e135a.

This is temporary until we get a preview 7 SDK at this URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/main/latest.version. This is what crank uses to grab the SDK which is still preview6. The benchmarks are currently broken because of this. I will un-revert once preview7 is official.

cc @layomia @adamsitnik @stephentoub 