### PR TITLE
Make HttpClient benchmarks compilable for older .NET versions

### DIFF
--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptions.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptions.cs
@@ -1,43 +1,48 @@
-namespace HttpClientBenchmarks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
-public class ClientOptions
+namespace HttpClientBenchmarks
 {
-    public const int DefaultBufferSize = 81920;
-    public const int DefaultDuration = 15;
-
-    public string? Address { get; set; }
-    public string? Port { get; set; }
-    public bool UseHttps { get; set; }
-    public string? Path { get; set; }
-    public Version? HttpVersion { get; set; }
-    public int NumberOfHttpClients { get; set; }
-    public int ConcurrencyPerHttpClient { get; set; }
-    public int Http11MaxConnectionsPerServer { get; set; }
-    public bool Http20EnableMultipleConnections { get; set; }
-    public bool UseWinHttpHandler { get; set; }
-    public bool UseHttpMessageInvoker { get; set; }
-    public bool CollectRequestTimings { get; set; }
-    public string? Scenario { get; set; }
-    public int ContentSize { get; set; }
-    public int ContentWriteSize { get; set; }
-    public bool ContentFlushAfterWrite { get; set; }
-    public bool ContentUnknownLength { get; set; }
-    public List<(string Name, string? Value)> Headers { get; set; } = new();
-    public int GeneratedStaticHeadersCount { get; set; }
-    public int GeneratedDynamicHeadersCount { get; set; }
-    public bool UseDefaultRequestHeaders { get; set; }
-    public int Warmup { get; set; }
-    public int Duration { get; set; }
-
-    public override string ToString()
+    public class ClientOptions
     {
-        return $"Address={Address}; Port={Port}; UseHttps={UseHttps}; Path={Path}; HttpVersion={HttpVersion}; NumberOfHttpClients={NumberOfHttpClients}; " +
-            $"ConcurrencyPerHttpClient={ConcurrencyPerHttpClient}; Http11MaxConnectionsPerServer={Http11MaxConnectionsPerServer}; " +
-            $"Http20EnableMultipleConnections={Http20EnableMultipleConnections}; UseWinHttpHandler={UseWinHttpHandler}; " +
-            $"UseHttpMessageInvoker={UseHttpMessageInvoker}; CollectRequestTimings={CollectRequestTimings}; Scenario={Scenario}; " +
-            $"ContentSize={ContentSize}; ContentWriteSize={ContentWriteSize}; ContentFlushAfterWrite={ContentFlushAfterWrite}; " +
-            $"ContentUnknownLength={ContentUnknownLength}; Headers=[{string.Join(", ", Headers.Select(h => $"\"{h.Name}: {h.Value}\""))}]; " +
-            $"GeneratedStaticHeadersCount={GeneratedStaticHeadersCount}; GeneratedDynamicHeadersCount={GeneratedDynamicHeadersCount}; " +
-            $"UseDefaultRequestHeaders={UseDefaultRequestHeaders}; Warmup={Warmup}; Duration={Duration}";
+        public const int DefaultBufferSize = 81920;
+        public const int DefaultDuration = 15;
+
+        public string? Address { get; set; }
+        public string? Port { get; set; }
+        public bool UseHttps { get; set; }
+        public string? Path { get; set; }
+        public Version? HttpVersion { get; set; }
+        public int NumberOfHttpClients { get; set; }
+        public int ConcurrencyPerHttpClient { get; set; }
+        public int Http11MaxConnectionsPerServer { get; set; }
+        public bool Http20EnableMultipleConnections { get; set; }
+        public bool UseWinHttpHandler { get; set; }
+        public bool UseHttpMessageInvoker { get; set; }
+        public bool CollectRequestTimings { get; set; }
+        public string? Scenario { get; set; }
+        public int ContentSize { get; set; }
+        public int ContentWriteSize { get; set; }
+        public bool ContentFlushAfterWrite { get; set; }
+        public bool ContentUnknownLength { get; set; }
+        public List<(string Name, string? Value)> Headers { get; set; } = new List<(string Name, string? Value)>();
+        public int GeneratedStaticHeadersCount { get; set; }
+        public int GeneratedDynamicHeadersCount { get; set; }
+        public bool UseDefaultRequestHeaders { get; set; }
+        public int Warmup { get; set; }
+        public int Duration { get; set; }
+
+        public override string ToString()
+        {
+            return $"Address={Address}; Port={Port}; UseHttps={UseHttps}; Path={Path}; HttpVersion={HttpVersion}; NumberOfHttpClients={NumberOfHttpClients}; " +
+                $"ConcurrencyPerHttpClient={ConcurrencyPerHttpClient}; Http11MaxConnectionsPerServer={Http11MaxConnectionsPerServer}; " +
+                $"Http20EnableMultipleConnections={Http20EnableMultipleConnections}; UseWinHttpHandler={UseWinHttpHandler}; " +
+                $"UseHttpMessageInvoker={UseHttpMessageInvoker}; CollectRequestTimings={CollectRequestTimings}; Scenario={Scenario}; " +
+                $"ContentSize={ContentSize}; ContentWriteSize={ContentWriteSize}; ContentFlushAfterWrite={ContentFlushAfterWrite}; " +
+                $"ContentUnknownLength={ContentUnknownLength}; Headers=[{string.Join(", ", Headers.Select(h => $"\"{h.Name}: {h.Value}\""))}]; " +
+                $"GeneratedStaticHeadersCount={GeneratedStaticHeadersCount}; GeneratedDynamicHeadersCount={GeneratedDynamicHeadersCount}; " +
+                $"UseDefaultRequestHeaders={UseDefaultRequestHeaders}; Warmup={Warmup}; Duration={Duration}";
+        }
     }
 }

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptionsBinder.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/ClientOptionsBinder.cs
@@ -1,98 +1,102 @@
+using System;
 using System.CommandLine;
 using System.CommandLine.Binding;
 
