### PR TITLE
Update Json middleware benchmark to use source-gen

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <!-- For local dev specify all supported TFMs they can be easily tested -->
   <PropertyGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <TargetFrameworks>net7.0</TargetFrameworks>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <!-- For local dev specify all supported TFMs they can be easily tested -->
   <PropertyGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <TargetFrameworks>net7.0</TargetFrameworks>

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -4,6 +4,8 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Builder;
@@ -17,21 +19,24 @@ namespace Benchmarks.Middleware
     public class JsonMiddleware
     {
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
-        private static readonly UTF8Encoding _encoding = new UTF8Encoding(false);
         private const int _bufferSize = 27;
         private readonly RequestDelegate _next;
+        private readonly JsonSerializerOptions _jsonOptions;
 
-        public JsonMiddleware(RequestDelegate next) => _next = next;
+        public JsonMiddleware(RequestDelegate next, IOptions<JsonOptions> jsonOptions)
+        {
+            _next = next;
+            _jsonOptions = jsonOptions.Value.SerializerOptions;
+        }
 
         public Task Invoke(HttpContext httpContext)
         {
             if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
             {
                 httpContext.Response.StatusCode = 200;
-                httpContext.Response.ContentType = "application/json";
                 httpContext.Response.ContentLength = _bufferSize;
 
-                return JsonSerializer.SerializeAsync<JsonMessage>(httpContext.Response.Body, new JsonMessage { message = "Hello, World!" });
+                return httpContext.Response.WriteAsJsonAsync<JsonMessage>(new JsonMessage { message = "Hello, World!" }, _jsonOptions, httpContext.RequestAborted);
             }
 
             return _next(httpContext);
@@ -41,6 +46,12 @@ namespace Benchmarks.Middleware
     public static class JsonMiddlewareExtensions
     {
         public static IApplicationBuilder UseJson(this IApplicationBuilder builder) => builder.UseMiddleware<JsonMiddleware>();
+    }
+
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(JsonMessage))]
+    internal partial class CustomJsonContext : JsonSerializerContext
+    {
     }
 
     public struct JsonMessage

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -21,14 +21,17 @@ namespace Benchmarks.Middleware
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
         private const int _bufferSize = 27;
         private readonly RequestDelegate _next;
+#if NET8_0_OR_GREATER
+        private readonly JsonTypeInfo<JsonMessage> _jsonTypeInfo;
+#else
         private readonly JsonSerializerOptions _jsonOptions;
