### PR TITLE
gRPC scenarios HTTP/3 Windows fix

### DIFF
--- a/build/grpc-v2-scenarios.yml
+++ b/build/grpc-v2-scenarios.yml
@@ -117,7 +117,7 @@ steps:
     - ${{ each payload in parameters.payloads }}:
       - ${{ each protocol in parameters.protocols }}:
         - ${{ each stream in parameters.connectionStreams }}:
-          - ${{ if or( not( eq(payload.displayName, 'h3')), eq( parameters.runH3, 'true')) }}:
+          - ${{ if or( not( eq(protocol.displayName, 'h3')), eq( parameters.runH3, 'true')) }}:
             - task: PublishToAzureServiceBus@1
               condition: succeededOrFailed()
               timeoutInMinutes: 5

--- a/build/grpc-v2-scenarios.yml
+++ b/build/grpc-v2-scenarios.yml
@@ -46,8 +46,6 @@ parameters:
 
   - displayName: "ASP.NET Core - Client: h2load"
     arguments: --scenario grpcaspnetcoreserver-h2loadclient   $(grpcJobs) --property server=grpcaspnetcoreserver --property client=h2loadclient --application.options.collectCounters true
-  - displayName: "Grpc.Core - Client: h2load"
-    arguments: --scenario grpccoreserver-h2loadclient         $(grpcJobs) --property server=grpccoreserver --property client=h2loadclient --application.options.collectCounters true
   - displayName: "Go - Client: h2load"
     arguments: --scenario grpcgoserver-h2loadclient           $(grpcJobs) --property server=grpcgoserver --property client=h2loadclient
 
@@ -96,6 +94,7 @@ parameters:
       arguments: --variable streams=70 --variable connections=1 --variable threads=1 --property streams=70x1
 
 steps:
+# h2c h2load unary to various servers
 - ${{ each s in parameters.h2loadscenarios }}:
   - ${{ each stream in parameters.connectionStreams }}:
     - task: PublishToAzureServiceBus@1
@@ -110,6 +109,9 @@ steps:
             "name": "crank",
             "args": [ "--application.channel edge --application.framework net6.0 --table GrpcBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --load.variables.duration ${{ parameters.duration }} --load.variables.warmup ${{ parameters.warmup }} ${{ s.arguments }} ${{ stream.arguments }} --variable protocol=h2c --property protocol=h2c --property scenario=unary --property payload=0 --variable body=AAAAAAcKBVdvcmxk --variable path=/grpc.testing.BenchmarkService/UnaryCall" ]	
           }
+
+# h2/h3 HttpClient to ASP.NET Core
+# h3 is currently Linux only
 - ${{ each s in parameters.grpcnetscenarios }}:
   - ${{ each callType in parameters.callTypes }}:
     - ${{ each payload in parameters.payloads }}:
@@ -129,6 +131,8 @@ steps:
                     "name": "crank",
                     "args": [ "--application.channel edge --load.channel edge --application.framework net6.0 --load.framework net6.0 --table GrpcBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --load.variables.duration ${{ parameters.duration }} --load.variables.warmup ${{ parameters.warmup }} ${{ s.arguments }} ${{ callType.arguments }} ${{ payload.arguments }} ${{ stream.arguments }} ${{ protocol.arguments }}" ]
                   }
+
+# h2c between various clients and servers
 - ${{ each s in parameters.scenarios }}:
   - ${{ each callType in parameters.callTypes }}:
     - ${{ each payload in parameters.payloads }}:

--- a/build/grpc-v2-scenarios.yml
+++ b/build/grpc-v2-scenarios.yml
@@ -32,13 +32,6 @@ parameters:
   - displayName: "ASP.NET Core - Client: Go"
     arguments: --scenario grpcaspnetcoreserver-grpcgoclient   $(grpcJobs) --property server=grpcaspnetcoreserver --property client=grpcgoclient --application.options.collectCounters true
 