-namespace HttpClientBenchmarks;
-
-public class ClientOptionsBinder : BinderBase<ClientOptions>
+namespace HttpClientBenchmarks
 {
-    public static Option<string> AddressOption { get; } = new ("--address", "The server address to request") { IsRequired = true };
-    public static Option<string> PortOption { get; } = new ("--port", "The server port to request") { IsRequired = true };
-    public static Option<bool> UseHttpsOption { get; } = new ("--useHttps", () => false, "Whether to use HTTPS");
-    public static Option<string> PathOption { get; } = new ("--path", () => "/", "The server path to request");
-    public static Option<Version> HttpVersionOption { get; } = new ("--httpVersion", "HTTP Version (1.1 or 2.0 or 3.0)") { IsRequired = true };
-    public static Option<int> NumberOfHttpClientsOption { get; } = new ("--numberOfHttpClients", () => 1, "Number of HttpClients");
-    public static Option<int> ConcurrencyPerHttpClientOption { get; } = new ("--concurrencyPerHttpClient", () => 1, "Number of concurrect requests per one HttpClient");
-    public static Option<int> Http11MaxConnectionsPerServerOption { get; } = new ("--http11MaxConnectionsPerServer", () => 0, "Max number of HTTP/1.1 connections per server, 0 for unlimited");
-    public static Option<bool> Http20EnableMultipleConnectionsOption { get; } = new ("--http20EnableMultipleConnections", () => true, "Enable multiple HTTP/2.0 connections");
-    public static Option<bool> UseWinHttpHandlerOption { get; } = new ("--useWinHttpHandler", () => false, "Use WinHttpHandler instead of SocketsHttpHandler");
-    public static Option<bool> UseHttpMessageInvokerOption { get; } = new ("--useHttpMessageInvoker", () => false, "Use HttpMessageInvoker instead of HttpClient");
-    public static Option<bool> CollectRequestTimingsOption { get; } = new ("--collectRequestTimings", () => false, "Collect percentiled metrics of request timings");
-    public static Option<string> ScenarioOption { get; } = new ("--scenario", "Scenario to run ('get', 'post')") { IsRequired = true };
-    public static Option<int> ContentSizeOption { get; } = new ("--contentSize", () => 0, "Request Content size, 0 for no Content");
-    public static Option<int> ContentWriteSizeOption { get; } = new ("--contentWriteSize", () => ClientOptions.DefaultBufferSize, "Request Content single write size, also chunk size if chunked encoding is used");
-    public static Option<bool> ContentFlushAfterWriteOption { get; } = new ("--contentFlushAfterWrite", () => false, "Flush request content stream after each write");
-    public static Option<bool> ContentUnknownLengthOption { get; } = new ("--contentUnknownLength", () => false, "False to send Content-Length header, true to use chunked encoding for HTTP/1.1 or unknown content length for HTTP/2.0 and 3.0");
-    public static Option<string[]> HeaderOption { get; } = new (new string[] { "-H", "--header" }, "Custom headers, multiple values allowed");
-    public static Option<int> GeneratedStaticHeadersCountOption { get; } = new ("--generatedStaticHeadersCount", () => 0, "Number of generated request headers with static values");
-    public static Option<int> GeneratedDynamicHeadersCountOption { get; } = new ("--generatedDynamicHeadersCount", () => 0, "Number of generated request headers with values changing per each request");
-    public static Option<bool> UseDefaultRequestHeadersOption { get; } = new ("--useDefaultRequestHeaders", () => false, "Use HttpClient.DefaultRequestHeaders whenever possible");
-    public static Option<int> WarmupOption { get; } = new ("--warmup", () => ClientOptions.DefaultDuration, "Duration of the warmup in seconds");
-    public static Option<int> DurationOption { get; } = new ("--duration", () => ClientOptions.DefaultDuration, "Duration of the test in seconds");
-
-    public static void AddOptionsToCommand(RootCommand command)
+    public class ClientOptionsBinder : BinderBase<ClientOptions>
     {
-        command.AddOption(AddressOption);
-        command.AddOption(PortOption);
-        command.AddOption(UseHttpsOption);
-        command.AddOption(PathOption);
-        command.AddOption(HttpVersionOption);
-        command.AddOption(NumberOfHttpClientsOption);
-        command.AddOption(ConcurrencyPerHttpClientOption);
-        command.AddOption(Http11MaxConnectionsPerServerOption);
-        command.AddOption(Http20EnableMultipleConnectionsOption);
-        command.AddOption(UseWinHttpHandlerOption);
-        command.AddOption(UseHttpMessageInvokerOption);
-        command.AddOption(CollectRequestTimingsOption);
-        command.AddOption(ScenarioOption);
-        command.AddOption(ContentSizeOption);
-        command.AddOption(ContentWriteSizeOption);
-        command.AddOption(ContentFlushAfterWriteOption);
-        command.AddOption(ContentUnknownLengthOption);
-        command.AddOption(HeaderOption);
-        command.AddOption(GeneratedStaticHeadersCountOption);
-        command.AddOption(GeneratedDynamicHeadersCountOption);
-        command.AddOption(UseDefaultRequestHeadersOption);
-        command.AddOption(WarmupOption);
-        command.AddOption(DurationOption);
-    }
+        public static Option<string> AddressOption { get; } = new Option<string>("--address", "The server address to request") { IsRequired = true };
+        public static Option<string> PortOption { get; } = new Option<string>("--port", "The server port to request") { IsRequired = true };
+        public static Option<bool> UseHttpsOption { get; } = new Option<bool>("--useHttps", () => false, "Whether to use HTTPS");
+        public static Option<string> PathOption { get; } = new Option<string>("--path", () => "/", "The server path to request");
+        public static Option<Version> HttpVersionOption { get; } = new Option<Version>("--httpVersion", "HTTP Version (1.1 or 2.0 or 3.0)") { IsRequired = true };
+        public static Option<int> NumberOfHttpClientsOption { get; } = new Option<int>("--numberOfHttpClients", () => 1, "Number of HttpClients");
+        public static Option<int> ConcurrencyPerHttpClientOption { get; } = new Option<int>("--concurrencyPerHttpClient", () => 1, "Number of concurrect requests per one HttpClient");
+        public static Option<int> Http11MaxConnectionsPerServerOption { get; } = new Option<int>("--http11MaxConnectionsPerServer", () => 0, "Max number of HTTP/1.1 connections per server, 0 for unlimited");
+        public static Option<bool> Http20EnableMultipleConnectionsOption { get; } = new Option<bool>("--http20EnableMultipleConnections", () => true, "Enable multiple HTTP/2.0 connections");
+        public static Option<bool> UseWinHttpHandlerOption { get; } = new Option<bool>("--useWinHttpHandler", () => false, "Use WinHttpHandler instead of SocketsHttpHandler");
+        public static Option<bool> UseHttpMessageInvokerOption { get; } = new Option<bool>("--useHttpMessageInvoker", () => false, "Use HttpMessageInvoker instead of HttpClient");
+        public static Option<bool> CollectRequestTimingsOption { get; } = new Option<bool>("--collectRequestTimings", () => false, "Collect percentiled metrics of request timings");
+        public static Option<string> ScenarioOption { get; } = new Option<string>("--scenario", "Scenario to run ('get', 'post')") { IsRequired = true };
+        public static Option<int> ContentSizeOption { get; } = new Option<int>("--contentSize", () => 0, "Request Content size, 0 for no Content");
+        public static Option<int> ContentWriteSizeOption { get; } = new Option<int>("--contentWriteSize", () => ClientOptions.DefaultBufferSize, "Request Content single write size, also chunk size if chunked encoding is used");
+        public static Option<bool> ContentFlushAfterWriteOption { get; } = new Option<bool>("--contentFlushAfterWrite", () => false, "Flush request content stream after each write");
+        public static Option<bool> ContentUnknownLengthOption { get; } = new Option<bool>("--contentUnknownLength", () => false, "False to send Content-Length header, true to use chunked encoding for HTTP/1.1 or unknown content length for HTTP/2.0 and 3.0");
+        public static Option<string[]> HeaderOption { get; } = new Option<string[]>(new string[] { "-H", "--header" }, "Custom headers, multiple values allowed");
+        public static Option<int> GeneratedStaticHeadersCountOption { get; } = new Option<int>("--generatedStaticHeadersCount", () => 0, "Number of generated request headers with static values");
+        public static Option<int> GeneratedDynamicHeadersCountOption { get; } = new Option<int>("--generatedDynamicHeadersCount", () => 0, "Number of generated request headers with values changing per each request");
+        public static Option<bool> UseDefaultRequestHeadersOption { get; } = new Option<bool>("--useDefaultRequestHeaders", () => false, "Use HttpClient.DefaultRequestHeaders whenever possible");
+        public static Option<int> WarmupOption { get; } = new Option<int>("--warmup", () => ClientOptions.DefaultDuration, "Duration of the warmup in seconds");
+        public static Option<int> DurationOption { get; } = new Option<int>("--duration", () => ClientOptions.DefaultDuration, "Duration of the test in seconds");
 
-    protected override ClientOptions GetBoundValue(BindingContext bindingContext)
-    {
-        var parsed = bindingContext.ParseResult;
-
-        var options = new ClientOptions()
+        public static void AddOptionsToCommand(RootCommand command)
         {
-            Address = parsed.GetValueForOption(AddressOption),
-            Port = parsed.GetValueForOption(PortOption),
-            UseHttps = parsed.GetValueForOption(UseHttpsOption),
-            Path = parsed.GetValueForOption(PathOption),
-            HttpVersion = parsed.GetValueForOption(HttpVersionOption),
-            NumberOfHttpClients = parsed.GetValueForOption(NumberOfHttpClientsOption),
-            ConcurrencyPerHttpClient = parsed.GetValueForOption(ConcurrencyPerHttpClientOption),
-            Http11MaxConnectionsPerServer = parsed.GetValueForOption(Http11MaxConnectionsPerServerOption),
-            Http20EnableMultipleConnections = parsed.GetValueForOption(Http20EnableMultipleConnectionsOption),
-            UseWinHttpHandler = parsed.GetValueForOption(UseWinHttpHandlerOption),
-            UseHttpMessageInvoker = parsed.GetValueForOption(UseHttpMessageInvokerOption),
-            CollectRequestTimings = parsed.GetValueForOption(CollectRequestTimingsOption),
-            Scenario = parsed.GetValueForOption(ScenarioOption),
-            ContentSize = parsed.GetValueForOption(ContentSizeOption),
-            ContentWriteSize = parsed.GetValueForOption(ContentWriteSizeOption),
-            ContentFlushAfterWrite = parsed.GetValueForOption(ContentFlushAfterWriteOption),
-            ContentUnknownLength = parsed.GetValueForOption(ContentUnknownLengthOption),
-            GeneratedStaticHeadersCount = parsed.GetValueForOption(GeneratedStaticHeadersCountOption),
-            GeneratedDynamicHeadersCount = parsed.GetValueForOption(GeneratedDynamicHeadersCountOption),
-            UseDefaultRequestHeaders = parsed.GetValueForOption(UseDefaultRequestHeadersOption),
-            Warmup = parsed.GetValueForOption(WarmupOption),
-            Duration = parsed.GetValueForOption(DurationOption)
-        };
-
-        var headers = parsed.GetValueForOption(HeaderOption) ?? Array.Empty<string>();
-        foreach (var header in headers)
-        {
-            var headerNameValue = header.Split(':', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            options.Headers.Add((headerNameValue[0], headerNameValue.Length > 1 ? headerNameValue[1] : null));
+            command.AddOption(AddressOption);
+            command.AddOption(PortOption);
+            command.AddOption(UseHttpsOption);
+            command.AddOption(PathOption);
+            command.AddOption(HttpVersionOption);
+            command.AddOption(NumberOfHttpClientsOption);
+            command.AddOption(ConcurrencyPerHttpClientOption);
+            command.AddOption(Http11MaxConnectionsPerServerOption);
+            command.AddOption(Http20EnableMultipleConnectionsOption);
+            command.AddOption(UseWinHttpHandlerOption);
+            command.AddOption(UseHttpMessageInvokerOption);
+            command.AddOption(CollectRequestTimingsOption);
+            command.AddOption(ScenarioOption);
+            command.AddOption(ContentSizeOption);
+            command.AddOption(ContentWriteSizeOption);
+            command.AddOption(ContentFlushAfterWriteOption);
+            command.AddOption(ContentUnknownLengthOption);
+            command.AddOption(HeaderOption);
+            command.AddOption(GeneratedStaticHeadersCountOption);
+            command.AddOption(GeneratedDynamicHeadersCountOption);
+            command.AddOption(UseDefaultRequestHeadersOption);
+            command.AddOption(WarmupOption);
+            command.AddOption(DurationOption);
         }
 
-        return options;
+        protected override ClientOptions GetBoundValue(BindingContext bindingContext)
+        {
+            var parsed = bindingContext.ParseResult;
+
+            var options = new ClientOptions()
+            {
+                Address = parsed.GetValueForOption(AddressOption),
+                Port = parsed.GetValueForOption(PortOption),
+                UseHttps = parsed.GetValueForOption(UseHttpsOption),
+                Path = parsed.GetValueForOption(PathOption),
+                HttpVersion = parsed.GetValueForOption(HttpVersionOption),
+                NumberOfHttpClients = parsed.GetValueForOption(NumberOfHttpClientsOption),
+                ConcurrencyPerHttpClient = parsed.GetValueForOption(ConcurrencyPerHttpClientOption),
+                Http11MaxConnectionsPerServer = parsed.GetValueForOption(Http11MaxConnectionsPerServerOption),
+                Http20EnableMultipleConnections = parsed.GetValueForOption(Http20EnableMultipleConnectionsOption),
+                UseWinHttpHandler = parsed.GetValueForOption(UseWinHttpHandlerOption),
+                UseHttpMessageInvoker = parsed.GetValueForOption(UseHttpMessageInvokerOption),
+                CollectRequestTimings = parsed.GetValueForOption(CollectRequestTimingsOption),
+                Scenario = parsed.GetValueForOption(ScenarioOption),
+                ContentSize = parsed.GetValueForOption(ContentSizeOption),
+                ContentWriteSize = parsed.GetValueForOption(ContentWriteSizeOption),
+                ContentFlushAfterWrite = parsed.GetValueForOption(ContentFlushAfterWriteOption),
+                ContentUnknownLength = parsed.GetValueForOption(ContentUnknownLengthOption),
+                GeneratedStaticHeadersCount = parsed.GetValueForOption(GeneratedStaticHeadersCountOption),
+                GeneratedDynamicHeadersCount = parsed.GetValueForOption(GeneratedDynamicHeadersCountOption),
+                UseDefaultRequestHeaders = parsed.GetValueForOption(UseDefaultRequestHeadersOption),
+                Warmup = parsed.GetValueForOption(WarmupOption),
+                Duration = parsed.GetValueForOption(DurationOption)
+            };
+
+            var headers = parsed.GetValueForOption(HeaderOption) ?? Array.Empty<string>();
+            foreach (var header in headers)
+            {
+                var headerNameValue = header.Split(':', 2, StringSplitOptions.RemoveEmptyEntries);
+                string name = headerNameValue[0].Trim();
+                string? value = headerNameValue.Length > 1 ? headerNameValue[1].Trim() : null;
+                options.Headers.Add((name, value?.Length > 0 ? value : null));
+            }
+
+            return options;
+        }
     }
 }

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/HttpClient.csproj
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/HttpClient.csproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/HttpClient.csproj
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/HttpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Metrics.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Metrics.cs
@@ -1,34 +1,40 @@
-namespace HttpClientBenchmarks;
+using System.Collections.Generic;
 
-public class Metrics
+namespace HttpClientBenchmarks
 {
-    public List<long> HeadersTimes { get; set; } = new();
-    public List<long> ContentStartTimes { get; set; } = new();
-    public List<long> ContentEndTimes { get; set; } = new();
-    public long SuccessRequests { get; set; }
-    public long BadStatusRequests { get; set; }
-    public long ExceptionRequests { get; set; }
-    public double MeanRps { get; set; }
-
-    public Metrics()
+    public class Metrics
     {
-    }
+        public List<long> HeadersTimes { get; set; }
+        public List<long> ContentStartTimes { get; set; }
+        public List<long> ContentEndTimes { get; set; }
+        public long SuccessRequests { get; set; }
+        public long BadStatusRequests { get; set; }
+        public long ExceptionRequests { get; set; }
+        public double MeanRps { get; set; }
 
-    public Metrics(int timingsCapacity)
-    {
-        HeadersTimes.EnsureCapacity(timingsCapacity);
-        ContentStartTimes.EnsureCapacity(timingsCapacity);
-        ContentEndTimes.EnsureCapacity(timingsCapacity);
-    }
+        public Metrics()
+        {
+            HeadersTimes = new List<long>();
+            ContentStartTimes = new List<long>();
+            ContentEndTimes = new List<long>();
+        }
 
-    public void Add(Metrics m)
-    {
-        HeadersTimes.AddRange(m.HeadersTimes);
-        ContentStartTimes.AddRange(m.ContentStartTimes);
-        ContentEndTimes.AddRange(m.ContentEndTimes);
-        SuccessRequests += m.SuccessRequests;
-        BadStatusRequests += m.BadStatusRequests;
-        ExceptionRequests += m.ExceptionRequests;
-        MeanRps += m.MeanRps;
+        public Metrics(int timingsCapacity)
+        {
+            HeadersTimes = new List<long>(timingsCapacity);
+            ContentStartTimes = new List<long>(timingsCapacity);
+            ContentEndTimes = new List<long>(timingsCapacity);
+        }
+
+        public void Add(Metrics m)
+        {
+            HeadersTimes.AddRange(m.HeadersTimes);
+            ContentStartTimes.AddRange(m.ContentStartTimes);
+            ContentEndTimes.AddRange(m.ContentEndTimes);
+            SuccessRequests += m.SuccessRequests;
+            BadStatusRequests += m.BadStatusRequests;
+            ExceptionRequests += m.ExceptionRequests;
+            MeanRps += m.MeanRps;
+        }
     }
 }

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/Program.cs
@@ -1,500 +1,515 @@
-﻿using System.CommandLine;
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Crank.EventSources;
 
-namespace HttpClientBenchmarks;
-
-class Program
+namespace HttpClientBenchmarks
 {
-    private static readonly double s_msPerTick = 1000.0 / Stopwatch.Frequency;
-
-    private const int c_SingleThreadRpsEstimate = 3000;
-
-    private static ClientOptions s_options = null!;
-    private static Uri s_url = null!;
-    private static List<HttpMessageInvoker> s_httpClients = new();
-    private static Metrics s_metrics = new();
-
-    private static List<(string Name, string? Value)> s_generatedStaticHeaders = new();
-    private static List<string> s_generatedDynamicHeaderNames = new();
-
-    private static byte[]? s_requestContentData = null;
-    private static byte[]? s_requestContentLastChunk = null;
-    private static int s_fullChunkCount;
-    private static bool s_useByteArrayContent;
-
-    private static bool s_isWarmup;
-    private static bool s_isRunning;
-
-    public static async Task<int> Main(string[] args)
+    class Program
     {
-        var rootCommand = new RootCommand();
-        ClientOptionsBinder.AddOptionsToCommand(rootCommand);
+        private static readonly double s_msPerTick = 1000.0 / Stopwatch.Frequency;
 
-        rootCommand.SetHandler(async (ClientOptions options) =>
-            {
-                s_options = options;
-                Log("HttpClient benchmark");
-                Log("Options: " + s_options);
-                ValidateOptions();
+        private const int c_SingleThreadRpsEstimate = 3000;
 
-                await Setup();
-                Log("Setup done");
+        private static ClientOptions s_options = null!;
+        private static Uri s_url = null!;
+        private static List<HttpMessageInvoker> s_httpClients = new List<HttpMessageInvoker>();
+        private static Metrics s_metrics = new Metrics();
 
-                await RunScenario();
-                Log("Scenario done");
-            },
-            new ClientOptionsBinder());
+        private static List<(string Name, string? Value)> s_generatedStaticHeaders = new List<(string Name, string? Value)>();
+        private static List<string> s_generatedDynamicHeaderNames = new List<string>();
 
-        return await rootCommand.InvokeAsync(args);
-    }
+        private static byte[]? s_requestContentData = null;
+        private static byte[]? s_requestContentLastChunk = null;
+        private static int s_fullChunkCount;
+        private static bool s_useByteArrayContent;
 
-    private static void ValidateOptions()
-    {
-        if (!s_options.UseHttps && s_options.HttpVersion == HttpVersion.Version30)
+        private static bool s_isWarmup;
+        private static bool s_isRunning;
+
+        public static async Task<int> Main(string[] args)
         {
-            throw new ArgumentException("HTTP/3.0 only supports HTTPS");
-        }
+            var rootCommand = new RootCommand();
+            ClientOptionsBinder.AddOptionsToCommand(rootCommand);
 
-        if (s_options.UseWinHttpHandler && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            throw new ArgumentException("WinHttpHandler is only supported on Windows");
-        }
-
-        if (s_options.Scenario == "get" && s_options.ContentSize != 0)
-        {
-            throw new ArgumentException("Expected to have ContentSize = 0 for 'get' scenario, got " + s_options.ContentSize);
-        }
-
-        if (s_options.Scenario == "post" && s_options.ContentSize <= 0)
-        {
-            throw new ArgumentException("Expected to have ContentSize > 0 for 'post' scenario, got " + s_options.ContentSize);
-        }
-
-        if (s_options.UseHttpMessageInvoker && s_options.UseDefaultRequestHeaders)
-        {
-            throw new ArgumentException("HttpMessageInvoker does not support DefaultRequestHeaders");
-        }
-    }
-
-    private static async Task Setup()
-    {
-        BenchmarksEventSource.Register("env/processorcount", Operations.First, Operations.First, "Processor Count", "Processor Count", "n0");
-        LogMetric("env/processorcount", Environment.ProcessorCount);
-
-        var baseUrl = $"http{(s_options.UseHttps ? "s" : "")}://{s_options.Address}:{s_options.Port}";
-        s_url = new Uri(baseUrl + s_options.Path);
-        Log("Base url: " + baseUrl);
-        Log("Full url: " + s_url);
-
-        if (s_options.GeneratedStaticHeadersCount > 0 || s_options.GeneratedDynamicHeadersCount > 0)
-        {
-            CreateGeneratedHeaders();
-        }
-        
-        int max11ConnectionsPerServer = s_options.Http11MaxConnectionsPerServer > 0 ? s_options.Http11MaxConnectionsPerServer : int.MaxValue;
-
-        for (int i = 0; i < s_options.NumberOfHttpClients; ++i)
-        {
-            HttpMessageHandler handler;
-            if (s_options.UseWinHttpHandler)
-            {
-                // Disable "only supported on: 'windows'" warning -- options are already validated
-#pragma warning disable CA1416
-                handler = new WinHttpHandler()
+            rootCommand.SetHandler(async (ClientOptions options) =>
                 {
-                    // accept all certs
-                    ServerCertificateValidationCallback = delegate { return true; },
-                    MaxConnectionsPerServer = max11ConnectionsPerServer,
-                    EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections
-                };
-#pragma warning restore CA1416
-            }
-            else
+                    s_options = options;
+                    Log("HttpClient benchmark");
+                    Log("Options: " + s_options);
+                    ValidateOptions();
+
+                    await Setup();
+                    Log("Setup done");
+
+                    await RunScenario();
+                    Log("Scenario done");
+                },
+                new ClientOptionsBinder());
+
+            return await rootCommand.InvokeAsync(args);
+        }
+
+        private static void ValidateOptions()
+        {
+#if NET6_0_OR_GREATER
+            if (!s_options.UseHttps && s_options.HttpVersion == HttpVersion.Version30)
             {
-                handler = new SocketsHttpHandler() 
+                throw new ArgumentException("HTTP/3.0 only supports HTTPS");
+            }
+#endif
+
+            if (s_options.UseWinHttpHandler && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                throw new ArgumentException("WinHttpHandler is only supported on Windows");
+            }
+
+            if (s_options.Scenario == "get" && s_options.ContentSize != 0)
+            {
+                throw new ArgumentException("Expected to have ContentSize = 0 for 'get' scenario, got " + s_options.ContentSize);
+            }
+
+            if (s_options.Scenario == "post" && s_options.ContentSize <= 0)
+            {
+                throw new ArgumentException("Expected to have ContentSize > 0 for 'post' scenario, got " + s_options.ContentSize);
+            }
+
+            if (s_options.UseHttpMessageInvoker && s_options.UseDefaultRequestHeaders)
+            {
+                throw new ArgumentException("HttpMessageInvoker does not support DefaultRequestHeaders");
+            }
+        }
+
+        private static async Task Setup()
+        {
+            BenchmarksEventSource.Register("env/processorcount", Operations.First, Operations.First, "Processor Count", "Processor Count", "n0");
+            LogMetric("env/processorcount", Environment.ProcessorCount);
+
+            var baseUrl = $"http{(s_options.UseHttps ? "s" : "")}://{s_options.Address}:{s_options.Port}";
+            s_url = new Uri(baseUrl + s_options.Path);
+            Log("Base url: " + baseUrl);
+            Log("Full url: " + s_url);
+
+            if (s_options.GeneratedStaticHeadersCount > 0 || s_options.GeneratedDynamicHeadersCount > 0)
+            {
+                CreateGeneratedHeaders();
+            }
+
+            int max11ConnectionsPerServer = s_options.Http11MaxConnectionsPerServer > 0 ? s_options.Http11MaxConnectionsPerServer : int.MaxValue;
+
+            for (int i = 0; i < s_options.NumberOfHttpClients; ++i)
+            {
+                HttpMessageHandler handler;
+                if (s_options.UseWinHttpHandler)
                 {
-                    // accept all certs
-                    SslOptions = new SslClientAuthenticationOptions { RemoteCertificateValidationCallback = delegate { return true; } },
-                    MaxConnectionsPerServer = max11ConnectionsPerServer,
-                    EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections,
-                    ConnectTimeout = Timeout.InfiniteTimeSpan,
-                };
-            }
-
-            if (s_options.UseHttpMessageInvoker)
-            {
-                s_httpClients.Add(new HttpMessageInvoker(handler));
-            }
-            else
-            {
-                var client = new HttpClient(handler);
-                if (s_options.UseDefaultRequestHeaders)
-                {
-                    AddStaticHeaders(client.DefaultRequestHeaders);
-                }
-                s_httpClients.Add(client);
-            }
-        }
-
-        if (s_options.ContentSize > 0)
-        {
-            CreateRequestContentData();
-        }
-
-        // First request to the server; to ensure everything started correctly
-        var request = CreateRequest(HttpMethod.Get, new Uri(baseUrl));
-        var stopwatch = Stopwatch.StartNew();
-        var response = await SendAsync(s_httpClients[0], request);
-        var elapsed = stopwatch.ElapsedMilliseconds;
-        response.EnsureSuccessStatusCode();
-        BenchmarksEventSource.Register("http/firstrequest", Operations.Max, Operations.Max, "First request duration (ms)", "Duration of the first request to the server (ms)", "n0");
-        LogMetric("http/firstrequest", elapsed);
-    }
-
-    private static async Task RunScenario()
-    {
-        BenchmarksEventSource.Register("http/requests", Operations.Sum, Operations.Sum, "Requests", "Number of requests", "n0");
-        BenchmarksEventSource.Register("http/requests/badresponses", Operations.Sum, Operations.Sum, "Bad Status Code Requests", "Number of requests with bad status codes", "n0");
-        BenchmarksEventSource.Register("http/requests/errors", Operations.Sum, Operations.Sum, "Exceptions", "Number of exceptions", "n0");
-        BenchmarksEventSource.Register("http/rps/mean", Operations.Avg, Operations.Avg, "Mean RPS", "Requests per second - mean", "n0");
-
-        if (s_options.CollectRequestTimings)
-        {
-            RegisterPercentiledMetric("http/headers", "Time to response headers (ms)", "Time to response headers (ms)");
-            RegisterPercentiledMetric("http/contentstart", "Time to first response content byte (ms)", "Time to first response content byte (ms)");
-            RegisterPercentiledMetric("http/contentend", "Time to last response content byte (ms)", "Time to last response content byte (ms)");
-        }
-
-        Func<HttpMessageInvoker, Task<Metrics>> scenario;
-        switch(s_options.Scenario)
-        {
-            case "get":
-                scenario = Get;
-                break;
-            case "post":
-                scenario = Post;
-                break;
-            default:
-                throw new ArgumentException($"Unknown scenario: {s_options.Scenario}");
-        }
-
-        s_isWarmup = true;
-        s_isRunning = true;
-
-        var coordinatorTask = Task.Run(async () =>
-        {
-            await Task.Delay(TimeSpan.FromSeconds(s_options.Warmup));
-            s_isWarmup = false;
-            Log("Completing warmup...");
-            await Task.Delay(TimeSpan.FromSeconds(s_options.Duration));
-            s_isRunning = false;
-            Log("Completing scenario...");
-        });
-
-        var tasks = new List<Task<Metrics>>(s_options.NumberOfHttpClients * s_options.ConcurrencyPerHttpClient);
-        for (int i = 0; i < s_options.NumberOfHttpClients; ++i)
-        {
-            var client = s_httpClients[i];
-            for (int j = 0; j < s_options.ConcurrencyPerHttpClient; ++j)
-            {
-                tasks.Add(scenario(client));
-            }
-        }
-
-        await coordinatorTask;
-        var metricsArray = await Task.WhenAll(tasks);
-        foreach (var metrics in metricsArray)
-        {
-            s_metrics.Add(metrics);
-        }
-
-        LogMetric("http/requests", s_metrics.SuccessRequests + s_metrics.BadStatusRequests);
-        LogMetric("http/requests/badresponses", s_metrics.BadStatusRequests);
-        LogMetric("http/requests/errors", s_metrics.ExceptionRequests);
-        LogMetric("http/rps/mean", s_metrics.MeanRps);
-
-        if (s_options.CollectRequestTimings && s_metrics.SuccessRequests > 0)
-        {
-            LogPercentiledMetric("http/headers", s_metrics.HeadersTimes, TicksToMs);
-            LogPercentiledMetric("http/contentstart", s_metrics.ContentStartTimes, TicksToMs);
-            LogPercentiledMetric("http/contentend", s_metrics.ContentEndTimes, TicksToMs);
-        }
-    }
-
-    private static Task<Metrics> Get(HttpMessageInvoker client)
-    {
-        return Measure(() => 
-        {
-            var request = CreateRequest(HttpMethod.Get, s_url);
-            return SendAsync(client, request);
-        });
-    }
-
-    private static Task<Metrics> Post(HttpMessageInvoker client)
-    {
-        return Measure(async () => 
-        {
-            var request = CreateRequest(HttpMethod.Post, s_url);
-
-            Task<HttpResponseMessage> responseTask;
-            if (s_useByteArrayContent)
-            {
-                request.Content = new ByteArrayContent(s_requestContentData!);
-                responseTask = SendAsync(client, request);
-            }
-            else
-            {
-                var requestContent = new StreamingHttpContent();
-                request.Content = requestContent;
-
-                if (!s_options.ContentUnknownLength)
-                {
-                    request.Content.Headers.ContentLength = s_options.ContentSize;
-                }
-                // Otherwise, we don't need to set TransferEncodingChunked for HTTP/1.1 manually, it's done automatically if ContentLength is absent
-
-                responseTask = SendAsync(client, request);
-                var requestContentStream = await requestContent.GetStreamAsync();
-
-                for (int i = 0; i < s_fullChunkCount; ++i)
-                {
-                    await requestContentStream.WriteAsync(s_requestContentData);
-                    if (s_options.ContentFlushAfterWrite)
+                    // Disable "only supported on: 'windows'" warning -- options are already validated
+    #pragma warning disable CA1416
+                    handler = new WinHttpHandler()
                     {
-                        await requestContentStream.FlushAsync();
-                    }
-                }
-                if (s_requestContentLastChunk != null)
-                {
-                    await requestContentStream.WriteAsync(s_requestContentLastChunk);
-                }
-                requestContent.CompleteStream();
-            }
-
-            return await responseTask;
-        });
-    }
-
-    private static async Task<Metrics> Measure(Func<Task<HttpResponseMessage>> sendAsync)
-    {
-        var drainArray = new byte[ClientOptions.DefaultBufferSize];
-        var stopwatch = Stopwatch.StartNew();
-
-        var metrics = s_options.CollectRequestTimings 
-            ? new Metrics(s_options.Duration * c_SingleThreadRpsEstimate) 
-            : new Metrics();
-        bool isWarmup = true;
-
-        var durationStopwatch = Stopwatch.StartNew();
-        while (s_isRunning)
-        {
-            if (isWarmup && !s_isWarmup)
-            {
-                if (metrics.SuccessRequests == 0)
-                {
-                    throw new Exception($"No successful requests during warmup.");
-                }
-                isWarmup = false;
-                metrics.SuccessRequests = 0;
-                metrics.BadStatusRequests = 0;
-                metrics.ExceptionRequests = 0;
-                durationStopwatch.Restart();
-            }
-            
-            try
-            {
-                stopwatch.Restart();
-                using HttpResponseMessage result = await sendAsync();
-                var headersTime = stopwatch.ElapsedTicks;
-
-                if (result.IsSuccessStatusCode)
-                {
-                    using var content = result.Content.ReadAsStream();
-                    var bytesRead = await content.ReadAsync(drainArray);
-                    var contentStartTime = stopwatch.ElapsedTicks;
-
-                    while (bytesRead != 0)
-                    {
-                        bytesRead = await content.ReadAsync(drainArray);
-                    }
-                    var contentEndTime = stopwatch.ElapsedTicks;
-
-                    if (s_options.CollectRequestTimings && !isWarmup)
-                    {
-                        metrics.HeadersTimes.Add(headersTime);
-                        metrics.ContentStartTimes.Add(contentStartTime);
-                        metrics.ContentEndTimes.Add(contentEndTime);
-                    }
-                    metrics.SuccessRequests++;
+                        // accept all certs
+                        ServerCertificateValidationCallback = delegate { return true; },
+                        MaxConnectionsPerServer = max11ConnectionsPerServer,
+                        EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections
+                    };
+    #pragma warning restore CA1416
                 }
                 else
                 {
-                    Log("Bad status code: " + result.StatusCode);
-                    metrics.BadStatusRequests++;
+                    handler = new SocketsHttpHandler()
+                    {
+                        // accept all certs
+                        SslOptions = new SslClientAuthenticationOptions { RemoteCertificateValidationCallback = delegate { return true; } },
+                        MaxConnectionsPerServer = max11ConnectionsPerServer,
+#if NET5_0_OR_GREATER
+                        EnableMultipleHttp2Connections = s_options.Http20EnableMultipleConnections,
+#endif
+                        ConnectTimeout = Timeout.InfiniteTimeSpan,
+                    };
+                }
+
+                if (s_options.UseHttpMessageInvoker)
+                {
+                    s_httpClients.Add(new HttpMessageInvoker(handler));
+                }
+                else
+                {
+                    var client = new HttpClient(handler);
+                    if (s_options.UseDefaultRequestHeaders)
+                    {
+                        AddStaticHeaders(client.DefaultRequestHeaders);
+                    }
+                    s_httpClients.Add(client);
                 }
             }
-            catch (Exception ex)
+
+            if (s_options.ContentSize > 0)
             {
-                Log("Exception: " + ex);
-                metrics.ExceptionRequests++;
+                CreateRequestContentData();
+            }
+
+            // First request to the server; to ensure everything started correctly
+            var request = CreateRequest(HttpMethod.Get, new Uri(baseUrl));
+            var stopwatch = Stopwatch.StartNew();
+            var response = await SendAsync(s_httpClients[0], request);
+            var elapsed = stopwatch.ElapsedMilliseconds;
+            response.EnsureSuccessStatusCode();
+            BenchmarksEventSource.Register("http/firstrequest", Operations.Max, Operations.Max, "First request duration (ms)", "Duration of the first request to the server (ms)", "n0");
+            LogMetric("http/firstrequest", elapsed);
+        }
+
+        private static async Task RunScenario()
+        {
+            BenchmarksEventSource.Register("http/requests", Operations.Sum, Operations.Sum, "Requests", "Number of requests", "n0");
+            BenchmarksEventSource.Register("http/requests/badresponses", Operations.Sum, Operations.Sum, "Bad Status Code Requests", "Number of requests with bad status codes", "n0");
+            BenchmarksEventSource.Register("http/requests/errors", Operations.Sum, Operations.Sum, "Exceptions", "Number of exceptions", "n0");
+            BenchmarksEventSource.Register("http/rps/mean", Operations.Avg, Operations.Avg, "Mean RPS", "Requests per second - mean", "n0");
+
+            if (s_options.CollectRequestTimings)
+            {
+                RegisterPercentiledMetric("http/headers", "Time to response headers (ms)", "Time to response headers (ms)");
+                RegisterPercentiledMetric("http/contentstart", "Time to first response content byte (ms)", "Time to first response content byte (ms)");
+                RegisterPercentiledMetric("http/contentend", "Time to last response content byte (ms)", "Time to last response content byte (ms)");
+            }
+
+            Func<HttpMessageInvoker, Task<Metrics>> scenario;
+            switch(s_options.Scenario)
+            {
+                case "get":
+                    scenario = Get;
+                    break;
+                case "post":
+                    scenario = Post;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown scenario: {s_options.Scenario}");
+            }
+
+            s_isWarmup = true;
+            s_isRunning = true;
+
+            var coordinatorTask = Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(s_options.Warmup));
+                s_isWarmup = false;
+                Log("Completing warmup...");
+                await Task.Delay(TimeSpan.FromSeconds(s_options.Duration));
+                s_isRunning = false;
+                Log("Completing scenario...");
+            });
+
+            var tasks = new List<Task<Metrics>>(s_options.NumberOfHttpClients * s_options.ConcurrencyPerHttpClient);
+            for (int i = 0; i < s_options.NumberOfHttpClients; ++i)
+            {
+                var client = s_httpClients[i];
+                for (int j = 0; j < s_options.ConcurrencyPerHttpClient; ++j)
+                {
+                    tasks.Add(scenario(client));
+                }
+            }
+
+            await coordinatorTask;
+            var metricsArray = await Task.WhenAll(tasks);
+            foreach (var metrics in metricsArray)
+            {
+                s_metrics.Add(metrics);
+            }
+
+            LogMetric("http/requests", s_metrics.SuccessRequests + s_metrics.BadStatusRequests);
+            LogMetric("http/requests/badresponses", s_metrics.BadStatusRequests);
+            LogMetric("http/requests/errors", s_metrics.ExceptionRequests);
+            LogMetric("http/rps/mean", s_metrics.MeanRps);
+
+            if (s_options.CollectRequestTimings && s_metrics.SuccessRequests > 0)
+            {
+                LogPercentiledMetric("http/headers", s_metrics.HeadersTimes, TicksToMs);
+                LogPercentiledMetric("http/contentstart", s_metrics.ContentStartTimes, TicksToMs);
+                LogPercentiledMetric("http/contentend", s_metrics.ContentEndTimes, TicksToMs);
             }
         }
