### PR TITLE
Pack of cleanup/modernization for the platform benchmarks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ indent_style = space
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
+trim_trailing_whitespace = true
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj,xml}]

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
@@ -17,14 +17,9 @@ namespace PlatformBenchmarks
         private static string[] _queries = new string[MaxBatch + 1];
 
         public static string Query(int batchSize)
-        {
-            if (_queries[batchSize] != null)
-            {
-                return _queries[batchSize];
-            }
-
-            return CreateBatch(batchSize);
-        }
+            => _queries[batchSize] is null
+                ? CreateBatch(batchSize)
+                : _queries[batchSize];
 
         private static string CreateBatch(int batchSize)
         {

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/BatchUpdateString.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved. 
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
 
+using System;
 using System.Linq;
 
 namespace PlatformBenchmarks
@@ -11,8 +12,7 @@ namespace PlatformBenchmarks
 
         public static DatabaseServer DatabaseServer;
 
-        internal static readonly string[] Ids = Enumerable.Range(0, MaxBatch).Select(i => $"@I{i}").ToArray();
-        internal static readonly string[] Randoms = Enumerable.Range(0, MaxBatch).Select(i => $"@R{i}").ToArray();
+        internal static readonly string[] ParamNames = Enumerable.Range(0, MaxBatch * 2).Select(i => $"@p{i}").ToArray();
 
         private static string[] _queries = new string[MaxBatch + 1];
 
@@ -28,16 +28,30 @@ namespace PlatformBenchmarks
 
         private static string CreateBatch(int batchSize)
         {
-            var lastIndex = batchSize - 1;
-
             var sb = StringBuilderCache.Acquire();
 
+#if NET6_0_OR_GREATER
+            Func<int, string> paramNameGenerator = i => "$" + i;
+#else
+            Func<int, string> paramNameGenerator = i => "@p" + i;
+#endif
+
             sb.AppendLine("UPDATE world SET randomNumber = CASE id");
-            Enumerable.Range(0, batchSize).ToList().ForEach(i => sb.AppendLine($"when @I{i} then @R{i}"));
+            for (var i = 0; i < batchSize * 2;)
+            {
+                sb.AppendLine($"when {paramNameGenerator(++i)} then {paramNameGenerator(++i)}");
+            }
             sb.AppendLine("else randomnumber");
             sb.AppendLine("end");
             sb.Append("where id in (");
-            Enumerable.Range(0, batchSize).ToList().ForEach(i => sb.AppendLine($"@I{i}{(lastIndex == i ? "" : ",")} "));
+            for (var i = 1; i < batchSize * 2; i += 2)
+            {
+                sb.Append(paramNameGenerator(i));
+                if (i < batchSize * 2 - 1)
+                {
+                    sb.AppendLine(", ");
+                }
+            }
             sb.Append(")");
 
             return _queries[batchSize] = StringBuilderCache.GetStringAndRelease(sb);

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -15,11 +15,8 @@ namespace PlatformBenchmarks
     {
         private readonly ConcurrentRandom _random;
         private readonly string _connectionString;
-        private readonly MemoryCache _cache = new MemoryCache(
-            new MemoryCacheOptions()
-            {
-                ExpirationScanFrequency = TimeSpan.FromMinutes(60)
-            });
+        private readonly MemoryCache _cache
+            = new(new MemoryCacheOptions { ExpirationScanFrequency = TimeSpan.FromMinutes(60) });
 
         public RawDb(ConcurrentRandom random, AppSettings appSettings)
         {
@@ -29,35 +26,29 @@ namespace PlatformBenchmarks
 
         public async Task<World> LoadSingleQueryRow()
         {
-            using (var db = new NpgsqlConnection(_connectionString))
-            {
-                await db.OpenAsync();
+            using var db = new NpgsqlConnection(_connectionString);
+            await db.OpenAsync();
 
-                var (cmd, _) = CreateReadCommand(db);
-                using (cmd)
-                {
-                    return await ReadSingleRow(cmd);
-                }
-            }
+            var (cmd, _) = CreateReadCommand(db);
+            using var command = cmd;
+
+            return await ReadSingleRow(cmd);
         }
 
         public async Task<World[]> LoadMultipleQueriesRows(int count)
         {
             var result = new World[count];
 
-            using (var db = new NpgsqlConnection(_connectionString))
-            {
-                await db.OpenAsync();
+            using var db = new NpgsqlConnection(_connectionString);
+            await db.OpenAsync();
 
-                var (cmd, idParameter) = CreateReadCommand(db);
-                using (cmd)
-                {
-                    for (int i = 0; i < result.Length; i++)
-                    {
-                        result[i] = await ReadSingleRow(cmd);
-                        idParameter.TypedValue = _random.Next(1, 10001);
-                    }
-                }
+            var (cmd, idParameter) = CreateReadCommand(db);
+            using var command = cmd;
+
+            for (var i = 0; i < result.Length; i++)
+            {
+                result[i] = await ReadSingleRow(cmd);
+                idParameter.TypedValue = _random.Next(1, 10001);
             }
 
             return result;
@@ -87,32 +78,25 @@ namespace PlatformBenchmarks
 
             static async Task<CachedWorld[]> LoadUncachedQueries(int id, int i, int count, RawDb rawdb, CachedWorld[] result)
             {
-                using (var db = new NpgsqlConnection(rawdb._connectionString))
+                using var db = new NpgsqlConnection(rawdb._connectionString);
+                await db.OpenAsync();
+
+                var (cmd, idParameter) = rawdb.CreateReadCommand(db);
+                using var command = cmd;
+                Func<ICacheEntry, Task<CachedWorld>> create = async _ => await rawdb.ReadSingleRow(cmd);
+
+                var cacheKeys = _cacheKeys;
+                var key = cacheKeys[id];
+
+                idParameter.TypedValue = id;
+
+                for (; i < result.Length; i++)
                 {
-                    await db.OpenAsync();
+                    result[i] = await rawdb._cache.GetOrCreateAsync(key, create);
 
-                    var (cmd, idParameter) = rawdb.CreateReadCommand(db);
-                    using (cmd)
-                    {
-                        Func<ICacheEntry, Task<CachedWorld>> create = async (entry) => 
-                        {
-                            return await rawdb.ReadSingleRow(cmd);
-                        };
-
-                        var cacheKeys = _cacheKeys;
-                        var key = cacheKeys[id];
-
-                        idParameter.TypedValue = id;
-
-                        for (; i < result.Length; i++)
-                        {
-                            result[i] = await rawdb._cache.GetOrCreateAsync<CachedWorld>(key, create);
-
-                            id = rawdb._random.Next(1, 10001);
-                            idParameter.TypedValue = id;
-                            key = cacheKeys[id];
-                        }
-                    }
+                    id = rawdb._random.Next(1, 10001);
+                    idParameter.TypedValue = id;
+                    key = cacheKeys[id];
                 }
 
                 return result;
@@ -121,21 +105,18 @@ namespace PlatformBenchmarks
 
         public async Task PopulateCache()
         {
-            using (var db = new NpgsqlConnection(_connectionString))
-            {
-                await db.OpenAsync();
+            using var db = new NpgsqlConnection(_connectionString);
+            await db.OpenAsync();
 
-                var (cmd, idParameter) = CreateReadCommand(db);
-                using (cmd)
-                {
-                    var cacheKeys = _cacheKeys;
-                    var cache = _cache;
-                    for (var i = 1; i < 10001; i++)
-                    {
-                        idParameter.TypedValue = i;
-                        cache.Set<CachedWorld>(cacheKeys[i], await ReadSingleRow(cmd));
-                    }
-                }
+            var (cmd, idParameter) = CreateReadCommand(db);
+            using var command = cmd;
+
+            var cacheKeys = _cacheKeys;
+            var cache = _cache;
+            for (var i = 1; i < 10001; i++)
+            {
+                idParameter.TypedValue = i;
+                cache.Set<CachedWorld>(cacheKeys[i], await ReadSingleRow(cmd));
             }
 
             Console.WriteLine("Caching Populated");
@@ -145,40 +126,38 @@ namespace PlatformBenchmarks
         {
             var results = new World[count];
 
-            using (var db = new NpgsqlConnection(_connectionString))
+            using var db = new NpgsqlConnection(_connectionString);
+            await db.OpenAsync();
+
+            var (queryCmd, queryParameter) = CreateReadCommand(db);
+            using (queryCmd)
             {
-                await db.OpenAsync();
-
-                var (queryCmd, queryParameter) = CreateReadCommand(db);
-                using (queryCmd)
+                for (var i = 0; i < results.Length; i++)
                 {
-                    for (int i = 0; i < results.Length; i++)
-                    {
-                        results[i] = await ReadSingleRow(queryCmd);
-                        queryParameter.TypedValue = _random.Next(1, 10001);
-                    }
+                    results[i] = await ReadSingleRow(queryCmd);
+                    queryParameter.TypedValue = _random.Next(1, 10001);
                 }
+            }
 
-                using (var updateCmd = new NpgsqlCommand(BatchUpdateString.Query(count), db))
+            using (var updateCmd = new NpgsqlCommand(BatchUpdateString.Query(count), db))
+            {
+                for (var i = 0; i < results.Length; i++)
                 {
-                    for (int i = 0; i < results.Length; i++)
-                    {
-                        var randomNumber = _random.Next(1, 10001);
+                    var randomNumber = _random.Next(1, 10001);
 
 #if NET6_0_OR_GREATER
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = results[i].Id });
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = randomNumber });
+                    updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = results[i].Id });
+                    updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = randomNumber });
 #else
-                        var paramIndex = i * 2 + 1;
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex], value: results[i].Id));
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex + 1], value: randomNumber));
+                    var paramIndex = i * 2 + 1;
+                    updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex], value: results[i].Id));
+                    updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex + 1], value: randomNumber));
 #endif
 
