### PR TITLE
Use specific runtime version in AOT runs

### DIFF
--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -23,7 +23,8 @@ parameters:
     condition: Math.round(Date.now() / 43200000) % 6 == 1 # once every 6 half-days (43200000 ms per half-day)
 
   - displayName: Goldilocks Stage 1 (NativeAOT)
-    arguments: --scenario stage1publishaot $(goldilocksJobs) --property scenario=Stage1Aot --property publish=nativeaot
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --scenario stage1publishaot $(goldilocksJobs) --property scenario=Stage1Aot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
     condition: true
 
   - displayName: Gin Json

--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -33,7 +33,8 @@ parameters:
   - displayName: Trimmed
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
   - displayName: AOT
-    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
 
 steps:
 - ${{ each s in parameters.scenarios }}:


### PR DESCRIPTION
Workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing the ILCompiler package version

cc @sebastienros 