-        private readonly JsonTypeInfo _jsonTypeInfo;
+#endif
 
         public JsonMiddleware(RequestDelegate next, IOptions<JsonOptions> jsonOptions)
         {
             _next = next;
 #if NET8_0_OR_GREATER
-            _jsonTypeInfo = jsonOptions.Value.SerializerOptions.GetTypeInfo(typeof(JsonMessage));
+            _jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo<JsonMessage>(jsonOptions.Value.SerializerOptions);
 #else
             _jsonOptions = jsonOptions.Value.SerializerOptions;
 #endif

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -31,7 +31,7 @@ namespace Benchmarks.Middleware
         {
             _next = next;
 #if NET8_0_OR_GREATER
-            _jsonTypeInfo = JsonTypeInfo.CreateJsonTypeInfo<JsonMessage>(jsonOptions.Value.SerializerOptions);
+            _jsonTypeInfo = jsonOptions.Value.SerializerOptions.GetTypeInfo(typeof(JsonMessage)) as JsonTypeInfo<JsonMessage>;
 #else
             _jsonOptions = jsonOptions.Value.SerializerOptions;
 #endif

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -10,9 +10,8 @@ using System.Threading.Tasks;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Http.Json;
 
 namespace Benchmarks.Middleware
 {
@@ -36,7 +35,7 @@ namespace Benchmarks.Middleware
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentLength = _bufferSize;
 
-                return httpContext.Response.WriteAsJsonAsync<JsonMessage>(new JsonMessage { message = "Hello, World!" }, _jsonOptions, httpContext.RequestAborted);
+                return httpContext.Response.WriteAsJsonAsync(new JsonMessage { message = "Hello, World!" }, _jsonOptions, httpContext.RequestAborted);
             }
 
             return _next(httpContext);

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -19,7 +19,6 @@ namespace Benchmarks.Middleware
     public class JsonMiddleware
     {
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
-        private const int _bufferSize = 27;
         private readonly RequestDelegate _next;
 #if NET8_0_OR_GREATER
         private readonly JsonTypeInfo<JsonMessage> _jsonTypeInfo;
@@ -42,7 +41,6 @@ namespace Benchmarks.Middleware
             if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
             {
                 httpContext.Response.StatusCode = 200;
-                httpContext.Response.ContentLength = _bufferSize;
 
                 return httpContext.Response.WriteAsJsonAsync(new JsonMessage { message = "Hello, World!" },
 #if NET8_0_OR_GREATER

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -19,6 +19,7 @@ namespace Benchmarks.Middleware
     public class JsonMiddleware
     {
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
+        private const int _bufferSize = 27;
         private readonly RequestDelegate _next;
 #if NET8_0_OR_GREATER
         private readonly JsonTypeInfo<JsonMessage> _jsonTypeInfo;
@@ -30,7 +31,7 @@ namespace Benchmarks.Middleware
         {
             _next = next;
 #if NET8_0_OR_GREATER
-            _jsonTypeInfo = jsonOptions.Value.SerializerOptions.GetTypeInfo(typeof(JsonMessage)) as JsonTypeInfo<JsonMessage>;
+            _jsonTypeInfo = (JsonTypeInfo<JsonMessage>)jsonOptions.Value.SerializerOptions.GetTypeInfo(typeof(JsonMessage));
 #else
             _jsonOptions = jsonOptions.Value.SerializerOptions;
 #endif
@@ -41,6 +42,7 @@ namespace Benchmarks.Middleware
             if (httpContext.Request.Path.StartsWithSegments(_path, StringComparison.Ordinal))
             {
                 httpContext.Response.StatusCode = 200;
+                httpContext.Response.ContentLength = _bufferSize;
 
                 return httpContext.Response.WriteAsJsonAsync(new JsonMessage { message = "Hello, World!" },
 #if NET8_0_OR_GREATER

--- a/src/Benchmarks/Middleware/JsonMiddleware.cs
+++ b/src/Benchmarks/Middleware/JsonMiddleware.cs
@@ -21,20 +21,10 @@ namespace Benchmarks.Middleware
         private static readonly PathString _path = new PathString(Scenarios.GetPath(s => s.Json));
         private const int _bufferSize = 27;
         private readonly RequestDelegate _next;
-#if NET8_0_OR_GREATER
-        private readonly JsonTypeInfo<JsonMessage> _jsonTypeInfo;
-#else
-        private readonly JsonSerializerOptions _jsonOptions;
-#endif
 
-        public JsonMiddleware(RequestDelegate next, IOptions<JsonOptions> jsonOptions)
+        public JsonMiddleware(RequestDelegate next)
         {
             _next = next;
-#if NET8_0_OR_GREATER
-            _jsonTypeInfo = (JsonTypeInfo<JsonMessage>)jsonOptions.Value.SerializerOptions.GetTypeInfo(typeof(JsonMessage));
-#else
-            _jsonOptions = jsonOptions.Value.SerializerOptions;
-#endif
         }
 
         public Task Invoke(HttpContext httpContext)
@@ -44,13 +34,7 @@ namespace Benchmarks.Middleware
                 httpContext.Response.StatusCode = 200;
                 httpContext.Response.ContentLength = _bufferSize;
 
-                return httpContext.Response.WriteAsJsonAsync(new JsonMessage { message = "Hello, World!" },
-#if NET8_0_OR_GREATER
-                    _jsonTypeInfo
-#else
-                    _jsonOptions
-#endif
-                    );
+                return httpContext.Response.WriteAsJsonAsync(new JsonMessage { message = "Hello, World!" }, CustomJsonContext.Default.JsonMessage);
             }
 
             return _next(httpContext);

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -83,7 +83,11 @@ namespace Benchmarks
                     .ConfigureHttpJsonOptions(jsonOptions =>
                     {
                         jsonOptions.SerializerOptions.Encoder = null;
+#if NET7_0
                         jsonOptions.SerializerOptions.AddContext<Middleware.CustomJsonContext>();
+#elif NET8_0_OR_GREATER
+                        jsonOptions.SerializerOptions.TypeInfoResolverChain.Insert(0, Middleware.CustomJsonContext.Default);
+#endif
                     })
                 )
                 .UseDefaultServiceProvider(
@@ -125,9 +129,9 @@ namespace Benchmarks
             else if (String.Equals(Server, "HttpSys", StringComparison.OrdinalIgnoreCase))
             {
                 // Disable cross-platform warning
-                #pragma warning disable CA1416
+#pragma warning disable CA1416
                 webHostBuilder = webHostBuilder.UseHttpSys();
-                #pragma warning restore CA1416
+#pragma warning restore CA1416
             }
             else if (String.Equals(Server, "IISInProcess", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -79,10 +79,6 @@ namespace Benchmarks
                             options.CaptureScopes = false;
                         }
                     })
-                    .ConfigureHttpJsonOptions(jsonOptions =>
-                    {
-                        jsonOptions.SerializerOptions.Encoder = null;
-                    })
                 )
                 .UseDefaultServiceProvider(
                     (context, options) => options.ValidateScopes = context.HostingEnvironment.IsDevelopment());

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Reflection;
 using System.Runtime;
 using System.Text.RegularExpressions;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Hosting;
@@ -78,6 +79,11 @@ namespace Benchmarks
                             Console.WriteLine($"LoggerFilterOptions.CaptureScopes = false");
                             options.CaptureScopes = false;
                         }
+                    })
+                    .ConfigureHttpJsonOptions(jsonOptions =>
+                    {
+                        jsonOptions.SerializerOptions.Encoder = null;
+                        jsonOptions.SerializerOptions.AddContext<Middleware.CustomJsonContext>();
                     })
                 )
                 .UseDefaultServiceProvider(

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Reflection;
 using System.Runtime;
 using System.Text.RegularExpressions;
-using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using Benchmarks.Configuration;
 using Microsoft.AspNetCore.Hosting;
@@ -83,12 +82,6 @@ namespace Benchmarks
                     .ConfigureHttpJsonOptions(jsonOptions =>
                     {
                         jsonOptions.SerializerOptions.Encoder = null;
-#if NET7_0
-                        jsonOptions.SerializerOptions.TypeInfoResolver =
-                            JsonTypeInfoResolver.Combine(Middleware.CustomJsonContext.Default, jsonOptions.SerializerOptions.TypeInfoResolver);
-#elif NET8_0_OR_GREATER
-                        jsonOptions.SerializerOptions.TypeInfoResolverChain.Insert(0, Middleware.CustomJsonContext.Default);
-#endif
                     })
                 )
                 .UseDefaultServiceProvider(

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -84,7 +84,8 @@ namespace Benchmarks
                     {
                         jsonOptions.SerializerOptions.Encoder = null;
 #if NET7_0
-                        jsonOptions.SerializerOptions.AddContext<Middleware.CustomJsonContext>();
+                        jsonOptions.SerializerOptions.TypeInfoResolver =
+                            JsonTypeInfoResolver.Combine(Middleware.CustomJsonContext.Default, jsonOptions.SerializerOptions.TypeInfoResolver);
 #elif NET8_0_OR_GREATER
                         jsonOptions.SerializerOptions.TypeInfoResolverChain.Insert(0, Middleware.CustomJsonContext.Default);
 #endif


### PR DESCRIPTION
179m bytes per second to 3m
Working Set 440MB to 62MB
RPS change unknown right now since the baseline changed between running earlier in the day and now. But running them back-to-back right now gives a ~1.1% increase in RPS