-        var elapsed = durationStopwatch.ElapsedTicks * 1.0 / Stopwatch.Frequency;
-        metrics.MeanRps = (metrics.SuccessRequests +  metrics.BadStatusRequests) / elapsed;
-        return metrics;
-    }
 
-    private static void CreateGeneratedHeaders()
-    {
-        for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+        private static Task<Metrics> Get(HttpMessageInvoker client)
         {
-            s_generatedStaticHeaders.Add(("X-Generated-Static-Header-" + i, "X-Generated-Value-" + i));
-        }
-        
-        for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
-        {
-            s_generatedDynamicHeaderNames.Add("X-Generated-Dynamic-Header-" + i);
-        }
-    }
-
-    private static void CreateRequestContentData()
-    {
-        s_useByteArrayContent = !s_options.ContentUnknownLength && (!s_options.ContentFlushAfterWrite || s_options.ContentWriteSize >= s_options.ContentSize); // no streaming
-        if (s_useByteArrayContent)
-        {
-            s_fullChunkCount = 1;
-            s_requestContentData = new byte[s_options.ContentSize];
-            Array.Fill(s_requestContentData, (byte)'a');
-        }
-        else
-        {
-            s_fullChunkCount = s_options.ContentSize / s_options.ContentWriteSize;
-            if (s_fullChunkCount != 0)
+            return Measure(() =>
             {
-                s_requestContentData = new byte[s_options.ContentWriteSize];
+                var request = CreateRequest(HttpMethod.Get, s_url);
+                return SendAsync(client, request);
+            });
+        }
+
+        private static Task<Metrics> Post(HttpMessageInvoker client)
+        {
+            return Measure(async () =>
+            {
+                var request = CreateRequest(HttpMethod.Post, s_url);
+
+                Task<HttpResponseMessage> responseTask;
+                if (s_useByteArrayContent)
+                {
+                    request.Content = new ByteArrayContent(s_requestContentData!);
+                    responseTask = SendAsync(client, request);
+                }
+                else
+                {
+                    var requestContent = new StreamingHttpContent();
+                    request.Content = requestContent;
+
+                    if (!s_options.ContentUnknownLength)
+                    {
+                        request.Content.Headers.ContentLength = s_options.ContentSize;
+                    }
+                    // Otherwise, we don't need to set TransferEncodingChunked for HTTP/1.1 manually, it's done automatically if ContentLength is absent
+
+                    responseTask = SendAsync(client, request);
+                    var requestContentStream = await requestContent.GetStreamAsync();
+
+                    for (int i = 0; i < s_fullChunkCount; ++i)
+                    {
+                        await requestContentStream.WriteAsync(s_requestContentData);
+                        if (s_options.ContentFlushAfterWrite)
+                        {
+                            await requestContentStream.FlushAsync();
+                        }
+                    }
+                    if (s_requestContentLastChunk != null)
+                    {
+                        await requestContentStream.WriteAsync(s_requestContentLastChunk);
+                    }
+                    requestContent.CompleteStream();
+                }
+
+                return await responseTask;
+            });
+        }
+
+        private static async Task<Metrics> Measure(Func<Task<HttpResponseMessage>> sendAsync)
+        {
+            var drainArray = new byte[ClientOptions.DefaultBufferSize];
+            var stopwatch = Stopwatch.StartNew();
+
+            var metrics = s_options.CollectRequestTimings
+                ? new Metrics(s_options.Duration * c_SingleThreadRpsEstimate)
+                : new Metrics();
+            bool isWarmup = true;
+
+            var durationStopwatch = Stopwatch.StartNew();
+            while (s_isRunning)
+            {
+                if (isWarmup && !s_isWarmup)
+                {
+                    if (metrics.SuccessRequests == 0)
+                    {
+                        throw new Exception($"No successful requests during warmup.");
+                    }
+                    isWarmup = false;
+                    metrics.SuccessRequests = 0;
+                    metrics.BadStatusRequests = 0;
+                    metrics.ExceptionRequests = 0;
+                    durationStopwatch.Restart();
+                }
+
+                try
+                {
+                    stopwatch.Restart();
+                    using HttpResponseMessage result = await sendAsync();
+                    var headersTime = stopwatch.ElapsedTicks;
+
+                    if (result.IsSuccessStatusCode)
+                    {
+                        using var content = await result.Content.ReadAsStreamAsync();
+                        var bytesRead = await content.ReadAsync(drainArray);
+                        var contentStartTime = stopwatch.ElapsedTicks;
+
+                        while (bytesRead != 0)
+                        {
+                            bytesRead = await content.ReadAsync(drainArray);
+                        }
+                        var contentEndTime = stopwatch.ElapsedTicks;
+
+                        if (s_options.CollectRequestTimings && !isWarmup)
+                        {
+                            metrics.HeadersTimes.Add(headersTime);
+                            metrics.ContentStartTimes.Add(contentStartTime);
+                            metrics.ContentEndTimes.Add(contentEndTime);
+                        }
+                        metrics.SuccessRequests++;
+                    }
+                    else
+                    {
+                        Log("Bad status code: " + result.StatusCode);
+                        metrics.BadStatusRequests++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log("Exception: " + ex);
+                    metrics.ExceptionRequests++;
+                }
+            }
+            var elapsed = durationStopwatch.ElapsedTicks * 1.0 / Stopwatch.Frequency;
+            metrics.MeanRps = (metrics.SuccessRequests +  metrics.BadStatusRequests) / elapsed;
+            return metrics;
+        }
+
+        private static void CreateGeneratedHeaders()
+        {
+            for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+            {
+                s_generatedStaticHeaders.Add(("X-Generated-Static-Header-" + i, "X-Generated-Value-" + i));
+            }
+
+            for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
+            {
+                s_generatedDynamicHeaderNames.Add("X-Generated-Dynamic-Header-" + i);
+            }
+        }
+
+        private static void CreateRequestContentData()
+        {
+            s_useByteArrayContent = !s_options.ContentUnknownLength && (!s_options.ContentFlushAfterWrite || s_options.ContentWriteSize >= s_options.ContentSize); // no streaming
+            if (s_useByteArrayContent)
+            {
+                s_fullChunkCount = 1;
+                s_requestContentData = new byte[s_options.ContentSize];
                 Array.Fill(s_requestContentData, (byte)'a');
             }
-            int lastChunkSize = s_options.ContentSize % s_options.ContentWriteSize;
-            if (lastChunkSize != 0)
+            else
             {
-                s_requestContentLastChunk = new byte[lastChunkSize];
-                Array.Fill(s_requestContentLastChunk, (byte)'a');
+                s_fullChunkCount = s_options.ContentSize / s_options.ContentWriteSize;
+                if (s_fullChunkCount != 0)
+                {
+                    s_requestContentData = new byte[s_options.ContentWriteSize];
+                    Array.Fill(s_requestContentData, (byte)'a');
+                }
+                int lastChunkSize = s_options.ContentSize % s_options.ContentWriteSize;
+                if (lastChunkSize != 0)
+                {
+                    s_requestContentLastChunk = new byte[lastChunkSize];
+                    Array.Fill(s_requestContentLastChunk, (byte)'a');
+                }
             }
         }
-    }
 
-    private static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri) =>
-        new HttpRequestMessage(method, uri) { Version = s_options.HttpVersion!, VersionPolicy = HttpVersionPolicy.RequestVersionExact };
+        private static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri) =>
+            new HttpRequestMessage(method, uri) { 
+                Version = s_options.HttpVersion!,
+#if NET5_0_OR_GREATER
+                VersionPolicy = HttpVersionPolicy.RequestVersionExact
+#endif
+            };
 
