### PR TITLE
Use the new CreateSlimBuilder API

### DIFF
--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -29,7 +29,6 @@ scenarios:
       buildArguments: 
         - "/p:PublishAot=true"
         - "/p:StripSymbols=true"
-        - "/p:TrimMode=full"
     load:
       job: wrk
       variables:

--- a/src/Goldilocks/Goldilocks.csproj
+++ b/src/Goldilocks/Goldilocks.csproj
@@ -6,11 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Goldilocks</RootNamespace>
     <ServerGarbageCollection>False</ServerGarbageCollection>
-    <PublishIISAssets>false</PublishIISAssets>
   </PropertyGroup>
-
-  <ItemGroup>
-  </ItemGroup>
-
 
 </Project>

--- a/src/Goldilocks/Program.cs
+++ b/src/Goldilocks/Program.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 using Goldilocks;
 
-var builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 builder.Logging.ClearProviders(); // Clearing for benchmark scenario, template has AddConsole();
 
 builder.Services.ConfigureHttpJsonOptions(options =>

--- a/src/Goldilocks/appsettings.Development.json
+++ b/src/Goldilocks/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/src/Goldilocks/appsettings.json
+++ b/src/Goldilocks/appsettings.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
-}


### PR DESCRIPTION
The `dotnet new api -aot` template is getting updated to use the new slim API in https://github.com/dotnet/aspnetcore/pull/46040. Updating the benchmark to match.

NOTE: this depends on getting a build with https://github.com/dotnet/aspnetcore/pull/46040 merged. So it will fail until then.