### PR TITLE
Use Npgsql batching with Syncs in platform benchmarks

### DIFF
--- a/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/Kestrel/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Npgsql" Version="7.0.0-rc.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.1" />
+    <PackageReference Include="Npgsql" Version="7.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">


### PR DESCRIPTION
This introduces Npgsql Sync-batching (or batching with "error barriers") in the platform multiple queries and updates benchmarks. Previously, the multiple queries fired off by a single web request were executed in serial (2nd one executed only after the 1st one completed); after this, all queries are batched together (sent together, probably in a single packet), with PG Sync messages in between to prevent interference between them. Aside from eliminating the needless waiting for responses caused by serial execution, this makes it very probable that results for all later queries are already there when we await on them, reducing expensive async dispatches.

Scenario         | Before change | After change
---------------- | ------------- | ----------------
Multiple queries | 29,796        | 41,872 (+40.53%)
Updates          | 19,759        | 24,157 (+22.26%)

Note that the Update benchmark has high result variability, so the above figure shouldn't be trusted too much (multiple queries is very stable though). Note that an additional change change to split read/write pools for the Updates benchmark, and is expected to provide a further significant boost.

## Multiple query result comparison

| db                  | multiple_queries_baseline | multiple_queries_change |         |
| ------------------- | ------------------------- | ----------------------- | ------- |
| CPU Usage (%)       |                        47 |                      66 | +40.43% |
| Cores usage (%)     |                     1,311 |                   1,842 | +40.50% |
| Working Set (MB)    |                        46 |                      45 |  -2.17% |
| Build Time (ms)     |                     1,376 |                   1,416 |  +2.91% |
| Start Time (ms)     |                       374 |                     362 |  -3.21% |
| Published Size (KB) |                   929,904 |                 929,904 |   0.00% |


| application           | multiple_queries_baseline | multiple_queries_change |         |
| --------------------- | ------------------------- | ----------------------- | ------- |
| CPU Usage (%)         |                        63 |                      80 | +26.98% |
| Cores usage (%)       |                     1,774 |                   2,231 | +25.76% |
| Working Set (MB)      |                       630 |                     628 |  -0.32% |
| Private Memory (MB)   |                       996 |                   1,284 | +28.92% |
| Build Time (ms)       |                     3,124 |                   3,208 |  +2.69% |
| Start Time (ms)       |                     1,826 |                   1,832 |  +0.33% |
| Published Size (KB)   |                   101,633 |                 101,725 |  +0.09% |
| .NET Core SDK Version |   8.0.100-alpha.1.22513.1 | 8.0.100-alpha.1.22513.1 |         |


| load                   | multiple_queries_baseline | multiple_queries_change |          |
| ---------------------- | ------------------------- | ----------------------- | -------- |
| CPU Usage (%)          |                         4 |                       6 |  +50.00% |
| Cores usage (%)        |                       119 |                     160 |  +34.45% |
| Working Set (MB)       |                        38 |                      38 |    0.00% |
| Private Memory (MB)    |                       363 |                     363 |    0.00% |
| Start Time (ms)        |                         0 |                       0 |          |
| First Request (ms)     |                        88 |                      97 |  +10.23% |
| Requests/sec           |                    29,796 |                  41,872 |  +40.53% |
| Requests               |                   449,853 |                 632,259 |  +40.55% |
| Mean latency (ms)      |                     17.12 |                   12.87 |  -24.82% |
| Max latency (ms)       |                     28.41 |                   72.40 | +154.84% |
| Bad responses          |                         0 |                       0 |          |
| Socket errors          |                         0 |                       0 |          |
| Read throughput (MB/s) |                     21.52 |                   30.25 |  +40.57% |
| Latency 50th (ms)      |                     16.97 |                   11.43 |  -32.65% |
| Latency 75th (ms)      |                     18.49 |                   17.27 |   -6.60% |
| Latency 90th (ms)      |                     19.90 |                   24.92 |  +25.23% |
| Latency 99th (ms)      |                     22.79 |                   38.55 |  +69.15% |