-    private static Task<HttpResponseMessage> SendAsync(HttpMessageInvoker client, HttpRequestMessage request) 
-    {
-        if (!s_options.UseDefaultRequestHeaders)
+        private static Task<HttpResponseMessage> SendAsync(HttpMessageInvoker client, HttpRequestMessage request)
         {
-            AddStaticHeaders(request.Headers);
+            if (!s_options.UseDefaultRequestHeaders)
+            {
+                AddStaticHeaders(request.Headers);
+            }
+
+            if (s_options.GeneratedDynamicHeadersCount > 0)
+            {
+                AddDynamicHeaders(request.Headers);
+            }
+
+            return s_options.UseHttpMessageInvoker
+                ? client.SendAsync(request, CancellationToken.None)
+                : ((HttpClient)client).SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
         }
 
-        if (s_options.GeneratedDynamicHeadersCount > 0)
+        private static void AddStaticHeaders(HttpRequestHeaders headers)
         {
-            AddDynamicHeaders(request.Headers);
+            foreach (var header in s_options.Headers)
+            {
+                AddHeader(headers, header.Name, header.Value);
+            }
+
+            for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+            {
+                AddHeader(headers, s_generatedStaticHeaders[i].Name, s_generatedStaticHeaders[i].Value);
+            }
         }
 
-        return s_options.UseHttpMessageInvoker
-            ? client.SendAsync(request, CancellationToken.None)
-            : ((HttpClient)client).SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-    }
-
-    private static void AddStaticHeaders(HttpRequestHeaders headers)
-    {
-        foreach (var header in s_options.Headers)
+        private static void AddDynamicHeaders(HttpRequestHeaders headers)
         {
-            AddHeader(headers, header.Name, header.Value);
+            var value = headers.GetHashCode().ToString();
+            for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
+            {
+                AddHeader(headers, s_generatedDynamicHeaderNames[i], value);
+            }
         }
 
-        for (int i = 0; i < s_options.GeneratedStaticHeadersCount; ++i)
+        private static void AddHeader(HttpRequestHeaders headers, string name, string? value)
         {
-            AddHeader(headers, s_generatedStaticHeaders[i].Name, s_generatedStaticHeaders[i].Value);
-        }
-    }
-
-    private static void AddDynamicHeaders(HttpRequestHeaders headers)
-    {
-        var value = headers.GetHashCode().ToString();
-        for (int i = 0; i < s_options.GeneratedDynamicHeadersCount; ++i)
-        {
-            AddHeader(headers, s_generatedDynamicHeaderNames[i], value);
-        }
-    }
-
-    private static void AddHeader(HttpRequestHeaders headers, string name, string? value)
-    {
-        if (!headers.TryAddWithoutValidation(name, value))
-        {
-            throw new Exception($"Unable to add header \"{name}: {value}\" to the request");
-        }
-    }
-
-    private static void Log(string message)
-    {
-        var time = DateTime.UtcNow.ToString("hh:mm:ss.fff");
-        Console.WriteLine($"[{time}] {message}");
-    }
-
-    private static double TicksToMs(double ticks) => ticks * s_msPerTick;
-
-    private static double GetPercentile(int percent, List<long> sortedValues)
-    {
-        if (percent == 0)
-        {
-            return sortedValues[0];
+            if (!headers.TryAddWithoutValidation(name, value))
+            {
+                throw new Exception($"Unable to add header \"{name}: {value}\" to the request");
+            }
         }
 
-        if (percent == 100)
+        private static void Log(string message)
         {
-            return sortedValues[sortedValues.Count - 1];
+            var time = DateTime.UtcNow.ToString("hh:mm:ss.fff");
+            Console.WriteLine($"[{time}] {message}");
         }
 
-        var i = ((long)percent * sortedValues.Count) / 100.0 + 0.5;
-        var fractionPart = i - Math.Truncate(i);
+        private static double TicksToMs(double ticks) => ticks * s_msPerTick;
 
-        return (1.0 - fractionPart) * sortedValues[(int)Math.Truncate(i) - 1] + fractionPart * sortedValues[(int)Math.Ceiling(i) - 1];
-    }
+        private static double GetPercentile(int percent, List<long> sortedValues)
+        {
+            if (percent == 0)
+            {
+                return sortedValues[0];
+            }
 
-    private static void RegisterPercentiledMetric(string name, string shortDescription, string longDescription)
-    {
-        BenchmarksEventSource.Register(name + "/min", Operations.Min, Operations.Min, shortDescription + " - min", longDescription + " - min", "n2");
-        BenchmarksEventSource.Register(name + "/p50", Operations.Max, Operations.Max, shortDescription + " - p50", longDescription + " - 50th percentile", "n2");
-        BenchmarksEventSource.Register(name + "/p75", Operations.Max, Operations.Max, shortDescription + " - p75", longDescription + " - 75th percentile", "n2");
-        BenchmarksEventSource.Register(name + "/p90", Operations.Max, Operations.Max, shortDescription + " - p90", longDescription + " - 90th percentile", "n2");
-        BenchmarksEventSource.Register(name + "/p99", Operations.Max, Operations.Max, shortDescription + " - p99", longDescription + " - 99th percentile", "n2");
-        BenchmarksEventSource.Register(name + "/max", Operations.Max, Operations.Max, shortDescription + " - max", longDescription + " - max", "n2");
-    }
+            if (percent == 100)
+            {
+                return sortedValues[sortedValues.Count - 1];
+            }
 
-    private static void LogPercentiledMetric(string name, List<long> values, Func<double, double> prepareValue)
-    {
-        values.Sort();
+            var i = ((long)percent * sortedValues.Count) / 100.0 + 0.5;
+            var fractionPart = i - Math.Truncate(i);
 
-        LogMetric(name + "/min", prepareValue(GetPercentile(0, values)));
-        LogMetric(name + "/p50", prepareValue(GetPercentile(50, values)));
-        LogMetric(name + "/p75", prepareValue(GetPercentile(75, values)));
-        LogMetric(name + "/p90", prepareValue(GetPercentile(90, values)));
-        LogMetric(name + "/p99", prepareValue(GetPercentile(99, values)));
-        LogMetric(name + "/max", prepareValue(GetPercentile(100, values)));
-    }
+            return (1.0 - fractionPart) * sortedValues[(int)Math.Truncate(i) - 1] + fractionPart * sortedValues[(int)Math.Ceiling(i) - 1];
+        }
 