-  - displayName: "Grpc.Core - Client: Grpc.Net.Client"
-    arguments: --scenario grpccoreserver-grpcnetclient        $(grpcJobs) --property server=grpccoreserver --property client=grpcnetclient --application.options.collectCounters true
-  - displayName: "Grpc.Core - Client: Grpc.Core"
-    arguments: --scenario grpccoreserver-grpccoreclient       $(grpcJobs) --property server=grpccoreserver --property client=grpccoreclient --application.options.collectCounters true
-  - displayName: "Grpc.Core - Client: Go"
-    arguments: --scenario grpccoreserver-grpcgoclient         $(grpcJobs) --property server=grpccoreserver --property client=grpcgoclient --application.options.collectCounters true
-
   - displayName: "Go - Client: Grpc.Net.Client"
     arguments: --scenario grpcgoserver-grpcnetclient          $(grpcJobs) --property server=grpcgoserver --property client=grpcnetclient
   - displayName: "Go - Client: Grpc.Core"
@@ -107,7 +100,7 @@ steps:
   - ${{ each stream in parameters.connectionStreams }}:
     - task: PublishToAzureServiceBus@1
       condition: succeededOrFailed()
-      displayName: ${{ s.displayName }} h2c ${{ stream.displayName }}
+      displayName: h2c ${{ s.displayName }} ${{ stream.displayName }}
       inputs:
         connectedServiceName: ${{ parameters.connection }}
         waitForCompletion: true
@@ -122,19 +115,20 @@ steps:
     - ${{ each payload in parameters.payloads }}:
       - ${{ each protocol in parameters.protocols }}:
         - ${{ each stream in parameters.connectionStreams }}:
-          - task: PublishToAzureServiceBus@1
-            condition: succeededOrFailed()
-            timeoutInMinutes: 5
-            displayName: ${{ s.displayName }} ${{ callType.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} ${{ stream.displayName }}
-            inputs:
-              connectedServiceName: ${{ parameters.connection }}
-              waitForCompletion: true
-              messageBody: |
-                {
-                  "condition": "${{ parameters.condition }} && (new Date().getUTCHours() - 7 + 24) % 24 >= 13",
-                  "name": "crank",
-                  "args": [ "--application.channel edge --load.channel edge --application.framework net6.0 --load.framework net6.0 --table GrpcBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --load.variables.duration ${{ parameters.duration }} --load.variables.warmup ${{ parameters.warmup }} ${{ s.arguments }} ${{ callType.arguments }} ${{ payload.arguments }} ${{ stream.arguments }} ${{ protocol.arguments }}" ]
-                }
+          - ${{ if or( not( eq(payload.displayName, 'h3')), eq( parameters.runH3, 'true')) }}:
+            - task: PublishToAzureServiceBus@1
+              condition: succeededOrFailed()
+              timeoutInMinutes: 5
+              displayName: ${{ protocol.displayName }} ${{ s.displayName }} ${{ callType.displayName }} ${{ payload.displayName }} ${{ stream.displayName }}
+              inputs:
+                connectedServiceName: ${{ parameters.connection }}
+                waitForCompletion: true
+                messageBody: |
+                  {
+                    "condition": "${{ parameters.condition }} && (new Date().getUTCHours() - 7 + 24) % 24 >= 13",
+                    "name": "crank",
+                    "args": [ "--application.channel edge --load.channel edge --application.framework net6.0 --load.framework net6.0 --table GrpcBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --profile ${{ parameters.profile }} --no-metadata --no-measurements --load.variables.duration ${{ parameters.duration }} --load.variables.warmup ${{ parameters.warmup }} ${{ s.arguments }} ${{ callType.arguments }} ${{ payload.arguments }} ${{ stream.arguments }} ${{ protocol.arguments }}" ]
+                  }
 - ${{ each s in parameters.scenarios }}:
   - ${{ each callType in parameters.callTypes }}:
     - ${{ each payload in parameters.payloads }}:
@@ -142,7 +136,7 @@ steps:
         - task: PublishToAzureServiceBus@1
           condition: succeededOrFailed()
           timeoutInMinutes: 5
-          displayName: ${{ s.displayName }} ${{ callType.displayName }} ${{ payload.displayName }} h2c ${{ stream.displayName }}
+          displayName: h2c ${{ s.displayName }} ${{ callType.displayName }} ${{ payload.displayName }} ${{ stream.displayName }}
           inputs:
             connectedServiceName: ${{ parameters.connection }}
             waitForCompletion: true


### PR DESCRIPTION
Remove Grpc.Core server tests. It's being deprecated. Reduces the number of gRPC jobs.

Exclude h3 tests when supportsH3 parameter is not true. Stop h3 tests from erroring on Windows.