### PR TITLE
experimental migration to DapperAOT for DapperDb

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,6 +27,7 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
+    <DapperAOTVersion>0.1.28</DapperAOTVersion>
 
     <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,7 +27,7 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <DapperAOTVersion>0.1.29</DapperAOTVersion>
+    <DapperAOTVersion>0.1.30</DapperAOTVersion>
 
     <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -27,7 +27,7 @@
 
     <MongoDbVersion>2.8.0</MongoDbVersion>
     <DapperVersion>2.0.30</DapperVersion>
-    <DapperAOTVersion>0.1.28</DapperAOTVersion>
+    <DapperAOTVersion>0.1.29</DapperAOTVersion>
 
     <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -19,6 +19,11 @@
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
     <NoWarn>0618;NU1605</NoWarn>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+
+    <!-- langver needs to be at least 9 for extended partial methods, for DapperAOT's generator work -->
+    <LangVersion>10</LangVersion>
+    <!-- 'unsafe' allows DapperAOT to use [SkipLocalsInit] -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Old way of overriding the dotnet runtime -->
@@ -32,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="$(DapperVersion)" />
+    <PackageReference Include="Dapper.AOT" Version="$(DapperAOTVersion)" />
     
     <!-- We need to be able to reference a specific Pipelines version without having to change aspnet or netcore runtimes -->
     <PackageReference Include="System.IO.Pipelines" Condition="$(SystemIOPipelinesVersion) != ''" Version="$(SystemIOPipelinesVersion)" />

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+#nullable enable
 
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
@@ -81,10 +81,12 @@ namespace Benchmarks.Data
 
         public Task<World> LoadSingleQueryRow() => ReadSingleRow(NextRandom());
 
-        [Command("SELECT id, randomnumber FROM world WHERE id = @id", Annotate = false)] // Annotate is a "where this query comes from" hint, for DB debugging
+        // Annotate is a "where this query comes from" hint, for DB debugging
+        // ReuseCommand allows DbCommand objects to be reused; this doesn't currently work well if the provider might change at runtime!
+        [Command("SELECT id, randomnumber FROM world WHERE id = @id", Annotate = false, ReuseCommand = false)]
         private partial Task<World> ReadSingleRow(int id, DbConnection? db = null);
 
-        [Command("SELECT id, message FROM fortune", Annotate = false)]
+        [Command("SELECT id, message FROM fortune", Annotate = false, ReuseCommand = false)]
         private partial Task<List<Fortune>> ReadFortunesRows();
 
         [Command]

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -12,6 +12,10 @@ using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data
 {
+    // Annotate is a "where this query comes from" hint, for DB debugging
+    // [Annotate(false)] (not needed: default)
+    // ReuseCommand allows DbCommand objects to be reused; this doesn't currently work well if the provider might change at runtime!
+    // [ReuseCommand(true)] (not needed: default)
     public partial class DapperDb : IDb
     {
         private readonly IRandom _random;
@@ -83,12 +87,10 @@ namespace Benchmarks.Data
 
         public Task<World> LoadSingleQueryRow() => ReadSingleRow(NextRandom());
 
-        // Annotate is a "where this query comes from" hint, for DB debugging
-        // ReuseCommand allows DbCommand objects to be reused; this doesn't currently work well if the provider might change at runtime!
-        [Command("SELECT id, randomnumber FROM world WHERE id = @id", Annotate = false /*, ReuseCommand = false */)]
+        [Command("SELECT id, randomnumber FROM world WHERE id = @id")]
         private partial Task<World> ReadSingleRow(int id, DbConnection? db = null);
 
-        [Command("SELECT id, message FROM fortune", Annotate = false /*, ReuseCommand = false */)]
+        [Command("SELECT id, message FROM fortune")]
         private partial Task<List<Fortune>> ReadFortunesRows();
 
         [Command]

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using Benchmarks.Configuration;
 using Dapper;
+using Microsoft.Extensions.Options;
 
 namespace Benchmarks.Data
 {
@@ -18,11 +20,11 @@ namespace Benchmarks.Data
         [ConnectionString] // used by DapperAOT in conjuction with a discovered DbProviderFactory
         private readonly string _connectionString;
 
-        public DapperDb(IRandom random, DbProviderFactory dbProviderFactory, string connectionString)
+        public DapperDb(IRandom random, DbProviderFactory dbProviderFactory, IOptions<AppSettings> appSettings)
         {
             _random = random;
             _dbProviderFactory = dbProviderFactory;
-            _connectionString = connectionString;
+            _connectionString = appSettings.Value.ConnectionString;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -83,10 +85,10 @@ namespace Benchmarks.Data
 
         // Annotate is a "where this query comes from" hint, for DB debugging
         // ReuseCommand allows DbCommand objects to be reused; this doesn't currently work well if the provider might change at runtime!
-        [Command("SELECT id, randomnumber FROM world WHERE id = @id", Annotate = false, ReuseCommand = false)]
+        [Command("SELECT id, randomnumber FROM world WHERE id = @id", Annotate = false /*, ReuseCommand = false */)]
         private partial Task<World> ReadSingleRow(int id, DbConnection? db = null);
 
-        [Command("SELECT id, message FROM fortune", Annotate = false, ReuseCommand = false)]
+        [Command("SELECT id, message FROM fortune", Annotate = false /*, ReuseCommand = false */)]
         private partial Task<List<Fortune>> ReadFortunesRows();
 
         [Command]

--- a/src/Benchmarks/NuGet.config
+++ b/src/Benchmarks/NuGet.config
@@ -2,6 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
+    <!-- temporary hack for DapperAOT -->
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
 
     <!-- Feeds containing stable builds. Can be discarded once published on NuGet. -->
     <add key="darc-pub-dotnet-runtime-b928f03" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-b928f03f/nuget/v3/index.json" />


### PR DESCRIPTION
ignore for now; experimental spike to investigate AOT potential, and tweak data benchmark

| load                   | main      | branch   |
| ---------------------- | --------- | --------- |
| CPU Usage (%)          | 28        | 28        |
| Cores usage (%)        | 785       | 791       |
| Working Set (MB)       | 119       | 119       |
| Private Memory (MB)    | 358       | 358       |
| Start Time (ms)        | 0         | 0         |
| First Request (ms)     | 427       | 375       |
| Requests/sec           | 285,436   | 287,614   |
| Requests               | 4,309,861 | 4,335,287 |
| Mean latency (ms)      | 1.27      | 1.24      |
| Max latency (ms)       | 36.18     | 21.83     |
| Bad responses          | 0         | 0         |
| Socket errors          | 0         | 0         |
| Read throughput (MB/s) | 380.55    | 383.46    |
| Latency 50th (ms)      | 0.79      | 0.78      |
| Latency 75th (ms)      | 1.11      | 1.11      |
| Latency 90th (ms)      | 1.60      | 1.59      |
| Latency 99th (ms)      | 12.08     | 11.55     |