### PR TITLE
Add HttpClient benchmarks to runtime PR benchmarks

### DIFF
--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -12,8 +12,7 @@ components:
 defaults: '--{{job}}.framework net7.0 --relay AZURE_RELAY'
 
 variables:
-    job: client
-    httpclientcommon: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --variable useHttps=true --variable concurrencyPerHttpClient=100
+    job: application
 
 # the first value is the default if none is specified
 profiles:
@@ -34,41 +33,17 @@ benchmarks:
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext
-      variables:
-          job: application
 
     json:
       description: TechEmpower JSON Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario json
-      variables:
-          job: application
-    
+  
     fortunes:
       description: TechEmpower Fortunes Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes
+
+    httpclient-kestrel-configured:
+      description: 'HttpClient Benchmark (default: HTTP/1.1 GET 8K)'
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --scenario httpclient-kestrel-configured
       variables:
-          job: application
-
-    httpclient-h1-get:
-      description: HttpClient HTTP/1.1 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="1.1" --variable responseSize=8192'
-
-    httpclient-h2-get:
-      description: HttpClient HTTP/2.0 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="2.0" --variable responseSize=8192'
-
-    httpclient-h3-get:
-      description: HttpClient HTTP/3.0 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="3.0" --variable responseSize=8192'
-
-    httpclient-h1-post:
-      description: HttpClient HTTP/1.1 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="1.1" --variable requestContentSize=8192'
-
-    httpclient-h2-post:
-      description: HttpClient HTTP/2.0 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="2.0" --variable requestContentSize=8192'
-
-    httpclient-h3-post:
-      description: HttpClient HTTP/3.0 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="3.0" --variable requestContentSize=8192'
+          job: client

