### PR TITLE
Fix default scheme for MVC apps

### DIFF
--- a/src/BenchmarksApps/Mvc/mvcserver.yml
+++ b/src/BenchmarksApps/Mvc/mvcserver.yml
@@ -8,6 +8,7 @@ jobs:
     waitForExit: false
     variables:
       useNewtonsoftJson: false
+      serverScheme: http
     arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} {%if useNewtonsoftJson == true %} --useNewtonsoftJson true {% endif %}"
   mapaction:
     source:

--- a/src/BenchmarksApps/Mvc/mvcserver.yml
+++ b/src/BenchmarksApps/Mvc/mvcserver.yml
@@ -9,6 +9,7 @@ jobs:
     variables:
       useNewtonsoftJson: false
       serverScheme: http
+      serverPort: 5000
     arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} {%if useNewtonsoftJson == true %} --useNewtonsoftJson true {% endif %}"
   mapaction:
     source:


### PR DESCRIPTION
Broke default scenarios when I fixed the cert auth scenarios by not having a default serverScheme.