### PR TITLE
Add HTTP/3 stream limit parameter to HttpClient benchmarks

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -441,6 +441,8 @@ crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenario
   - `--variable generatedDynamicRequestHeadersCount=<N>` (default: `0`)
 - Response content size in bytes:
   - `--variable responseSize=<N>` (default: `0`, meaning no content)
+- Server's HTTP/3 stream limit:
+  - `--variable http3StreamLimit=<N>` (default: `0`, meaning server's default. Max value is 65535)
 - Number of HTTP clients (HttpClient in `httpClient` job, connection in WRK):
   - `--variable numberOfHttpClients=<N>` (default: `1`)
 - Number of concurrect requests per one HTTP client -- *unsupported by WRK*:

--- a/scenarios/httpclient.benchmarks.yml
+++ b/scenarios/httpclient.benchmarks.yml
@@ -15,6 +15,7 @@ variables:
     concurrencyPerHttpClient: 1 # unsupported by WRK -- other values will throw
     collectRequestTimings: false # unsupported by WRK --  other values will throw
     responseSize: 0 # 0 for no content in response
+    http3StreamLimit: 0 # 0 for server default. Max value is 65535
 
     # POST-specific parameters:
     requestContentSize: 0 # 0 for no content
@@ -129,7 +130,7 @@ jobs:
       branchOrCommit: main
       project: src/BenchmarksApps/HttpClientBenchmarks/Servers/Kestrel/Kestrel.csproj
     readyStateText: Application started # app should write this line to output -- default Kestrel logging does that
-    arguments: "--address {{serverAddress}} --port {{serverPort}} --useHttps {{useHttps}} --httpVersion {{httpVersion}} --responseSize {{responseSize}}"
+    arguments: "--address {{serverAddress}} --port {{serverPort}} --useHttps {{useHttps}} --httpVersion {{httpVersion}} --responseSize {{responseSize}} --http3StreamLimit {{http3StreamLimit}}"
 
   httpClient:
     source:

--- a/src/BenchmarksApps/HttpClientBenchmarks/Servers/Kestrel/Program.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Servers/Kestrel/Program.cs
@@ -20,6 +20,7 @@ class Program
         rootCommand.AddOption(new Option<bool>(new string[] { "--useHttps" }, () => false, "Whether to use HTTPS"));
         rootCommand.AddOption(new Option<string>(new string[] { "--httpVersion" }, "HTTP Version (1.1 or 2.0 or 3.0)") { Required = true });
         rootCommand.AddOption(new Option<int>(new string[] { "--responseSize" }, () => 0, "Response content size, 0 for no content"));
+        rootCommand.AddOption(new Option<ushort>(new string[] { "--http3StreamLimit" }, () => 0, "HTTP/3 stream limit, 0 for unset (Kestrel default), max value is " + ushort.MaxValue));
 
         rootCommand.Handler = CommandHandler.Create<ServerOptions>(options =>
         {
@@ -85,6 +86,14 @@ class Program
                 };
             });
         });
+        if (s_options.Http3StreamLimit != 0)
+        {
+            builder.WebHost.UseQuic(options =>
+            {
+                options.MaxBidirectionalStreamCount = s_options.Http3StreamLimit;
+                options.MaxUnidirectionalStreamCount = s_options.Http3StreamLimit;
+            });
+        }
         var app = builder.Build();
 
         var url = $"http{(s_options.UseHttps ? "s" : "")}://{s_options.Address}:{s_options.Port}";

--- a/src/BenchmarksApps/HttpClientBenchmarks/Servers/Kestrel/ServerOptions.cs
+++ b/src/BenchmarksApps/HttpClientBenchmarks/Servers/Kestrel/ServerOptions.cs
@@ -7,9 +7,10 @@ public class ServerOptions
     public bool UseHttps { get; set; }
     public string? HttpVersion { get; set; }
     public int ResponseSize { get; set; }
+    public ushort Http3StreamLimit { get; set; }
 
     public override string ToString()
     {
-        return $"Address={Address}; Port={Port}; UseHttps={UseHttps}; HttpVersion={HttpVersion}; ResponseSize={ResponseSize}";
+        return $"Address={Address}; Port={Port}; UseHttps={UseHttps}; HttpVersion={HttpVersion}; ResponseSize={ResponseSize}; Http3StreamLimit={Http3StreamLimit}";
     }
 }


### PR DESCRIPTION
Current default is 100 which might be too small (see https://github.com/dotnet/aspnetcore/issues/41831) -- need to be able to override it for benchmarking purposes.