### PR TITLE
Optimize runtime component

### DIFF
--- a/build/prbenchmarks.runtime.linux_arm64.config.yml
+++ b/build/prbenchmarks.runtime.linux_arm64.config.yml
@@ -2,12 +2,9 @@
 components:
     runtime:
         script: |
-            call ./build.sh clr+libs -c Release -runtimeconfiguration Release -arch arm64
-            call ./src/tests/build.sh Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release
-            rm -rf ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/*.pdb
+            call ./build.sh clr.runtime+clr.alljits+clr.iltools+clr.tools+clr.corelib+clr.nativecorelib -c Release -runtimeconfiguration Release -arch arm64
 
-        arguments:
-            --application.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
+        arguments: '--{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.arm64.Release/clrjit.dll --{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.arm64.Release/coreclr.dll --{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.arm64.Release/System.Private.CoreLib.dll'
 
     libs:
         script: |
@@ -16,10 +13,10 @@ components:
             rm -rf ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/*.pdb
 
         arguments:
-            --application.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
+            --{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net8.0 --relay AZURE_RELAY 
+defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --{{job}}.framework net8.0 --relay AZURE_RELAY 
 
 # the first value is the default if none is specified
 profiles:

--- a/build/prbenchmarks.runtime.linux_x64.config.yml
+++ b/build/prbenchmarks.runtime.linux_x64.config.yml
@@ -2,11 +2,9 @@
 components:
     runtime: 
         script: |
-            call ./build.sh clr+libs -c Release -runtimeconfiguration Release -arch x64
-            call ./src/tests/build.sh Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
-            rm -rf ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/*.pdb
+            call ./build.sh clr.runtime+clr.alljits+clr.iltools+clr.tools+clr.corelib+clr.nativecorelib -c Release -runtimeconfiguration Release -arch x64
 
-        arguments: '--{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.x64.Release/tests/Core_Root/'
+        arguments: '--{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.x64.Release/clrjit.dll --{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.x64.Release/coreclr.dll --{{job}}.options.outputFiles ./artifacts/bin/coreclr/Linux.x64.Release/System.Private.CoreLib.dll'
 
     libs: 
         script: |

--- a/build/prbenchmarks.runtime.windows_arm64.config.yml
+++ b/build/prbenchmarks.runtime.windows_arm64.config.yml
@@ -2,12 +2,9 @@
 components:
     runtime:
         script: |
-            call .\build.cmd clr+libs -c Release -runtimeconfiguration Release -arch arm64
-            call .\src\tests\build.cmd Release arm64 generatelayoutonly /p:LibrariesConfiguration=Release
-            del /F /S /Q .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\*.pdb
+            call .\build.cmd clr.runtime+clr.alljits+clr.iltools+clr.tools+clr.corelib+clr.nativecorelib -c Release -runtimeconfiguration Release -arch arm64
 
-        arguments:
-            --application.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
+        arguments: '--{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.arm64.Release\clrjit.dll --{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.arm64.Release\coreclr.dll --{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.arm64.Release\System.Private.CoreLib.dll'
 
     libs:
         script: |
@@ -16,10 +13,10 @@ components:
             del /F /S /Q .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\*.pdb
 
         arguments:
-            --application.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
+            --{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net8.0 --relay AZURE_RELAY 
+defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --{{job}}.framework net8.0 --relay AZURE_RELAY 
 
 # the first value is the default if none is specified
 profiles:

--- a/build/prbenchmarks.runtime.windows_x64.config.yml
+++ b/build/prbenchmarks.runtime.windows_x64.config.yml
@@ -2,11 +2,9 @@
 components:
     runtime:
         script: |
-            call .\build.cmd clr+libs -c Release -runtimeconfiguration Release -arch x64
-            call .\src\tests\build.cmd Release x64 generatelayoutonly /p:LibrariesConfiguration=Release
-            del /F /S /Q .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\*.pdb
+            call .\build.cmd clr.runtime+clr.alljits+clr.iltools+clr.tools+clr.corelib+clr.nativecorelib -c Release -runtimeconfiguration Release -arch x64
 
-        arguments: '--{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.x64.Release\tests\Core_Root\'
+        arguments: '--{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.x64.Release\clrjit.dll --{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.x64.Release\coreclr.dll --{{job}}.options.outputFiles .\artifacts\bin\coreclr\windows.x64.Release\System.Private.CoreLib.dll'
 
     libs:
         script: |


### PR DESCRIPTION
- Only build basic projects needed to produce `clrjit.dll`, `coreclr.dll` and `System.Private.CoreLib.dll`
- No need to perform `libs` build
- Stop populating `CORE_ROOT` and copying it entirely
- Just copy the 3 binaries for `runtime` components.