### PR TITLE
Set infinite ConnectTimeout for HttpClient benchmark

### DIFF
--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
@@ -121,7 +121,8 @@ class Program
                     // accept all certs
                     SslOptions = new SslClientAuthenticationOptions { RemoteCertificateValidationCallback = delegate { return true; } },
                     MaxConnectionsPerServer = max11ConnectionsPerServer,
-                    EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections
+                    EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections,
+                    ConnectTimeout = Timeout.InfiniteTimeSpan,
                 };
             }
 


### PR DESCRIPTION
This may not matter now that https://github.com/dotnet/runtime/issues/66297 was reverted, but we may still change `ConnectTimeout` in the future.

Without setting it to infinite in the benchmark, it makes it much more difficult trying to find a sweet spot of maximum throughput based on concurrency. If you go too high, you'll be flooded with errors instead of seeing a lower perf number.

cc: @CarnaViire 