## Updates result comparison

| db                  | updates_baseline | updates_change |         |
| ------------------- | ---------------- | -------------- | ------- |
| CPU Usage (%)       |               55 |             65 | +18.18% |
| Cores usage (%)     |            1,552 |          1,829 | +17.85% |
| Working Set (MB)    |               55 |             55 |   0.00% |
| Build Time (ms)     |            1,389 |          1,433 |  +3.17% |
| Start Time (ms)     |              359 |            363 |  +1.11% |
| Published Size (KB) |          929,904 |        929,904 |   0.00% |


| application           | updates_baseline        | updates_change          |        |
| --------------------- | ----------------------- | ----------------------- | ------ |
| CPU Usage (%)         |                      55 |                      59 | +7.27% |
| Cores usage (%)       |                   1,546 |                   1,645 | +6.40% |
| Working Set (MB)      |                     648 |                     606 | -6.48% |
| Private Memory (MB)   |                   1,309 |                   1,276 | -2.52% |
| Build Time (ms)       |                   3,235 |                   3,228 | -0.22% |
| Start Time (ms)       |                   1,903 |                   1,832 | -3.73% |
| Published Size (KB)   |                 101,633 |                 101,725 | +0.09% |
| .NET Core SDK Version | 8.0.100-alpha.1.22513.1 | 8.0.100-alpha.1.22513.1 |        |


| load                   | updates_baseline | updates_change |         |
| ---------------------- | ---------------- | -------------- | ------- |
| CPU Usage (%)          |                3 |              4 | +33.33% |
| Cores usage (%)        |               90 |            106 | +17.78% |
| Working Set (MB)       |               38 |             38 |   0.00% |
| Private Memory (MB)    |              363 |            363 |   0.00% |
| Start Time (ms)        |                0 |              0 |         |
| First Request (ms)     |              107 |            106 |  -0.93% |
| Requests/sec           |           19,759 |         24,157 | +22.26% |
| Requests               |          298,354 |        364,417 | +22.14% |
| Mean latency (ms)      |            28.14 |          24.65 | -12.40% |
| Max latency (ms)       |           134.44 |         176.29 | +31.13% |
| Bad responses          |                0 |              0 |         |
| Socket errors          |                0 |              0 |         |
| Read throughput (MB/s) |            14.28 |          17.45 | +22.20% |
| Latency 50th (ms)      |            23.54 |          19.34 | -17.84% |
| Latency 75th (ms)      |            25.66 |          27.62 |  +7.64% |
| Latency 90th (ms)      |            33.08 |          40.85 | +23.49% |
| Latency 99th (ms)      |           112.72 |         119.48 |  +6.00% |

<details>
<summary>Command-lines used</summary>

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario multiple_queries --profile aspnet-citrine-lin --application.framework net7.0 --application.source.branchOrCommit main#539cf90bdc1e274e47a7737b1c741da0d4e9c001 --json multiple_queries_baseline.json
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario multiple_queries --profile aspnet-citrine-lin --application.framework net7.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit IsolationBatching#1e4fe5f277f90dcf7ff432b8f349fbab12642444 --json multiple_queries_change.json

crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario updates --profile aspnet-citrine-lin --application.framework net7.0 --application.source.branchOrCommit main#539cf90bdc1e274e47a7737b1c741da0d4e9c001 --json updates_baseline.json
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/platform.benchmarks.yml --scenario updates --profile aspnet-citrine-lin --application.framework net7.0 --application.source.repository http://github.com/roji/AspNetBenchmarks --application.source.branchOrCommit IsolationBatching#1e4fe5f277f90dcf7ff432b8f349fbab12642444 --json updates_change.json
```

</details>

/cc @NinoFloris @vonzshik @Brar @ajcvickers @sebastienros