### PR TITLE
Use NonValidated headers in HttpClient proxy + avoid logging costs

### DIFF
--- a/src/BenchmarksApps/HttpClient/Proxy/Proxy.csproj
+++ b/src/BenchmarksApps/HttpClient/Proxy/Proxy.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
-    <LangVersion>8</LangVersion>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/HttpClient/Proxy/appsettings.json
+++ b/src/BenchmarksApps/HttpClient/Proxy/appsettings.json
@@ -1,9 +1,14 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore.Hosting.Diagnostics": "None"
+    },
+    "EventLog": {
+      "LogLevel": {
+        "Default": "None"
+      }
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
- Used `NonValidated` when copying headers now that YARP does the same
- Lowered the logging level to prevent AspNetCore from creating an `Activity` per request (resulting in more work on both AspNetCore and HttpClient's side). This is something we already disabled in YARP for benchmarks.
- Avoided allocating the `new Version(2, 0)` per request
- Changed how the destination `Uri` is created to be closer to what YARP does

| load                | base      | pr        |         |
| ------------------- | --------- | --------- | ------- |
| CPU Usage (%)       |        36 |        40 | +11,11% |
| Cores usage (%)     |     1.001 |     1.112 | +11,09% |
| Working Set (MB)    |        41 |        42 |  +2,44% |
| Private Memory (MB) |       110 |       110 |   0,00% |
| Start Time (ms)     |        97 |        96 |  -1,03% |
| First Request (ms)  |       148 |       158 |  +6,76% |
| Requests            | 8.680.249 | 9.740.038 | +12,21% |
| Bad responses       |         0 |         0 |         |
| Mean latency (us)   |       882 |       786 | -10,92% |
| Max latency (us)    |   133.249 |    75.982 | -42,98% |
| Requests/sec        |   289.578 |   325.247 | +12,32% |
| Requests/sec (max)  |   327.136 |   368.215 | +12,56% |