--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -6,11 +6,14 @@ components:
             call ./src/tests/build.sh Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
             rm -rf ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/*.pdb
 
-        arguments:
-            --application.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/
+        arguments: '--{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/'
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net7.0 --relay AZURE_RELAY 
+defaults: '--{{job}}.framework net7.0 --relay AZURE_RELAY'
+
+variables:
+    job: client
+    httpclientcommon: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --variable useHttps=true --variable concurrencyPerHttpClient=100
 
 # the first value is the default if none is specified
 profiles:
@@ -31,11 +34,41 @@ benchmarks:
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext
+      variables:
+          job: application
 
     json:
       description: TechEmpower JSON Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario json
+      variables:
+          job: application
     
     fortunes:
       description: TechEmpower Fortunes Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes
+      variables:
+          job: application
+
+    httpclient-h1-get:
+      description: HttpClient HTTP/1.1 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="1.1" --variable responseSize=8192'
+
+    httpclient-h2-get:
+      description: HttpClient HTTP/2.0 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="2.0" --variable responseSize=8192'
+
+    httpclient-h3-get:
+      description: HttpClient HTTP/3.0 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="3.0" --variable responseSize=8192'
+
+    httpclient-h1-post:
+      description: HttpClient HTTP/1.1 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="1.1" --variable requestContentSize=8192'
+
+    httpclient-h2-post:
+      description: HttpClient HTTP/2.0 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="2.0" --variable requestContentSize=8192'
+
+    httpclient-h3-post:
+      description: HttpClient HTTP/3.0 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="3.0" --variable requestContentSize=8192'

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -13,8 +13,7 @@ components:
 defaults: '--{{job}}.framework net7.0 --relay AZURE_RELAY'
 
 variables:
-    job: client
-    httpclientcommon: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --variable useHttps=true --variable concurrencyPerHttpClient=100
+    job: application
 
 # the first value is the default if none is specified
 profiles:
@@ -31,41 +30,17 @@ benchmarks:
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext
-      variables:
-          job: application
 
     json:
       description: TechEmpower JSON Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario json
-      variables:
-          job: application
-    
+
     fortunes:
       description: TechEmpower Fortunes Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes
+
+    httpclient-kestrel-configured:
+      description: 'HttpClient Benchmark (default: HTTP/1.1 GET 8K)'
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --scenario httpclient-kestrel-configured
       variables:
-          job: application
-
-    httpclient-h1-get:
-      description: HttpClient HTTP/1.1 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="1.1" --variable responseSize=8192'
-
-    httpclient-h2-get:
-      description: HttpClient HTTP/2.0 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="2.0" --variable responseSize=8192'
-
-    httpclient-h3-get:
-      description: HttpClient HTTP/3.0 GET
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="3.0" --variable responseSize=8192'
-
-    httpclient-h1-post:
-      description: HttpClient HTTP/1.1 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="1.1" --variable requestContentSize=8192'
-
-    httpclient-h2-post:
-      description: HttpClient HTTP/2.0 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="2.0" --variable requestContentSize=8192'
-
-    httpclient-h3-post:
-      description: HttpClient HTTP/3.0 POST
-      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="3.0" --variable requestContentSize=8192'
+          job: client

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -6,11 +6,15 @@ components:
             call .\src\tests\build.cmd Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
             del /F /S /Q .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\*.pdb
 
-        arguments:
-            --application.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\
+        arguments: '--{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'
+
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net7.0 --relay AZURE_RELAY 
+defaults: '--{{job}}.framework net7.0 --relay AZURE_RELAY'
+
+variables:
+    job: client
+    httpclientcommon: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml --server.framework net7.0 --variable useHttps=true --variable concurrencyPerHttpClient=100
 
 # the first value is the default if none is specified
 profiles:
@@ -27,11 +31,41 @@ benchmarks:
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext
+      variables:
+          job: application
 
     json:
       description: TechEmpower JSON Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario json
+      variables:
+          job: application
     
     fortunes:
       description: TechEmpower Fortunes Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario fortunes
+      variables:
+          job: application
+
+    httpclient-h1-get:
+      description: HttpClient HTTP/1.1 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="1.1" --variable responseSize=8192'
+
+    httpclient-h2-get:
+      description: HttpClient HTTP/2.0 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="2.0" --variable responseSize=8192'
+
+    httpclient-h3-get:
+      description: HttpClient HTTP/3.0 GET
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-get --variable httpVersion="3.0" --variable responseSize=8192'
+
+    httpclient-h1-post:
+      description: HttpClient HTTP/1.1 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="1.1" --variable requestContentSize=8192'
+
+    httpclient-h2-post:
+      description: HttpClient HTTP/2.0 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="2.0" --variable requestContentSize=8192'
+
+    httpclient-h3-post:
+      description: HttpClient HTTP/3.0 POST
+      arguments: '{{httpclientcommon}} --scenario httpclient-kestrel-post --variable httpVersion="3.0" --variable requestContentSize=8192'

--- a/scenarios/httpclient.benchmarks.yml
+++ b/scenarios/httpclient.benchmarks.yml
@@ -47,7 +47,7 @@ scenarios:
       job: httpClient
       variables:
         scenario: get
-  
+
   httpclient-kestrel-post:
     server:
       job: kestrel
@@ -68,6 +68,24 @@ scenarios:
         requestContentWriteSize: 1
         requestContentFlushAfterWrite: true
         requestContentUnknownLength: true
+
+  httpclient-kestrel-configured:
+    server:
+      job: kestrel
+      variables:
+        httpVersion: "1.1"
+        useHttps: true
+        responseSize: 8192
+    client:
+      job: httpClient
+      variables:
+        scenario: get
+        httpVersion: "1.1"
+        useHttps: true
+        numberOfHttpClients: 1
+        concurrencyPerHttpClient: '{% if cores > 0 %}{{cores}}{% else %}1{% endif %}'
+        http20EnableMultipleConnections: false
+        useHttpMessageInvoker: true
 
   wrk-kestrel-get:
     server:
@@ -157,6 +175,7 @@ profiles:
   aspnet-citrine-lin:
     variables:
       serverAddress: 10.0.0.105
+      cores: 28
     jobs:
       server:
         endpoints: 
@@ -168,6 +187,7 @@ profiles:
   aspnet-citrine-lin-relay:
     variables:
       serverAddress: 10.0.0.105
+      cores: 28
     jobs:
       server:
         endpoints: 
@@ -179,6 +199,7 @@ profiles:
   aspnet-citrine-win:
     variables:
       serverAddress: 10.0.0.103
+      cores: 28
     jobs:
       server:
         endpoints: 
@@ -190,6 +211,7 @@ profiles:
   aspnet-citrine-win-relay:
     variables:
       serverAddress: 10.0.0.103
+      cores: 28
     jobs:
       server:
         endpoints: 
@@ -201,6 +223,7 @@ profiles:
   aspnet-citrine-arm:
     variables:
       serverAddress: 10.0.0.105
+      cores: 32
     jobs:
       server:
         endpoints: 
@@ -212,6 +235,7 @@ profiles:
   aspnet-citrine-arm-relay:
     variables:
       serverAddress: 10.0.0.105
+      cores: 32
     jobs:
       server:
         endpoints: 
@@ -223,6 +247,7 @@ profiles:
   aspnet-citrine-amd:
     variables:
       serverAddress: 10.0.0.103
+      cores: 48
     jobs:
       server:
         endpoints: 
@@ -234,6 +259,7 @@ profiles:
   aspnet-citrine-amd-relay:
     variables:
       serverAddress: 10.0.0.103
+      cores: 48
     jobs:
       server:
         endpoints: 
@@ -245,6 +271,7 @@ profiles:
   aspnet-perf-lin:
     variables:
       serverAddress: 10.0.0.104
+      cores: 12
     jobs:
       server:
         endpoints: 
@@ -256,6 +283,7 @@ profiles:
   aspnet-perf-lin-relay:
     variables:
       serverAddress: 10.0.0.104
+      cores: 12
     jobs:
       server:
         endpoints: 
@@ -267,6 +295,7 @@ profiles:
   aspnet-perf-win:
     variables:
       serverAddress: 10.0.0.103
+      cores: 12
     jobs:
       server:
         endpoints: 
@@ -278,6 +307,7 @@ profiles:
   aspnet-perf-win-relay:
     variables:
       serverAddress: 10.0.0.103
+      cores: 12
     jobs:
       server:
         endpoints: 


### PR DESCRIPTION
Depends on https://github.com/dotnet/crank/pull/471

It can theoretically be done without the PR above, but it would require moving and copy-pasting everything to `benchmarks.arguments`, including what was in `defaults` and in `components.arguments`. HttpClient benchmarks don't have `application` job so Crank will fail if an argument with `application` would be passed there.

Let me know what you think @sebastienros 