### PR TITLE
Add server GC vs workstation GC to AOT benchmarks

### DIFF
--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -55,7 +55,7 @@ parameters:
 
   - displayName: Goldilocks gRPC Stage 1 (NativeAOT - Server GC)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_gcServer=1
+    arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_gcServer=1
     condition: true
 
   - displayName: Gin Json

--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -18,6 +18,10 @@ parameters:
     arguments: --scenario basicminimalapivanilla $(goldilocksJobs) --property scenario=Stage1 --property publish=coreclr
     condition: true
 
+  - displayName: Goldilocks Stage 1 (CoreCLR - Server GC)
+    arguments: --scenario basicminimalapivanilla $(goldilocksJobs) --property scenario=Stage1ServerGC --property publish=coreclr --application.environmentVariables DOTNET_gcServer=1
+    condition: true
+
   - displayName: Goldilocks Stage 1 (CoreCLR - No PGO)
     arguments: --scenario basicminimalapivanilla $(goldilocksJobs) --property scenario=Stage1NoPgo --property publish=coreclr --application.environmentVariables DOTNET_TieredPGO=0
     condition: Math.round(Date.now() / 43200000) % 6 == 1 # once every 6 half-days (43200000 ms per half-day)
@@ -27,8 +31,17 @@ parameters:
     arguments: --scenario basicminimalapipublishaot $(goldilocksJobs) --property scenario=Stage1Aot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
     condition: true
 
+  - displayName: Goldilocks Stage 1 (NativeAOT - Server GC)
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --scenario basicminimalapipublishaot $(goldilocksJobs) --property scenario=Stage1AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_gcServer=1
+    condition: true
+
   - displayName: Goldilocks gRPC Stage 1 (CoreCLR)
     arguments: --scenario basicgrpcvanilla $(goldilocksJobs) --property scenario=Stage1Grpc --property publish=coreclr
+    condition: true
+
+  - displayName: Goldilocks gRPC Stage 1 (CoreCLR - Server GC)
+    arguments: --scenario basicgrpcvanilla $(goldilocksJobs) --property scenario=Stage1GrpcServerGC --property publish=coreclr
     condition: true
 
   - displayName: Goldilocks gRPC Stage 1 (CoreCLR - No PGO)
@@ -38,6 +51,11 @@ parameters:
   - displayName: Goldilocks gRPC Stage 1 (NativeAOT)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
     arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    condition: true
+
+  - displayName: Goldilocks gRPC Stage 1 (NativeAOT - Server GC)
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_gcServer=1
     condition: true
 
   - displayName: Gin Json

--- a/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
+++ b/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Goldilocks</RootNamespace>
-    <ServerGarbageCollection>False</ServerGarbageCollection>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
   </PropertyGroup>
 
 </Project>

--- a/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I tested `DOTNET_gcServer=1` on my machine and it appears to override the publish setting.