### PR TITLE
HttpClient benchmark - add generated headers

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -433,6 +433,10 @@ crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenario
   - `--variable requestHeaders=none` (default)
   - `--variable requestHeaders=connectionclose`
   - `--variable requestHeaders=expectcontinue`
+- Number of generated request headers with static values:
+  - `--variable generatedStaticRequestHeadersCount=<N>` (default: `0`)
+- Number of generated request headers with values changing per each request:
+  - `--variable generatedDynamicRequestHeadersCount=<N>` (default: `0`)
 - Number of HTTP clients (HttpClient in `httpClient` job, connection in WRK):
   - `--variable numberOfHttpClients=<N>` (default: `1`)
 - Number of concurrect requests per one HTTP client -- *unsupported by WRK*:
@@ -471,6 +475,9 @@ crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenario
 - Whether to use HttpMessageInvoker instead of HttpClient:
   - `--variable useHttpMessageInvoker=false` (default)
   - `--variable useHttpMessageInvoker=true`
+- Whether to use HttpClient.DefaultRequestHeaders for pre-set and static headers:
+  - `--variable useDefaultRequestHeaders=false` (default)
+  - `--variable useDefaultRequestHeaders=true`
 
 ## FAQ
 

--- a/scenarios/httpclient.benchmarks.yml
+++ b/scenarios/httpclient.benchmarks.yml
@@ -26,12 +26,16 @@ variables:
     http20EnableMultipleConnections: true
     useWinHttpHandler: false
     useHttpMessageInvoker: false
+    useDefaultRequestHeaders: false
 
+    # Request headers parameters:
     headersDictionary:
       none: '' # supported in WRK
       connectionclose: '--header "Connection: close"' # supported in WRK
       expectcontinue: '--header "Expect: 100-continue"'
     requestHeaders: none
+    generatedStaticRequestHeadersCount: 0
+    generatedDynamicRequestHeadersCount: 0
 
 scenarios:
   httpclient-kestrel-get:
@@ -106,6 +110,14 @@ scenarios:
           {
             throw "Unsupported requestHeaders value: " + job.Variables.requestHeaders;
           }
+          if (String(job.Variables.generatedStaticRequestHeadersCount) != "0")
+          {
+            throw "generatedStaticRequestHeadersCount is unsupported in WRK. Expected: 0, got: " + job.Variables.generatedStaticRequestHeadersCount;
+          }
+          if (String(job.Variables.generatedDynamicRequestHeadersCount) != "0")
+          {
+            throw "generatedDynamicRequestHeadersCount is unsupported in WRK. Expected: 0, got: " + job.Variables.generatedDynamicRequestHeadersCount;
+          }
           '
 
 
@@ -126,7 +138,7 @@ jobs:
     isConsoleApp: true
     waitForExit: true
     timeout: 1200 #seconds
-    arguments: "--address {{serverAddress}} --port {{serverPort}} --useHttps {{useHttps}} --scenario {{scenario}} --httpVersion {{httpVersion}} --numberOfHttpClients {{numberOfHttpClients}} --concurrencyPerHttpClient {{concurrencyPerHttpClient}} --http11MaxConnectionsPerServer {{http11MaxConnectionsPerServer}} --http20EnableMultipleConnections {{http20EnableMultipleConnections}} --useWinHttpHandler {{useWinHttpHandler}} --useHttpMessageInvoker {{useHttpMessageInvoker}} --collectRequestTimings {{collectRequestTimings}} --contentSize {{requestContentSize}} --contentWriteSize {{requestContentWriteSize}} --contentFlushAfterWrite {{requestContentFlushAfterWrite}} --contentUnknownLength {{requestContentUnknownLength}} {{headersDictionary[requestHeaders]}} --warmup {{warmup}} --duration {{duration}}"
+    arguments: "--address {{serverAddress}} --port {{serverPort}} --useHttps {{useHttps}} --scenario {{scenario}} --httpVersion {{httpVersion}} --numberOfHttpClients {{numberOfHttpClients}} --concurrencyPerHttpClient {{concurrencyPerHttpClient}} --http11MaxConnectionsPerServer {{http11MaxConnectionsPerServer}} --http20EnableMultipleConnections {{http20EnableMultipleConnections}} --useWinHttpHandler {{useWinHttpHandler}} --useHttpMessageInvoker {{useHttpMessageInvoker}} --collectRequestTimings {{collectRequestTimings}} --contentSize {{requestContentSize}} --contentWriteSize {{requestContentWriteSize}} --contentFlushAfterWrite {{requestContentFlushAfterWrite}} --contentUnknownLength {{requestContentUnknownLength}} {{headersDictionary[requestHeaders]}} --generatedStaticHeadersCount {{generatedStaticRequestHeadersCount}} --generatedDynamicHeadersCount {{generatedDynamicRequestHeadersCount}} --useDefaultRequestHeaders {{useDefaultRequestHeaders}} --warmup {{warmup}} --duration {{duration}}"
 
 profiles:
   local:

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptions.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptions.cs
@@ -22,6 +22,9 @@ public class ClientOptions
     public bool ContentFlushAfterWrite { get; set; }
     public bool ContentUnknownLength { get; set; }
     public List<(string Name, string? Value)> Headers { get; set; } = new();
