### PR TITLE
Fix BasicMinimalApi app with trimming

### DIFF
--- a/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
+++ b/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+    <!--
+      Work around https://github.com/dotnet/linker/issues/3061.
+      This is needed even with EnableRequestDelegateGenerator because not all MapGet methods are supported yet.
+      Once https://github.com/dotnet/aspnetcore/issues/46275 is fixed, this can be removed.
+    -->
+    <_ExtraTrimmerArgs Condition="'$(PublishTrimmed)' == 'true' and '$(PublishAot)' != 'true'">$(_ExtraTrimmerArgs) --keep-metadata parametername</_ExtraTrimmerArgs>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The trimmer tool will strip parameter names of methods it doesn't think are being reflected upon. However, this means that RequestDelegateFactory doesn't work in a trimmed (not AOT) app. This is tracked in https://github.com/dotnet/linker/issues/3061.

Work around the trimming bug by passing `--keep-metadata parametername` so it doesn't trim parameter names. This allows RDF to work correctly.

Note that once the EnableRequestDelegateGenerator source generator works with the `dotnet new api` template, this workaround will no longer be needed.

FYI - @agocke @vitek-karas @captainsafia 