### PR TITLE
Use net7.0 for proxies downstream

### DIFF
--- a/scenarios/proxy.benchmarks.yml
+++ b/scenarios/proxy.benchmarks.yml
@@ -80,6 +80,12 @@ jobs:
       branchOrCommit: main
       project: src/Downstream/Downstream.csproj
     readyStateText: Application started.
+    framework: net7.0
+    channel: edge
+    environmentVariables:
+      DOTNET_TieredPGO: 1
+      DOTNET_ReadyToRun: 0
+      DOTNET_TC_QuickJitForLoops: 1
     variables:
       downstreamArguments:
       downstreamPort: 8081


### PR DESCRIPTION
Lets us pick up the latest changes, like the H2 improvements in Kestrel.