### PR TITLE
Add runtime libs-only PR benchmark component

### DIFF
--- a/build/prbenchmarks.runtime.linux_arm64.config.yml
+++ b/build/prbenchmarks.runtime.linux_arm64.config.yml
@@ -9,6 +9,15 @@ components:
         arguments:
             --application.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
 
+    runtime-libs:
+        script: |
+            call ./build.sh libs -c Release -runtimeconfiguration Release -arch arm64
+            call ./src/tests/build.sh Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release
+            rm -rf ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/*.pdb
+
+        arguments:
+            --application.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
+
 # default arguments that are always used on crank commands
 defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net8.0 --relay AZURE_RELAY 
 

--- a/build/prbenchmarks.runtime.linux_arm64.config.yml
+++ b/build/prbenchmarks.runtime.linux_arm64.config.yml
@@ -9,7 +9,7 @@ components:
         arguments:
             --application.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
 
-    runtime-libs:
+    libs:
         script: |
             call ./build.sh libs -c Release -runtimeconfiguration Release -arch arm64
             call ./src/tests/build.sh Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release

--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -8,7 +8,7 @@ components:
 
         arguments: '--{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/'
 
-    runtime-libs: 
+    libs: 
         script: |
             call ./build.sh libs -c Release -runtimeconfiguration Release -arch x64
             call ./src/tests/build.sh Release x64 generatelayoutonly /p:LibrariesConfiguration=Release

--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -8,6 +8,14 @@ components:
 
         arguments: '--{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/'
 
+    runtime-libs: 
+        script: |
+            call ./build.sh libs -c Release -runtimeconfiguration Release -arch x64
+            call ./src/tests/build.sh Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
+            rm -rf ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/*.pdb
+
+        arguments: '--{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/'
+
 # default arguments that are always used on crank commands
 defaults: '--{{job}}.framework net8.0 --relay AZURE_RELAY'
 

--- a/build/prbenchmarks.runtime.windows_arm64.config.yml
+++ b/build/prbenchmarks.runtime.windows_arm64.config.yml
@@ -9,7 +9,7 @@ components:
         arguments:
             --application.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
 
-    runtime-libs:
+    libs:
         script: |
             call .\build.cmd libs -c Release -runtimeconfiguration Release -arch arm64
             call .\src\tests\build.cmd Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release

--- a/build/prbenchmarks.runtime.windows_arm64.config.yml
+++ b/build/prbenchmarks.runtime.windows_arm64.config.yml
@@ -9,6 +9,15 @@ components:
         arguments:
             --application.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
 
+    runtime-libs:
+        script: |
+            call .\build.cmd libs -c Release -runtimeconfiguration Release -arch arm64
+            call .\src\tests\build.cmd Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release
+            del /F /S /Q .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\*.pdb
+
+        arguments:
+            --application.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
+
 # default arguments that are always used on crank commands
 defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net8.0 --relay AZURE_RELAY 
 

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -10,7 +10,7 @@ components:
 
     libs:
         script: |
-            call .\build.cmd libs -c Release -arch x64
+            call .\build.cmd libs -c Release -runtimeconfiguration Release -arch x64
             call .\src\tests\build.cmd Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
             del /F /S /Q .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\*.pdb
 

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -8,6 +8,13 @@ components:
 
         arguments: '--{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'
 
+    runtime-libs:
+        script: |
+            call .\build.cmd libs -c Release -arch x64
+            call .\src\tests\build.cmd Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
+            del /F /S /Q .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\*.pdb
+
+        arguments: '--{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'
 
 # default arguments that are always used on crank commands
 defaults: '--{{job}}.framework net8.0 --relay AZURE_RELAY'

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -8,7 +8,7 @@ components:
 
         arguments: '--{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'
 
-    runtime-libs:
+    libs:
         script: |
             call .\build.cmd libs -c Release -arch x64
             call .\src\tests\build.cmd Release x64 generatelayoutonly /p:LibrariesConfiguration=Release


### PR DESCRIPTION
Building only libs reduces building time by ~66% (from ~30min to ~10min locally)

Contributes to https://github.com/dotnet/runtime/issues/77215