+    public int GeneratedStaticHeadersCount { get; set; }
+    public int GeneratedDynamicHeadersCount { get; set; }
+    public bool UseDefaultRequestHeaders { get; set; }
     public int Warmup { get; set; }
     public int Duration { get; set; }
 
@@ -33,6 +36,7 @@ public class ClientOptions
             $"UseHttpMessageInvoker={UseHttpMessageInvoker}; CollectRequestTimings={CollectRequestTimings}; Scenario={Scenario}; " +
             $"ContentSize={ContentSize}; ContentWriteSize={ContentWriteSize}; ContentFlushAfterWrite={ContentFlushAfterWrite}; " +
             $"ContentUnknownLength={ContentUnknownLength}; Headers=[{string.Join(", ", Headers.Select(h => $"\"{h.Name}: {h.Value}\""))}]; " +
-            $"Warmup={Warmup}; Duration={Duration}";
+            $"GeneratedStaticHeadersCount={GeneratedStaticHeadersCount}; GeneratedDynamicHeadersCount={GeneratedDynamicHeadersCount}; " +
+            $"UseDefaultRequestHeaders={UseDefaultRequestHeaders}; Warmup={Warmup}; Duration={Duration}";
     }
 }

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptionsBinder.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptionsBinder.cs
@@ -22,6 +22,9 @@ public class ClientOptionsBinder : BinderBase<ClientOptions>
     public static Option<bool> ContentFlushAfterWriteOption { get; } = new ("--contentFlushAfterWrite", () => false, "Flush request content stream after each write");
     public static Option<bool> ContentUnknownLengthOption { get; } = new ("--contentUnknownLength", () => false, "False to send Content-Length header, true to use chunked encoding for HTTP/1.1 or unknown content length for HTTP/2.0 and 3.0");
     public static Option<string[]> HeaderOption { get; } = new (new string[] { "-H", "--header" }, "Custom headers, multiple values allowed");
+    public static Option<int> GeneratedStaticHeadersCountOption { get; } = new ("--generatedStaticHeadersCount", () => 0, "Number of generated request headers with static values");
+    public static Option<int> GeneratedDynamicHeadersCountOption { get; } = new ("--generatedDynamicHeadersCount", () => 0, "Number of generated request headers with values changing per each request");
+    public static Option<bool> UseDefaultRequestHeadersOption { get; } = new ("--useDefaultRequestHeaders", () => false, "Use HttpClient.DefaultRequestHeaders whenever possible");
     public static Option<int> WarmupOption { get; } = new ("--warmup", () => ClientOptions.DefaultDuration, "Duration of the warmup in seconds");
     public static Option<int> DurationOption { get; } = new ("--duration", () => ClientOptions.DefaultDuration, "Duration of the test in seconds");
 
@@ -44,6 +47,9 @@ public class ClientOptionsBinder : BinderBase<ClientOptions>
         command.AddOption(ContentFlushAfterWriteOption);
         command.AddOption(ContentUnknownLengthOption);
         command.AddOption(HeaderOption);
+        command.AddOption(GeneratedStaticHeadersCountOption);
+        command.AddOption(GeneratedDynamicHeadersCountOption);
+        command.AddOption(UseDefaultRequestHeadersOption);
         command.AddOption(WarmupOption);
         command.AddOption(DurationOption);
     }
@@ -70,6 +76,9 @@ public class ClientOptionsBinder : BinderBase<ClientOptions>
             ContentWriteSize = parsed.GetValueForOption(ContentWriteSizeOption),
             ContentFlushAfterWrite = parsed.GetValueForOption(ContentFlushAfterWriteOption),
             ContentUnknownLength = parsed.GetValueForOption(ContentUnknownLengthOption),
+            GeneratedStaticHeadersCount = parsed.GetValueForOption(GeneratedStaticHeadersCountOption),
+            GeneratedDynamicHeadersCount = parsed.GetValueForOption(GeneratedDynamicHeadersCountOption),
+            UseDefaultRequestHeaders = parsed.GetValueForOption(UseDefaultRequestHeadersOption),
             Warmup = parsed.GetValueForOption(WarmupOption),
             Duration = parsed.GetValueForOption(DurationOption)
         };

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using Microsoft.Crank.EventSources;
@@ -18,6 +18,9 @@ class Program
     private static string s_url = null!;
     private static List<HttpMessageInvoker> s_httpClients = new();
     private static Metrics s_metrics = new();
