### PR TITLE
Bump Npgsql dependencies to 6.0.0-rc.2

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,30 +27,37 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <NpgsqlVersion>5.0.5</NpgsqlVersion>
-    <NpgsqlVersion60>6.0.0-preview4</NpgsqlVersion60>
+
+    <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
+    <NpgsqlVersion60>6.0.0-rc.2</NpgsqlVersion60>
+
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.2</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion22>2.2.4</NpgsqlEntityFrameworkCorePostgreSQLVersion22>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.0.1</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.11</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.6</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.0-preview4</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.0-rc.2</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
+
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
     <PomeloEntityFrameworkCoreMySqlVersion22>2.2.0</PomeloEntityFrameworkCoreMySqlVersion22>
     <PomeloEntityFrameworkCoreMySqlVersion30>3.0.1</PomeloEntityFrameworkCoreMySqlVersion30>
     <PomeloEntityFrameworkCoreMySqlVersion31>3.1.1</PomeloEntityFrameworkCoreMySqlVersion31>
+    <PomeloEntityFrameworkCoreMySqlVersion50>5.0.2</PomeloEntityFrameworkCoreMySqlVersion50>
+    <PomeloEntityFrameworkCoreMySqlVersion60>6.0.0-preview.7</PomeloEntityFrameworkCoreMySqlVersion60>
+
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqlServerVersion30>
     <MicrosoftEntityFrameworkCoreSqlServerVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqlServerVersion31>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.6</MicrosoftEntityFrameworkCoreSqlServerVersion50>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.0-preview.4.21253.1</MicrosoftEntityFrameworkCoreSqlServerVersion60>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.10</MicrosoftEntityFrameworkCoreSqlServerVersion50>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.0-rc.2.21480.5</MicrosoftEntityFrameworkCoreSqlServerVersion60>
+
     <MicrosoftEntityFrameworkCoreSqliteVersion21>2.1.14</MicrosoftEntityFrameworkCoreSqliteVersion21>
     <MicrosoftEntityFrameworkCoreSqliteVersion22>2.2.6</MicrosoftEntityFrameworkCoreSqliteVersion22>
     <MicrosoftEntityFrameworkCoreSqliteVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqliteVersion30>
     <MicrosoftEntityFrameworkCoreSqliteVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqliteVersion31>
-    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.6</MicrosoftEntityFrameworkCoreSqliteVersion50>
-    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.0-preview.4.21253.1</MicrosoftEntityFrameworkCoreSqliteVersion60>
+    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.10</MicrosoftEntityFrameworkCoreSqliteVersion50>
+    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.0-rc.2.21480.5</MicrosoftEntityFrameworkCoreSqliteVersion60>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -54,8 +54,8 @@
     <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion21)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion21)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion21)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion21)" />
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.2'">
@@ -69,8 +69,8 @@
     <PackageReference Include="Microsoft.AspNetCore.AspNetCoreModuleV2" Version="2.2.2" />
     
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion22)" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion22)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion22)" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion22)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
@@ -81,11 +81,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="3.0.0-preview3-19122-02" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion30)" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion50)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.1" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion30)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion30)" />
-
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion30)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
@@ -96,11 +95,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="3.0.0-preview3-19122-02" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion31)" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion50)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion31)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion31)" />
-
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion31)" />
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework) == 'net5.0'">
@@ -113,10 +111,10 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="5.0.0-preview.6.20303.1" />
 
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion50)" />
-    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion50)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion50)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion50)" />
-
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion50)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
@@ -130,7 +128,7 @@
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion60)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion60)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion60)" />
-
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion60)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -86,7 +86,7 @@ namespace Benchmarks
 #endif
                                 )
 #if NET6_0_OR_GREATER
-                            .DisableConcurrencyDetection()
+                            .EnableThreadSafetyChecks(false)
 #endif
                         , 1024);
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/EfDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/EfDb.cs
@@ -25,7 +25,7 @@ namespace PlatformBenchmarks
 #endif
                 )
 #if NET6_0_OR_GREATER