-                        results[i].RandomNumber = randomNumber;
-                    }
-
-                    await updateCmd.ExecuteNonQueryAsync();
+                    results[i].RandomNumber = randomNumber;
                 }
+
+                await updateCmd.ExecuteNonQueryAsync();
             }
 
             return results;
@@ -192,17 +171,16 @@ namespace PlatformBenchmarks
             {
                 await db.OpenAsync();
 
-                using (var cmd = new NpgsqlCommand("SELECT id, message FROM fortune", db))
-                using (var rdr = await cmd.ExecuteReaderAsync())
+                using var cmd = new NpgsqlCommand("SELECT id, message FROM fortune", db);
+                using var rdr = await cmd.ExecuteReaderAsync();
+                
+                while (await rdr.ReadAsync())
                 {
-                    while (await rdr.ReadAsync())
-                    {
-                        result.Add(new Fortune
-                        (
-                            id:rdr.GetInt32(0),
-                            message: rdr.GetString(1)
-                        ));
-                    }
+                    result.Add(new Fortune
+                    (
+                        id: rdr.GetInt32(0),
+                        message: rdr.GetString(1)
+                    ));
                 }
             }
 
@@ -230,16 +208,14 @@ namespace PlatformBenchmarks
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private async Task<World> ReadSingleRow(NpgsqlCommand cmd)
         {
-            using (var rdr = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SingleRow))
-            {
-                await rdr.ReadAsync();
+            using var rdr = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SingleRow);
+            await rdr.ReadAsync();
 
