### PR TITLE
Creating separate MVC version of TechEmpower scenarios

### DIFF
--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -233,25 +233,6 @@ namespace Benchmarks
                 });
             }
 
-#if NETCOREAPP2_1 || NETCOREAPP2_2
-            if (Scenarios.Any("Mvc"))
-            {
-                var mvcBuilder = services
-                    .AddMvcCore()
-                    .SetCompatibilityVersion(CompatibilityVersion.Latest);
-
-                if (Scenarios.MvcJson || Scenarios.Any("MvcDbSingle") || Scenarios.Any("MvcDbMulti"))
-                {
-                    mvcBuilder.AddJsonFormatters();
-                }
-                if (Scenarios.MvcViews || Scenarios.Any("MvcDbFortunes"))
-                {
-                    mvcBuilder
-                        .AddViews()
-                        .AddRazorViewEngine();
-                }
-            }
-#elif NETCOREAPP3_0 || NETCOREAPP3_1 || NETCOREAPP5_0 || NET5_0 || NET6_0_OR_GREATER
             if (Scenarios.Any("Endpoint"))
             {
                 services.AddRouting();
@@ -275,9 +256,6 @@ namespace Benchmarks
                     builder.AddNewtonsoftJson();
                 }
             }
-#else
-#error "Unsupported TFM"
-#endif
 
             if (Scenarios.Any("MemoryCache"))
             {
@@ -417,7 +395,7 @@ namespace Benchmarks
             if (Scenarios.Any("Mvc"))
             {
                 app.UseRouting();
-            
+
                 app.UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();

--- a/src/BenchmarksApps/TechEmpower/Mvc/AppSettings.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/AppSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace Mvc;
+
+public class AppSettings
+{
+    public string? ConnectionString { get; set; }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Controllers/DatabaseController.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Controllers/DatabaseController.cs
@@ -7,8 +7,6 @@ namespace Mvc.Controllers;
 public class DatabaseController : Controller
 {
     [HttpGet("fortunes")]
-    public Task<List<Fortune>> Fortunes([FromServices] Db db)
-    {
-        return db.LoadFortunesRows();
-    }
+    public Task<List<Fortune>> Fortunes([FromServices] Db db) 
+            => db.LoadFortunesRows();
 }

--- a/src/BenchmarksApps/TechEmpower/Mvc/Controllers/DatabaseController.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Controllers/DatabaseController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Mvc.Database;
+using Mvc.Models;
+
+namespace Mvc.Controllers;
+
+public class DatabaseController : Controller
+{
+    [HttpGet("fortunes")]
+    public Task<List<Fortune>> Fortunes([FromServices] Db db)
+    {
+        return db.LoadFortunesRows();
+    }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Controllers/HomeController.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Controllers/HomeController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Mvc.Controllers;
+
+public class HomeController : Controller
+{
+    public IActionResult Index()
+    {
+        return View();
+    }
+
+    [HttpGet("plaintext")]
+    public string Plaintext()
+    {
+        return "Hello, World!";
+    }
+
+    [HttpGet("json")]
+    [Produces("application/json")]
+    public object Json()
+    {
+        return new { message = "Hello, World!" };
+    }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/ApplicationDbContext.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Mvc.Models;
+
+namespace Mvc.Database;
+
+public sealed class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions options)
+        : base(options)
+    {
+        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        ChangeTracker.AutoDetectChangesEnabled = false;
+    }
+
+    public DbSet<Fortune>? Fortune { get; set; }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/ApplicationDbContext.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/ApplicationDbContext.cs
@@ -12,5 +12,5 @@ public sealed class ApplicationDbContext : DbContext
         ChangeTracker.AutoDetectChangesEnabled = false;
     }
 
-    public DbSet<Fortune>? Fortune { get; set; }
+    public required DbSet<Fortune> Fortunes { get; set; }
 }

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
@@ -51,5 +51,5 @@ public class Db
     }
 
     private static readonly Func<ApplicationDbContext, IAsyncEnumerable<Fortune>> _fortunesQuery
-        = EF.CompileAsyncQuery((ApplicationDbContext context) => context.Fortune);
+        = EF.CompileAsyncQuery((ApplicationDbContext context) => context.Fortunes);
 }

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
@@ -12,10 +12,8 @@ public class Db
 {
     private readonly PooledDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
-    public Db(AppSettings? appSettings)
+    public Db(AppSettings appSettings)
     {
-        ArgumentNullException.ThrowIfNull(appSettings);
-
         var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
 
         optionsBuilder

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/Db.cs
@@ -1,0 +1,57 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Mvc.Models;
+
+#pragma warning disable EF1001 // Using internal EF pooling APIs, can be cleaned up after 6.0.0-preview4
+
+namespace Mvc.Database;
+
+public class Db
+{
+    private readonly PooledDbContextFactory<ApplicationDbContext> _dbContextFactory;
+
+    public Db(AppSettings? appSettings)
+    {
+        ArgumentNullException.ThrowIfNull(appSettings);
+
+        var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+
+        optionsBuilder
+            .UseNpgsql(appSettings.ConnectionString, o => o.ExecutionStrategy(d => new NonRetryingExecutionStrategy(d)))
+            .EnableThreadSafetyChecks(false)
+            ;
+
+        var extension = (optionsBuilder.Options.FindExtension<CoreOptionsExtension>() ?? new CoreOptionsExtension())
+            .WithMaxPoolSize(1024);
+
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(extension);
+
+        var options = optionsBuilder.Options;
+        _dbContextFactory = new PooledDbContextFactory<ApplicationDbContext>(
+            new DbContextPool<ApplicationDbContext>(options));
+    }
+
+    public async Task<List<Fortune>> LoadFortunesRows()
+    {
+        var result = new List<Fortune>();
+
+        using (var dbContext = _dbContextFactory.CreateDbContext())
+        {
+            await foreach (var fortune in _fortunesQuery(dbContext))
+            {
+                result.Add(fortune);
+            }
+        }
+
+        result.Add(new Fortune { Message = "Additional fortune added at request time." });
+
+        result.Sort();
+
+        return result;
+    }
+
+    private static readonly Func<ApplicationDbContext, IAsyncEnumerable<Fortune>> _fortunesQuery
+        = EF.CompileAsyncQuery((ApplicationDbContext context) => context.Fortune);
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Models/Fortune.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Models/Fortune.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.Serialization;
+
+namespace Mvc.Models;
+
+[Table("fortune")]
+public class Fortune : IComparable<Fortune>, IComparable
+{
+    [Column("id")]
+    public int Id { get; set; }
+
+    [Column("message")]
+    [StringLength(2048)]
+    [IgnoreDataMember]
+    [Required]
+    public string? Message { get; set; }
+
+    public int CompareTo(object? obj)
+    {
+        return CompareTo((Fortune?)obj);
+    }
+
+    public int CompareTo(Fortune? other)
+    {
+        return string.CompareOrdinal(Message, other?.Message);
+    }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
     <PackageReference Include="Npgsql" Version="7.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Npgsql" Version="7.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -6,4 +6,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0-rc.2" />
+  </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
@@ -7,7 +7,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
 
 // Load custom configuration
-var appSettings = builder.Configuration.Get<AppSettings>();
+var appSettings = new AppSettings();
+builder.Configuration.Bind(appSettings);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();

--- a/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
@@ -1,10 +1,17 @@
+using Mvc;
+using Mvc.Database;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Remove logging since they are not required for the benchmark
+// Remove logging as this is not required for the benchmark
 builder.Logging.ClearProviders();
+
+// Load custom configuration
+var appSettings = builder.Configuration.Get<AppSettings>();
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+builder.Services.AddSingleton(new Db(appSettings));
 
 var app = builder.Build();
 

--- a/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Remove logging since they are not required for the benchmark
+builder.Logging.ClearProviders();
+
+// Add services to the container.
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+app.UseRouting();
+
+app.MapControllerRoute(
+    name: "default",
+    pattern: "{controller=Home}/{action=Index}/{id?}");
+
+app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
+app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));
+
+app.Run();

--- a/src/BenchmarksApps/TechEmpower/Mvc/README.md
+++ b/src/BenchmarksApps/TechEmpower/Mvc/README.md
@@ -1,0 +1,7 @@
+This folder contains a canonical version of an ASP.NET MVC implementation of TechEmpower scenarios.
+
+### Implementation details
+
+- Logging is disabled to improve performance
+- Routes are defined as attributes on the actions
+

--- a/src/BenchmarksApps/TechEmpower/Mvc/Views/Home/Index.cshtml
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Views/Home/Index.cshtml
@@ -1,0 +1,7 @@
+﻿<div class="text-center">
+    <h1 class="display-4">TechEmpower ASP.NET Core MVC benchmarks</h1>
+    <ul>
+        <li><a href="~/plaintext">Plaintext</a></li>
+        <li><a href="~/json">Json</a></li>
+    </ul>
+</div>

--- a/src/BenchmarksApps/TechEmpower/Mvc/appsettings.Development.json
+++ b/src/BenchmarksApps/TechEmpower/Mvc/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/Mvc/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/BenchmarksApps/TechEmpower/Mvc/source.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/Mvc/source.benchmarks.yml
@@ -1,0 +1,216 @@
+﻿imports:
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
+  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+
+variables:
+    serverPort: 5000
+    
+jobs:
+  mvc:
+    source:
+      localFolder: .
+      project: Mvc.csproj
+    readyStateText: Application started.
+    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}}"
+    variables:
+      serverScheme: http
+    environmentVariables:
+      database: PostgresQL
+      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000
+
+  postgresql:
+    source:
+      repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
+      branchOrCommit: master
+      dockerFile: toolset/databases/postgres/postgres.dockerfile
+      dockerImageName: postgres_te
+      dockerContextDirectory: toolset/databases/postgres
+    readyStateText: ready to accept connections
+    noClean: true
+
+scenarios:
+  fortunes:
+    db:
+      job: postgresql
+    application:
+      job: mvc
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes
+
+  plaintext:
+    application:
+      job: mvc
+    load:
+      job: wrk
+      variables:
+        presetHeaders: plaintext
+        path: /plaintext
+        pipeline: 16
+
+  json:
+    application:
+      job: mvc
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /json
+
+  # fortunes_ef_mvc_https:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: MvcDbFortunesEf
+  #       protocol: https
+  #       serverScheme: https        
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: html
+  #       path: /mvc/fortunes/ef
+  #       serverScheme: https
+
+  # fortunes_dapper:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbFortunesDapper
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: html
+  #       path: /fortunes/dapper
+
+  # single_query:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbSingleQueryRaw
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /db/raw
+  #       connections: 512
+
+  # single_query_ef:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbSingleQueryRaw
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /db/ef
+  #       connections: 512
+
+  # single_query_dapper:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbSingleQueryDapper
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /db/dapper
+  #       connections: 512
+
+  # multiple_queries:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiQueryRaw
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /queries/raw?queries=20
+  #       connections: 512
+
+  # multiple_queries_ef:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiQueryEf
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /queries/ef?queries=20
+  #       connections: 512
+
+  # multiple_queries_dapper:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiQueryDapper
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /queries/dapper?queries=20
+  #       connections: 512
+
+  # updates:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiUpdateRaw
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /updates/raw?queries=20
+  #       connections: 512
+
+  # updates_ef:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiUpdateEf
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /updates/ef?queries=20
+  #       connections: 512
+
+  # updates_dapper:
+  #   db:
+  #     job: postgresql
+  #   application:
+  #     job: aspnetbenchmarks
+  #     variables:
+  #       scenario: DbMultiUpdateDapper
+  #   load:
+  #     job: wrk
+  #     variables:
+  #       presetHeaders: json
+  #       path: /updates/dapper?queries=20
+  #       connections: 512
+


### PR DESCRIPTION
Starting to split the big Benchmarks app into separate ones. Goal is to make it manageable and easier to sync with TE's repos, but also be closer to what the templates create. We are still doing the changes necessary for performance when it matters but it has to be realistic changes.

Database scenarios are not yet implemented here as the current app contains a lot of them and I think we can refocus. For instance, RAW should be kept for Platform, the same way EF is not in Platform. Should we only go with EF here? That would mean MVC/Razor/EF.

If we want to compare EF/Dapper/Raw and also support other databases (in which case the aspnet app type doesn't matter) we could have a separate app (minimal) that would provide all these variations. But still use the TechEmpower scenarios. This one would not go in the TE repository so it could get messier.