+
+    private static List<(string Name, string? Value)> s_generatedStaticHeaders = new();
+    private static List<string> s_generatedDynamicHeaderNames = new();
 
     private static byte[]? s_requestContentData = null;
     private static byte[]? s_requestContentLastChunk = null;
@@ -71,6 +74,11 @@ class Program
         {
             throw new ArgumentException("Expected to have ContentSize > 0 for 'post' scenario, got " + s_options.ContentSize);
         }
+
+        if (s_options.UseHttpMessageInvoker && s_options.UseDefaultRequestHeaders)
+        {
+            throw new ArgumentException("HttpMessageInvoker does not support DefaultRequestHeaders");
+        }
     }
 
     private static async Task Setup()
@@ -80,6 +88,11 @@ class Program
 
         s_url = $"http{(s_options.UseHttps ? "s" : "")}://{s_options.Address}:{s_options.Port}";
         Log("Url: " + s_url);
+
+        if (s_options.GeneratedStaticHeadersCount > 0 || s_options.GeneratedDynamicHeadersCount > 0)
+        {
+            CreateGeneratedHeaders();
+        }
         
         int max11ConnectionsPerServer = s_options.Http11MaxConnectionsPerServer > 0 ? s_options.Http11MaxConnectionsPerServer : int.MaxValue;
 
@@ -110,7 +123,19 @@ class Program
                 };
             }
 
-            s_httpClients.Add(s_options.UseHttpMessageInvoker ? new HttpMessageInvoker(handler) : new HttpClient(handler));
+            if (s_options.UseHttpMessageInvoker)
+            {
+                s_httpClients.Add(new HttpMessageInvoker(handler));
+            }
+            else
+            {
+                var client = new HttpClient(handler);
+                if (s_options.UseDefaultRequestHeaders)
+                {
+                    AddStaticHeaders(client.DefaultRequestHeaders);
+                }
+                s_httpClients.Add(client);
+            }
         }
 
         if (s_options.ContentSize > 0)
@@ -325,6 +350,19 @@ class Program
         return metrics;
     }
 
+    private static void CreateGeneratedHeaders()
+    {
+        for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+        {
+            s_generatedStaticHeaders.Add(("X-Generated-Static-Header-" + i, "X-Generated-Value-" + i));
+        }
+        
+        for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
+        {
+            s_generatedDynamicHeaderNames.Add("X-Generated-Dynamic-Header-" + i);
+        }
+    }
+
     private static void CreateRequestContentData()
     {
         s_useByteArrayContent = !s_options.ContentUnknownLength && (!s_options.ContentFlushAfterWrite || s_options.ContentWriteSize >= s_options.ContentSize); // no streaming
@@ -356,17 +394,49 @@ class Program
 
     private static Task<HttpResponseMessage> SendAsync(HttpMessageInvoker client, HttpRequestMessage request) 
     {
-        foreach (var header in s_options.Headers)
+        if (!s_options.UseDefaultRequestHeaders)
         {
-            if (!request.Headers.TryAddWithoutValidation(header.Name, header.Value))
-            {
-                throw new Exception($"Unable to add header \"{header.Name}: {header.Value}\" to the request");
-            }
+            AddStaticHeaders(request.Headers);
+        }
+
+        if (s_options.GeneratedDynamicHeadersCount > 0)
+        {
+            AddDynamicHeaders(request.Headers);
         }
 
         return s_options.UseHttpMessageInvoker
             ? client.SendAsync(request, CancellationToken.None)
             : ((HttpClient)client).SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+    }
+
+    private static void AddStaticHeaders(HttpRequestHeaders headers)
+    {
+        foreach (var header in s_options.Headers)
+        {
+            AddHeader(headers, header.Name, header.Value);
+        }
+
+        for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+        {
+            AddHeader(headers, s_generatedStaticHeaders[i].Name, s_generatedStaticHeaders[i].Value);
+        }
+    }
+
+    private static void AddDynamicHeaders(HttpRequestHeaders headers)
+    {
+        var value = headers.GetHashCode().ToString();
+        for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
+        {
+            AddHeader(headers, s_generatedDynamicHeaderNames[i], value);
+        }
+    }
+
+    private static void AddHeader(HttpRequestHeaders headers, string name, string? value)
+    {
+        if (!headers.TryAddWithoutValidation(name, value))
+        {
+            throw new Exception($"Unable to add header \"{name}: {value}\" to the request");
+        }
     }
 
     private static void Log(string message)


### PR DESCRIPTION
Add configuration to set number of generated headers with static values and number of generated headers with values changing per request.

Add flag to use `HttpClient.DefaultRequestHeaders` for static headers.

cc @ManickaP @MihaZupan