-                return new World
-                {
-                    Id = rdr.GetInt32(0),
-                    RandomNumber = rdr.GetInt32(1)
-                };
-            }
+            return new World
+            {
+                Id = rdr.GetInt32(0),
+                RandomNumber = rdr.GetInt32(1)
+            };
         }
 
         private static readonly object[] _cacheKeys = Enumerable.Range(0, 10001).Select((i) => new CacheKey(i)).ToArray();
@@ -254,7 +230,7 @@ namespace PlatformBenchmarks
             public bool Equals(CacheKey key)
                 => key._value == _value;
 
-            public override bool Equals(object obj) 
+            public override bool Equals(object obj)
                 => ReferenceEquals(obj, this);
 
             public override int GetHashCode()

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/Data/RawDb.cs
@@ -161,15 +161,18 @@ namespace PlatformBenchmarks
 
                 using (var updateCmd = new NpgsqlCommand(BatchUpdateString.Query(count), db))
                 {
-                    var ids = BatchUpdateString.Ids;
-                    var randoms = BatchUpdateString.Randoms;
-
                     for (int i = 0; i < results.Length; i++)
                     {
                         var randomNumber = _random.Next(1, 10001);
 
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: ids[i], value: results[i].Id));
-                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: randoms[i], value: randomNumber));
+#if NET6_0_OR_GREATER
+                        updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = results[i].Id });
+                        updateCmd.Parameters.Add(new NpgsqlParameter<int> { TypedValue = randomNumber });
+#else
+                        var paramIndex = i * 2 + 1;
+                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex], value: results[i].Id));
+                        updateCmd.Parameters.Add(new NpgsqlParameter<int>(parameterName: BatchUpdateString.ParamNames[paramIndex + 1], value: randomNumber));
+#endif
 
                         results[i].RandomNumber = randomNumber;
                     }