-    private static void LogMetric(string name, double value)
-    {
-        BenchmarksEventSource.Measure(name, value);
-        Log($"{name}: {value}");
-    }
+        private static void RegisterPercentiledMetric(string name, string shortDescription, string longDescription)
+        {
+            BenchmarksEventSource.Register(name + "/min", Operations.Min, Operations.Min, shortDescription + " - min", longDescription + " - min", "n2");
+            BenchmarksEventSource.Register(name + "/p50", Operations.Max, Operations.Max, shortDescription + " - p50", longDescription + " - 50th percentile", "n2");
+            BenchmarksEventSource.Register(name + "/p75", Operations.Max, Operations.Max, shortDescription + " - p75", longDescription + " - 75th percentile", "n2");
+            BenchmarksEventSource.Register(name + "/p90", Operations.Max, Operations.Max, shortDescription + " - p90", longDescription + " - 90th percentile", "n2");
+            BenchmarksEventSource.Register(name + "/p99", Operations.Max, Operations.Max, shortDescription + " - p99", longDescription + " - 99th percentile", "n2");
+            BenchmarksEventSource.Register(name + "/max", Operations.Max, Operations.Max, shortDescription + " - max", longDescription + " - max", "n2");
+        }
 
-    private static void LogMetric(string name, long value)
-    {
-        BenchmarksEventSource.Measure(name, value);
-        Log($"{name}: {value}");
+        private static void LogPercentiledMetric(string name, List<long> values, Func<double, double> prepareValue)
+        {
+            values.Sort();
+
+            LogMetric(name + "/min", prepareValue(GetPercentile(0, values)));
+            LogMetric(name + "/p50", prepareValue(GetPercentile(50, values)));
+            LogMetric(name + "/p75", prepareValue(GetPercentile(75, values)));
+            LogMetric(name + "/p90", prepareValue(GetPercentile(90, values)));
+            LogMetric(name + "/p99", prepareValue(GetPercentile(99, values)));
+            LogMetric(name + "/max", prepareValue(GetPercentile(100, values)));
+        }
+
+        private static void LogMetric(string name, double value)
+        {
+            BenchmarksEventSource.Measure(name, value);
+            Log($"{name}: {value}");
+        }
+
+        private static void LogMetric(string name, long value)
+        {
+            BenchmarksEventSource.Measure(name, value);
+            Log($"{name}: {value}");
+        }
     }
 }

