### PR TITLE
Remove 'linked' scenario and add AOT

### DIFF
--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -32,8 +32,8 @@ parameters:
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true\" --property mode=SingleFile
   - displayName: Trimmed
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
-  - displayName: Linked
-    arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true /p:TrimMode=link\" --property mode=Linked
+  - displayName: AOT
+    arguments: --application.buildArguments \"/p:PublishAot=true\" --property mode=Linked
 
 steps:
 - ${{ each s in parameters.scenarios }}:

--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -33,7 +33,7 @@ parameters:
   - displayName: Trimmed
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
   - displayName: AOT
-    arguments: --application.buildArguments \"/p:PublishAot=true\" --property mode=Linked
+    arguments: --application.buildArguments \"/p:PublishAot=true\" --property mode=Aot
 
 steps:
 - ${{ each s in parameters.scenarios }}:


### PR DESCRIPTION
The TrimMode=link option is now deprecated and has the same behavior as the trim defaults. AOT, however, is new and is worth tracking in this list.