### PR TITLE
Add serializer options to fix Goldilocks benchmark.

### DIFF
--- a/src/Goldilocks/Goldilocks.csproj
+++ b/src/Goldilocks/Goldilocks.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="System.Text.Json" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
+
 
 </Project>

--- a/src/Goldilocks/Goldilocks.csproj
+++ b/src/Goldilocks/Goldilocks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 
 

--- a/src/Goldilocks/Program.cs
+++ b/src/Goldilocks/Program.cs
@@ -1,4 +1,12 @@
+using System.Text.Json.Serialization;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.AddContext<GoldilocksSerializer>();
+});
+
 var app = builder.Build();
 
 var summaries = new[]
@@ -8,7 +16,7 @@ var summaries = new[]
 
 app.MapGet("/weatherforecast", () =>
 {
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
+    var forecast = Enumerable.Range(1, 5).Select(index =>
         new WeatherForecast
         (
             DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
@@ -24,4 +32,12 @@ app.Run();
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+[JsonSerializable(typeof(object))]
+[JsonSerializable(typeof(WeatherForecast))]
+[JsonSerializable(typeof(WeatherForecast[]))]
+partial class GoldilocksSerializer : JsonSerializerContext
+{
+
 }


### PR DESCRIPTION
Addresses #1776

Added a serializer context. This should enable the app to respond with a valid JSON payload.