--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition="'$(BenchmarksTargetFramework)' != ''">$(BenchmarksTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -32,9 +32,14 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Npgsql" Version="6.0.0-rc.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0-rc.2" />
+  <ItemGroup Condition="$(TargetFramework) == 'net6.0'">
+    <PackageReference Include="Npgsql" Version="6.0.7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Npgsql" Version="7.0.0-rc.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">


### PR DESCRIPTION
This mainly changes to use Npgsql 7.0.0-rc.1 for 7.0 and does various cleanup/modernization.

The only actual optimization here is changing the raw platform Updates benchmark to use Npgsql positional parameters instead of named (see improvement below).

This is also a baseline for further planned improvements for 7.0.

/cc @sebastienros @ajcvickers @NinoFloris @vonzshik @Brar

Scenario | Before  | After
-------- | ------- | -----
Fortunes | 446,335 | 466,476
Updates  | 16,940  | 18,658

<details>
<summary>Full results</summary>

## Before PR

### Fortunes

<details>
<summary>Full results</summary>

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net6.0

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 35      |
| Cores usage (%)     | 994     |
| Working Set (MB)    | 44      |
| Build Time (ms)     | 1,323   |
| Start Time (ms)     | 365     |
| Published Size (KB) | 929,630 |


| application           |               |
| --------------------- | ------------- |
| CPU Usage (%)         | 96            |
| Cores usage (%)       | 2,677         |
| Working Set (MB)      | 486           |
| Private Memory (MB)   | 2,035         |
| Build Time (ms)       | 4,946         |
| Start Time (ms)       | 1,910         |
| Published Size (KB)   | 97,139        |
| .NET Core SDK Version | 6.0.401       |
| ASP.NET Core Version  | 6.0.9+3fe12b9 |
| .NET Runtime Version  | 6.0.9+163a635 |


| load                   |           |
| ---------------------- | --------- |
| CPU Usage (%)          | 38        |
| Cores usage (%)        | 1,057     |
| Working Set (MB)       | 38        |
| Private Memory (MB)    | 363       |
| Start Time (ms)        | 0         |
| First Request (ms)     | 109       |
| Requests/sec           | 446,335   |
| Requests               | 6,739,418 |
| Mean latency (ms)      | 1.23      |
| Max latency (ms)       | 25.96     |
| Bad responses          | 0         |
| Socket errors          | 0         |
| Read throughput (MB/s) | 579.32    |
| Latency 50th (ms)      | 1.07      |
| Latency 75th (ms)      | 1.30      |
| Latency 90th (ms)      | 1.69      |
| Latency 99th (ms)      | 4.73      |
```

</details>

### Updates

RPS: 

<details>
<summary>Full results</summary>

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario updates --profile aspnet-citrine-lin --application.framework net6.0

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 54      |
| Cores usage (%)     | 1,504   |
| Working Set (MB)    | 56      |
| Build Time (ms)     | 1,523   |
| Start Time (ms)     | 353     |
| Published Size (KB) | 929,630 |


| application           |               |
| --------------------- | ------------- |
| CPU Usage (%)         | 74            |
| Cores usage (%)       | 2,062         |
| Working Set (MB)      | 474           |
| Private Memory (MB)   | 2,049         |
| Build Time (ms)       | 3,188         |
| Start Time (ms)       | 1,869         |
| Published Size (KB)   | 97,139        |
| .NET Core SDK Version | 6.0.401       |
| ASP.NET Core Version  | 6.0.9+3fe12b9 |
| .NET Runtime Version  | 6.0.9+163a635 |


| load                   |         |
| ---------------------- | ------- |
| CPU Usage (%)          | 3       |
| Cores usage (%)        | 82      |
| Working Set (MB)       | 38      |
| Private Memory (MB)    | 363     |
| Start Time (ms)        | 0       |
| First Request (ms)     | 135     |
| Requests/sec           | 16,940  |
| Requests               | 255,453 |
| Mean latency (ms)      | 38.16   |
| Max latency (ms)       | 228.76  |
| Bad responses          | 0       |
| Socket errors          | 0       |
| Read throughput (MB/s) | 12.24   |
| Latency 50th (ms)      | 24.73   |
| Latency 75th (ms)      | 28.11   |
| Latency 90th (ms)      | 88.71   |
| Latency 99th (ms)      | 179.22  |
```

</details>

## After PR

### Fortunes

<details>
<summary>Full results</summary>

```
crank --config https://raw.githubusercontent.com/roji/AspNetBenchmarks/Npgsql/scenarios/platform.benchmarks.yml --scenario fortunes --profile aspnet-citrine-lin --application.framework net7.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit Npgsql

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 36      |
| Cores usage (%)     | 1,016   |
| Working Set (MB)    | 44      |
| Build Time (ms)     | 1,368   |
| Start Time (ms)     | 352     |
| Published Size (KB) | 929,630 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 96                         |
| Cores usage (%)       | 2,695                      |
| Working Set (MB)      | 624                        |
| Private Memory (MB)   | 1,799                      |
| Build Time (ms)       | 1,619                      |
| Start Time (ms)       | 1,899                      |
| Published Size (KB)   | 101,623                    |
| .NET Core SDK Version | 8.0.100-alpha.1.22470.29   |
| ASP.NET Core Version  | 7.0.0-rtm.22471.6+c735b8c  |
| .NET Runtime Version  | 7.0.0-rtm.22471.13+34c5488 |


| load                   |           |
| ---------------------- | --------- |
| CPU Usage (%)          | 38        |
| Cores usage (%)        | 1,070     |
| Working Set (MB)       | 38        |
| Private Memory (MB)    | 363       |
| Start Time (ms)        | 0         |
| First Request (ms)     | 91        |
| Requests/sec           | 466,476   |
| Requests               | 7,043,556 |
| Mean latency (ms)      | 1.16      |
| Max latency (ms)       | 21.24     |
| Bad responses          | 0         |
| Socket errors          | 0         |
| Read throughput (MB/s) | 605.46    |
| Latency 50th (ms)      | 1.03      |
| Latency 75th (ms)      | 1.25      |
| Latency 90th (ms)      | 1.56      |
| Latency 99th (ms)      | 4.08      |
```

</details>

### Updates

<details>
<summary>Full results</summary>

```
crank --config https://raw.githubusercontent.com/roji/AspNetBenchmarks/Npgsql/scenarios/platform.benchmarks.yml --scenario updates --profile aspnet-citrine-lin --application.framework net7.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit Npgsql

| db                  |         |
| ------------------- | ------- |
| CPU Usage (%)       | 57      |
| Cores usage (%)     | 1,603   |
| Working Set (MB)    | 56      |
| Build Time (ms)     | 1,364   |
| Start Time (ms)     | 350     |
| Published Size (KB) | 929,630 |


| application           |                            |
| --------------------- | -------------------------- |
| CPU Usage (%)         | 56                         |
| Cores usage (%)       | 1,568                      |
| Working Set (MB)      | 660                        |
| Private Memory (MB)   | 1,765                      |
| Build Time (ms)       | 1,561                      |
| Start Time (ms)       | 1,923                      |
| Published Size (KB)   | 101,623                    |
| .NET Core SDK Version | 8.0.100-alpha.1.22470.29   |
| ASP.NET Core Version  | 7.0.0-rtm.22471.6+c735b8c  |
| .NET Runtime Version  | 7.0.0-rtm.22471.13+34c5488 |


| load                   |         |
| ---------------------- | ------- |
| CPU Usage (%)          | 3       |
| Cores usage (%)        | 88      |
| Working Set (MB)       | 38      |
| Private Memory (MB)    | 363     |
| Start Time (ms)        | 0       |
| First Request (ms)     | 96      |
| Requests/sec           | 18,658  |
| Requests               | 281,705 |
| Mean latency (ms)      | 32.64   |
| Max latency (ms)       | 200.02  |
| Bad responses          | 0       |
| Socket errors          | 0       |
| Read throughput (MB/s) | 13.48   |
| Latency 50th (ms)      | 23.55   |
| Latency 75th (ms)      | 25.94   |
| Latency 90th (ms)      | 65.23   |
| Latency 99th (ms)      | 145.21  |
```

</details>
</details>