### PR TITLE
Fix PR benchmark bot build and pass log url param

### DIFF
--- a/build/prbenchmarks.yml
+++ b/build/prbenchmarks.yml
@@ -49,11 +49,13 @@ jobs:
   steps:
   - powershell: |
         Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
-        .\dotnet-install.ps1 -version 6.0.101
+        .\dotnet-install.ps1 -version 7.0.100
 
         git clone https://github.com/dotnet/crank -b main
         cd .\crank\src\Microsoft.Crank.PullRequestBot
-        dotnet publish -c release -o build -r win-x64 --self-contained true --framework net6.0
+        dotnet publish -c release -o build -r win-x64 --self-contained true --framework net7.0
+
+        $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/aspnetcore `
@@ -61,7 +63,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/efcore `
@@ -69,7 +72,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/runtime `
@@ -77,7 +81,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/runtime `
@@ -85,7 +90,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/runtime `
@@ -93,7 +99,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
         ./build/crank-pr.exe `
             --repository https://github.com/dotnet/runtime `
@@ -101,7 +108,8 @@ jobs:
             --app-id $(github.appid) `
             --install-id $(github.installid) `
             --app-key "env:APP_KEY" `
-            --publish-results true
+            --publish-results true `
+            --external-log-uri $buildUrl
 
     env:
         AZURE_RELAY: $(relay.connectionstring)


### PR DESCRIPTION
Seems like some proj files or something else were recently updated to include only 7.0 target, so PR benchmark AzDO script (that installs only .NET 6) broke: https://dev.azure.com/dnceng/internal/_build/results?buildId=2050147&view=logs&j=9ef21fd1-5d60-5fa4-f8b2-6dc79e173863&t=245c5015-ae8e-5bb0-ff34-6d6f59122374&l=50

<details>
<summary>logs</summary>

```
  Determining projects to restore...
C:\Users\cloudtest\AppData\Local\Microsoft\dotnet\sdk\6.0.101\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 7.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 7.0. [D:\a\_work\1\s\crank\src\Microsoft.Crank.Controller\Microsoft.Crank.Controller.csproj]
C:\Users\cloudtest\AppData\Local\Microsoft\dotnet\sdk\6.0.101\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 7.0.  Either target .NET 6.0 or lower, or use a version of the .NET SDK that supports .NET 7.0. [D:\a\_work\1\s\crank\src\Microsoft.Crank.PullRequestBot\Microsoft.Crank.PullRequestBot.csproj]
./build/crank-pr.exe : The term './build/crank-pr.exe' is not recognized as the name of a cmdlet, function, script 
file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct 
and try again.
```

</details>

Hopefully it should be fixed with installing .NET 7 instead of 6.

This PR also passes `--external-log-uri` param added in https://github.com/dotnet/crank/pull/496. URL format taken from https://developercommunity.visualstudio.com/t/there-seems-to-be-no-way-to-link-to-the-current-bu/344377#T-N345917

Contributes to https://github.com/dotnet/runtime/issues/77215

cc @sebastienros @kunalspathak 