### PR TITLE
Add microbenchmarks scenario to PR bot

### DIFF
--- a/build/prbenchmarks.runtime.linux_arm64.config.yml
+++ b/build/prbenchmarks.runtime.linux_arm64.config.yml
@@ -19,6 +19,10 @@ profiles:
         arguments: --profile aspnet-citrine-arm-lin-relay
 
 benchmarks:
+    microbenchmarks:
+      description: '.NET Performance micro benchmarks (default filter: "*LinqBenchmarks*", change by adding "--variable filter=...")'
+      arguments: --config https://raw.githubusercontent.com/aspnet/benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario custom
+
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext

--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -28,6 +28,10 @@ profiles:
         arguments: --profile aspnet-citrine-amd-relay
 
 benchmarks:
+    microbenchmarks:
+      description: '.NET Performance micro benchmarks (default filter: "*LinqBenchmarks*", change by adding "--variable filter=...")'
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario custom
+
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext

--- a/build/prbenchmarks.runtime.windows_arm64.config.yml
+++ b/build/prbenchmarks.runtime.windows_arm64.config.yml
@@ -19,6 +19,10 @@ profiles:
         arguments: --profile aspnet-citrine-arm-win-relay
 
 benchmarks:
+    microbenchmarks:
+      description: '.NET Performance micro benchmarks (default filter: "*LinqBenchmarks*", change by adding "--variable filter=...")'
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario custom
+
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -24,6 +24,10 @@ profiles:
         arguments: --profile aspnet-citrine-win-relay
 
 benchmarks:
+    microbenchmarks:
+      description: '.NET Performance micro benchmarks (default filter: "*LinqBenchmarks*", change by adding "--variable filter=...")'
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario custom
+
     plaintext:
       description: TechEmpower Plaintext Scenario - ASP.NET Platform implementation
       arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario plaintext


### PR DESCRIPTION
Setting custom filter from PR comment depends on https://github.com/dotnet/crank/pull/482

PR comment would look like:
`/benchmark microbenchmarks aspnet-citrine-win runtime --variable filter=System.Memory*`