--- a/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/StreamingHttpContent.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Clients/HttpClient/StreamingHttpContent.cs
@@ -1,36 +1,57 @@
+using System.IO;
 using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace HttpClientBenchmarks;
-
-public class StreamingHttpContent : HttpContent
+namespace HttpClientBenchmarks
 {
-    private readonly TaskCompletionSource _completeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly TaskCompletionSource<Stream> _getStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    public class StreamingHttpContent : HttpContent
     {
-        throw new NotSupportedException();
-    }
+#if NET5_0_OR_GREATER
+        private readonly TaskCompletionSource _completeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+#else
+        private readonly TaskCompletionSource<object?> _completeTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+#endif
+        private readonly TaskCompletionSource<Stream> _getStreamTcs = new TaskCompletionSource<Stream>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
-    {
-        _getStreamTcs.TrySetResult(stream);
-        await _completeTcs.Task.WaitAsync(cancellationToken);
-    }
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            _getStreamTcs.TrySetResult(stream);
+            await _completeTcs.Task.ConfigureAwait(false);
+        }
 
-    protected override bool TryComputeLength(out long length)
-    {
-        length = -1;
-        return false;
-    }
+#if NET5_0_OR_GREATER
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        {
+            _getStreamTcs.TrySetResult(stream);
 
-    public Task<Stream> GetStreamAsync()
-    {
-        return _getStreamTcs.Task;
-    }
+            using (cancellationToken.Register(static s => ((TaskCompletionSource)s!).TrySetCanceled(), _completeTcs))
+            {
+                await _completeTcs.Task.ConfigureAwait(false);
+            }
+        }
+#endif
 
-    public void CompleteStream()
-    {
-        _completeTcs.TrySetResult();
+        protected override bool TryComputeLength(out long length)
+        {
+            length = -1;
+            return false;
+        }
+
+        public Task<Stream> GetStreamAsync()
+        {
+            return _getStreamTcs.Task;
+        }
+
+        public void CompleteStream()
+        {
+#if NET5_0_OR_GREATER
+            _completeTcs.TrySetResult();
+#else
+            _completeTcs.TrySetResult(null);
+#endif
+        }
     }
 }


### PR DESCRIPTION
To be able to compare perf with older .NET versions, client is now compilable for .NET Core 3.1+.

Should be easier to review with ignore-whitespace option.

cc @MihaZupan 