-                            .DisableConcurrencyDetection()
+                            .EnableThreadSafetyChecks(false)
 #endif
                 ;
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -211,8 +211,13 @@ namespace PlatformBenchmarks
 
         private (NpgsqlCommand readCmd, NpgsqlParameter<int> idParameter) CreateReadCommand(NpgsqlConnection connection)
         {
+#if NET6_0_OR_GREATER
+            var cmd = new NpgsqlCommand("SELECT id, randomnumber FROM world WHERE id = $1", connection);
+            var parameter = new NpgsqlParameter<int> { Value = _random.Next(1, 10001) };
+#else
             var cmd = new NpgsqlCommand("SELECT id, randomnumber FROM world WHERE id = @Id", connection);
             var parameter = new NpgsqlParameter<int>(parameterName: "@Id", value: _random.Next(1, 10001));
+#endif
 
             cmd.Parameters.Add(parameter);
 

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
-    <PackageReference Include="Npgsql" Version="6.0.0-preview4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-preview4" />
+    <PackageReference Include="Npgsql" Version="6.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-rc.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">


### PR DESCRIPTION
And use positional parameters in platform benchmarks.

Bump other database-related dependencies.

scenario              | Before/After | RPS
--------------------- | ------------ | ---
Fortunes platform raw | Before       | 482,143
Fortunes platform raw | After        | 475,239
Fortunes platform EF  | Before       | 372,978
Fortunes platform EF  | After        | 373,148

<details>
<summary>Detailed run results</summary>

### Fortunes platform raw, Before

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit main --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 39      |
| Cores usage (%)     | 1,085   |
| Working Set (MB)    | 46      |
| Build Time (ms)     | 1,706   |
| Start Time (ms)     | 357     |
| Published Size (KB) | 915,635 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 95                         |
| Cores usage (%)       | 2,650                      |
| Working Set (MB)      | 467                        |
| Private Memory (MB)   | 2,043                      |
| Build Time (ms)       | 4,249                      |
| Start Time (ms)       | 1,408                      |
| Published Size (KB)   | 93,749                     |
| .NET Core SDK Version | 6.0.100-rtm.21519.18       |
| ASP.NET Core Version  | 6.0.0-rtm.21519.22+66fd211 |
| .NET Runtime Version  | 6.0.0-rtm.21518.12+5a23dc3 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 876        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 73         |
| Requests/sec           | 482,143    |
| Requests               | 57,905,437 |
| Mean latency (ms)      | 1.11       |
| Max latency (ms)       | 21.00      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 625.80     |
| Latency 50th (ms)      | 1.00       |
| Latency 75th (ms)      | 1.21       |
| Latency 90th (ms)      | 1.51       |
| Latency 99th (ms)      | 4.19       |
```

### Fortunes platform raw, After

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit NpgsqlRc1 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 37      |
| Cores usage (%)     | 1,040   |
| Working Set (MB)    | 44      |
| Build Time (ms)     | 1,878   |
| Start Time (ms)     | 345     |
| Published Size (KB) | 915,635 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 94                         |
| Cores usage (%)       | 2,634                      |
| Working Set (MB)      | 491                        |
| Private Memory (MB)   | 2,064                      |
| Build Time (ms)       | 2,963                      |
| Start Time (ms)       | 1,435                      |
| Published Size (KB)   | 94,090                     |
| .NET Core SDK Version | 6.0.100-rtm.21519.18       |
| ASP.NET Core Version  | 6.0.0-rtm.21519.22+66fd211 |
| .NET Runtime Version  | 6.0.0-rtm.21518.12+5a23dc3 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 31         |
| Cores usage (%)        | 856        |
| Working Set (MB)       | 37         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 82         |
| Requests/sec           | 475,239    |
| Requests               | 57,076,128 |
| Mean latency (ms)      | 1.13       |
| Max latency (ms)       | 19.96      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 616.84     |
| Latency 50th (ms)      | 1.02       |
| Latency 75th (ms)      | 1.22       |
| Latency 90th (ms)      | 1.53       |
| Latency 99th (ms)      | 4.18       |
```

### Fortunes platform EF, Before

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit main --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 32      |
| Cores usage (%)     | 910     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,942   |
| Start Time (ms)     | 339     |
| Published Size (KB) | 915,635 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 96                         |
| Cores usage (%)       | 2,682                      |
| Working Set (MB)      | 624                        |
| Private Memory (MB)   | 2,116                      |
| Build Time (ms)       | 4,289                      |
| Start Time (ms)       | 1,451                      |
| Published Size (KB)   | 93,749                     |
| .NET Core SDK Version | 6.0.100-rtm.21519.18       |
| ASP.NET Core Version  | 6.0.0-rtm.21519.22+66fd211 |
| .NET Runtime Version  | 6.0.0-rtm.21518.12+5a23dc3 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 24         |
| Cores usage (%)        | 663        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 750        |
| Requests/sec           | 372,978    |
| Requests               | 44,794,503 |
| Mean latency (ms)      | 1.47       |
| Max latency (ms)       | 35.21      |
| Bad responses          | 0          |
| Socket errors          | 3          |
| Read throughput (MB/s) | 484.11     |
| Latency 50th (ms)      | 1.30       |
| Latency 75th (ms)      | 1.60       |
| Latency 90th (ms)      | 2.02       |
| Latency 99th (ms)      | 6.20       |
```

### Fortunes platform EF, After

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes_ef --profile aspnet-citrine-lin --application.framework net6.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit NpgsqlRc1 --variable warmup=45 --variable duration=120

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 32      |
| Cores usage (%)     | 891     |
| Working Set (MB)    | 45      |
| Build Time (ms)     | 1,720   |
| Start Time (ms)     | 349     |
| Published Size (KB) | 915,635 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 96                         |
| Cores usage (%)       | 2,679                      |
| Working Set (MB)      | 731                        |
| Private Memory (MB)   | 2,305                      |
| Build Time (ms)       | 4,258                      |
| Start Time (ms)       | 1,405                      |
| Published Size (KB)   | 94,090                     |
| .NET Core SDK Version | 6.0.100-rtm.21519.18       |
| ASP.NET Core Version  | 6.0.0-rtm.21519.22+66fd211 |
| .NET Runtime Version  | 6.0.0-rtm.21518.12+5a23dc3 |


| load                   |            |
| ---------------------- | ---------- |
| CPU Usage (%)          | 24         |
| Cores usage (%)        | 669        |
| Working Set (MB)       | 38         |
| Private Memory (MB)    | 363        |
| Start Time (ms)        | 0          |
| First Request (ms)     | 796        |
| Requests/sec           | 373,148    |
| Requests               | 44,815,164 |
| Mean latency (ms)      | 1.48       |
| Max latency (ms)       | 31.51      |
| Bad responses          | 0          |
| Socket errors          | 0          |
| Read throughput (MB/s) | 484.33     |
| Latency 50th (ms)      | 1.29       |
| Latency 75th (ms)      | 1.60       |
| Latency 90th (ms)      | 2.05       |
| Latency 99th (ms)      | 6.62       |
```

</details>
