### PR TITLE
Improve proxies http2 benchmarks

### DIFF
--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -16,67 +16,78 @@ parameters:
   type: object
   default: 
   - displayName: YARP
-    arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp --application.channel edge --application.framework net8.0
+    scenario: proxy-yarp
+    arguments: $(proxyJobs) --property proxy=yarp --application.framework net8.0
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: 'true'
   - displayName: YARP gRPC
-    arguments: --scenario proxy-yarp-grpc        $(proxyGRPCJobs) --property proxy=yarp --application.channel edge --application.framework net8.0
+    scenario: proxy-yarp-grpc
+    arguments: $(proxyGRPCJobs) --property proxy=yarp --application.framework net8.0
     supportsGRPC: true
     condition: 'true'
   - displayName: YARP-net70
-    arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp-net70 --application.framework net7.0
+    scenario: proxy-yarp
+    arguments: $(proxyJobs) --property proxy=yarp-net70 --application.framework net7.0
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: Math.round(Date.now() / 43200000) % 4 == 0 # once every 4 half-days
   - displayName: YARP-PGO
-    arguments: --scenario proxy-yarp        $(proxyJobs) --property proxy=yarp-pgo --application.channel edge --application.framework net8.0 --application.environmentVariables DOTNET_TieredPGO=1 --application.environmentVariables DOTNET_ReadyToRun=0 --application.environmentVariables DOTNET_TC_QuickJitForLoops=1
+    scenario: proxy-yarp
+    arguments: $(proxyJobs) --property proxy=yarp-pgo --application.framework net8.0 --application.environmentVariables DOTNET_TieredPGO=1 --application.environmentVariables DOTNET_ReadyToRun=0 --application.environmentVariables DOTNET_TC_QuickJitForLoops=1
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: Math.round(Date.now() / 43200000) % 4 == 1 # once every 4 half-days
   - displayName: HttpClient
-    arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient --application.channel edge --application.framework net8.0
+    scenario: proxy-httpclient
+    arguments: $(proxyJobs) --property proxy=httpclient --application.framework net8.0
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: Math.round(Date.now() / 43200000) % 4 == 2 # once every 4 half-days
   - displayName: HttpClient-PGO
-    arguments: --scenario proxy-httpclient  $(proxyJobs) --property proxy=httpclient-pgo --application.channel edge --application.framework net8.0 --application.environmentVariables DOTNET_TieredPGO=1 --application.environmentVariables DOTNET_ReadyToRun=0 --application.environmentVariables DOTNET_TC_QuickJitForLoops=1
+    scenario: proxy-httpclient
+    arguments: $(proxyJobs) --property proxy=httpclient-pgo --application.framework net8.0 --application.environmentVariables DOTNET_TieredPGO=1 --application.environmentVariables DOTNET_ReadyToRun=0 --application.environmentVariables DOTNET_TC_QuickJitForLoops=1
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: Math.round(Date.now() / 43200000) % 4 == 3 # once every 4 half-days
   - displayName: NGinx
-    arguments: --scenario proxy-nginx       $(proxyJobs) --property proxy=nginx --variable warmup=0
+    scenario: proxy-nginx
+    arguments: $(proxyJobs) --property proxy=nginx --variable warmup=0
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     condition: Math.round(Date.now() / 43200000) % 5 == 0 # once every 5 half-days
   - displayName: NGinx gRPC
-    arguments: --scenario proxy-nginx-grpc       $(proxyGRPCJobs) --property proxy=nginx --variable warmup=0
+    scenario: proxy-nginx-grpc
+    arguments: $(proxyGRPCJobs) --property proxy=nginx --variable warmup=0
     supportsGRPC: true
     condition: Math.round(Date.now() / 43200000) % 5 == 1 # once every 5 half-days
   - displayName: HAProxy
-    arguments: --scenario proxy-haproxy     $(proxyJobs) --property proxy=haproxy
+    scenario: proxy-haproxy
+    arguments: $(proxyJobs) --property proxy=haproxy
     supportsHttp: true
     condition: Math.round(Date.now() / 43200000) % 5 == 2 # once every 5 half-days
   - displayName: Envoy
-    arguments: --scenario proxy-envoy       $(proxyJobs) --property proxy=envoy
+    scenario: proxy-envoy
+    arguments: $(proxyJobs) --property proxy=envoy
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true
     supportsDownstreamHttp2: true
     condition: Math.round(Date.now() / 43200000) % 5 == 3 # once every 5 half-days
   - displayName: Envoy gRPC
-    arguments: --scenario proxy-envoy-grpc       $(proxyGRPCJobs) --property proxy=envoy
+    scenario: proxy-envoy-grpc
+    arguments: $(proxyGRPCJobs) --property proxy=envoy
     supportsGRPC: true
     condition: Math.round(Date.now() / 43200000) % 5 == 4 # once every 5 half-days
 
@@ -123,12 +134,12 @@ parameters:
       arguments: --variable serverScheme=http --variable downstreamScheme=https --variable downstreamProtocol=http2 --property serverProtocol=http --property downstreamProtocol=h2
       requiresDownstreamHttp2: true
     - displayName: h2 - http
-      arguments: --variable connections=28 --variable serverScheme=https --variable serverProtocol=http2 --property serverProtocol=h2 --property downstreamProtocol=http
-      requiresServerHttp2: true
+      arguments: --variable serverScheme=https --variable serverProtocol=http2 --property serverProtocol=h2 --property downstreamProtocol=http
+      scenarioSuffix: -h2load
     - displayName: h2 - h2
-      arguments: --variable connections=28 --variable serverScheme=https --variable serverProtocol=http2 --variable downstreamScheme=https --variable downstreamProtocol=http2 --property serverProtocol=h2 --property downstreamProtocol=h2
+      arguments: --variable serverScheme=https --variable serverProtocol=http2 --variable downstreamScheme=https --variable downstreamProtocol=http2 --property serverProtocol=h2 --property downstreamProtocol=h2
       requiresServerHttp2: true
-      requiresDownstreamHttp2: true
+      scenarioSuffix: -h2load
     - displayName: gRPC (h2 - h2)
       arguments: --variable connections=1 --variable streams=100 --variable serverScheme=https --variable serverProtocol=grpc --variable downstreamScheme=https --variable downstreamProtocol=grpc --property serverProtocol=grpc --property downstreamProtocol=grpc
       requiresGRPC: true
@@ -136,14 +147,14 @@ parameters:
 #    - displayName: h2 - h2c
 #      arguments: --variable serverScheme=https --variable downstreamScheme=http --load.variables.transport http2 --downstream.variables.httpProtocol http2 --property serverProtocol=http --property downstreamProtocol=h2c
 #      requiresServerHttps: false
-#      requiresServerHttp2: true
+#      scenarioSuffix: -h2load
 
 steps:
 - ${{ each s in parameters.scenarios }}:
   - ${{ each payload in parameters.payloads }}:
     - ${{ each protocol in parameters.protocols }}:
       # doesn't (requiresServerHttps or supportsServerHttps) AND (doesn't requiresServerHttp2 or supportsServerHttp2)
-      - ${{ if and( not( protocol.requiresGRPC), or( not( protocol.requiresHttp), s.supportsHttp), or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( not( protocol.requiresServerHttp2), s.supportsServerHttp2), or( not( protocol.requiresDownstreamHttp2), s.supportsDownstreamHttp2) ) }}:
+      - ${{ if and( not( protocol.requiresGRPC), or( not( protocol.requiresHttp), s.supportsHttp), or( not( protocol.requiresServerHttps), s.supportsServerHttps), or( ne( protocol.scenarioSuffix, '-h2load'), s.supportsServerHttp2), or( not( protocol.requiresDownstreamHttp2), s.supportsDownstreamHttp2) ) }}:
         - task: PublishToAzureServiceBus@1
           condition: succeededOrFailed()
           timeoutInMinutes: 5
@@ -157,7 +168,7 @@ steps:
                 "condition": "(${{ parameters.condition }}) && (${{ s.condition }})",
                 "timeout": "00:03:00",
                 "name": "crank",
-                "args": [ "--command-line-property --table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) ${{ parameters.arguments }} --no-metadata --no-measurements --downstream.options.reuseBuild true ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} $(System.JobDisplayName)\"" ]
+                "args": [ "--command-line-property --table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) ${{ parameters.arguments }} --no-metadata --no-measurements --downstream.options.reuseBuild true --scenario ${{ s.scenario }}${{ protocol.scenarioSuffix }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} $(System.JobDisplayName)\"" ]
               }
 
 # GRPC only: requiresServerGRPC and supportsGRPC
@@ -180,5 +191,5 @@ steps:
                 "condition": "(${{ parameters.condition }}) && (${{ s.condition }})",
                 "timeout": "00:03:00",
                 "name": "crank",
-                "args": [ "--command-line-property --table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) ${{ parameters.arguments }} --no-metadata --no-measurements --downstream.options.reuseBuild true ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --property rate=0 --property cpu=0 --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} $(System.JobDisplayName)\"" ]
+                "args": [ "--command-line-property --table ProxyBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) ${{ parameters.arguments }} --no-metadata --no-measurements --downstream.options.reuseBuild true --scenario ${{ s.scenario }}${{ protocol.scenarioSuffix }} ${{ s.arguments }} ${{ payload.arguments }} ${{ protocol.arguments }} --property rate=0 --property cpu=0 --description \"${{ s.displayName }} ${{ payload.displayName }} ${{ protocol.displayName }} $(System.JobDisplayName)\"" ]
               }

--- a/docker/envoy/envoy-http2.yaml
+++ b/docker/envoy/envoy-http2.yaml
@@ -42,10 +42,11 @@ static_resources:
             tls_certificates:
               - certificate_chain: { filename: "etc/testCert.crt" }
                 private_key: { filename: "etc/testCert.key" }
+            alpn_protocols: [ "h2,http/1.1" ]
 
   clusters:
   - name: downstream
-    connect_timeout: 1s
+    connect_timeout: 5s
     type: static # don't resolve the domain name, expect and IP
     lb_policy: round_robin
     load_assignment:

--- a/docker/envoy/envoy-https-http.yaml
+++ b/docker/envoy/envoy-https-http.yaml
@@ -42,10 +42,11 @@ static_resources:
             tls_certificates:
               - certificate_chain: { filename: "etc/testCert.crt" }
                 private_key: { filename: "etc/testCert.key" }
+            alpn_protocols: [ "h2,http/1.1" ]
 
   clusters:
   - name: downstream
-    connect_timeout: 1s
+    connect_timeout: 5s
     type: static # don't resolve the domain name, expect and IP
     lb_policy: round_robin
     load_assignment:

--- a/docker/envoy/envoy-https-https.yaml
+++ b/docker/envoy/envoy-https-https.yaml
@@ -42,10 +42,11 @@ static_resources:
             tls_certificates:
               - certificate_chain: { filename: "etc/testCert.crt" }
                 private_key: { filename: "etc/testCert.key" }
+            alpn_protocols: [ "h2,http/1.1" ]
 
   clusters:
   - name: downstream
-    connect_timeout: 1s
+    connect_timeout: 5s
     type: static # don't resolve the domain name, expect and IP
     lb_policy: round_robin
     load_assignment:

--- a/docker/nginx/nginx-http2.conf
+++ b/docker/nginx/nginx-http2.conf
@@ -14,11 +14,13 @@ http {
 
     upstream backend {
         server DOWNSTREAM_ADDRESS:DOWNSTREAM_PORT;
-        keepalive 1024; # more than twice the number of client connections, since warmup will already reserve a set
+        keepalive 8192; # With HTTP/2, we may have ~'100 * coreCount' concurrent streams
     }
     
     server {
         listen 8080 http2 ssl;
+        keepalive_requests 100000000;
+        http2_max_requests 100000000;
 
         ssl_certificate /etc/ssl/certs/testCert.crt;
         ssl_certificate_key /etc/ssl/private/testCert.rsa;
@@ -31,6 +33,7 @@ http {
         location / {
             proxy_pass DOWNSTREAM_SCHEME://backend;
             proxy_http_version 1.1;
+            proxy_set_header Connection ""; # Remove the Connection header if the client sends it, we don't want to close the upstream connection
         }
     }
 }

--- a/scenarios/proxy.benchmarks.yml
+++ b/scenarios/proxy.benchmarks.yml
@@ -8,6 +8,8 @@ imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk2/wrk2.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml
 
 variables:
     path: /
@@ -16,12 +18,30 @@ variables:
     serverProtocol: http # http, http2
     downstreamProtocol: http # http, http2
     downstreamPort: 8081
-   
+
 jobs:
   # override bombardier transport argument based on the serverProtocol variable
   bombardier:
     variables:
       transport: '{% if serverProtocol == "http2" %}http2{% else %}fasthttp{% endif %}'
+      serverPort: 8080
+
+  h2LoadClient:
+    variables:
+      connections: '{{cores}}'
+      threads: '{{cores}}'
+      streams: 100
+      serverPort: 8080
+
+  httpClient: # Useful for manual debugging
+    variables:
+      numberOfHttpClients: '{{cores}}'
+      concurrencyPerHttpClient: 100
+      httpVersion: '{% if serverProtocol == "http2" %}2.0{% else %}1.1{% endif %}'
+      serverPort: 8080
+      scenario: 'get'
+      host: '{{serverAddress}}'
+      useHttps: '{{ serverScheme == "https" }}'
 
   httpclientproxy:
     source:
@@ -30,6 +50,7 @@ jobs:
       project: src/BenchmarksApps/HttpClient/Proxy/Proxy.csproj
     readyStateText: Application started.
     arguments: '--urls {{serverScheme}}://*:8080 --baseUri {{downstreamScheme}}://{{downstreamAddress}}:{{downstreamPort}}'
+
   nginxproxy:
     source:
       Repository: https://github.com/aspnet/benchmarks.git
@@ -46,6 +67,7 @@ jobs:
       - SERVER_SCHEME={{serverScheme}}
       - SERVER_PROTOCOL={{serverProtocol}}
     port: 8080
+
   envoyproxy:
     source:
       Repository: https://github.com/aspnet/benchmarks.git
@@ -63,6 +85,7 @@ jobs:
       - DOWNSTREAM_SCHEME={{downstreamScheme}}
       - DOWNSTREAM_PROTOCOL={{downstreamProtocol}}
     port: 8080
+
   haproxyproxy:
     source:
       Repository: https://github.com/aspnet/benchmarks.git
@@ -74,6 +97,7 @@ jobs:
         DOWNSTREAM_ADDRESS: '{{downstreamAddress}}'
         DOWNSTREAM_PORT: '{{downstreamPort}}'
     port: 8080
+
   downstream:
     source:
       repository: https://github.com/aspnet/benchmarks.git
@@ -81,7 +105,6 @@ jobs:
       project: src/Downstream/Downstream.csproj
     readyStateText: Application started.
     framework: net7.0
-    channel: edge
     environmentVariables:
       DOTNET_TieredPGO: 1
       DOTNET_ReadyToRun: 0
@@ -90,6 +113,7 @@ jobs:
       downstreamArguments:
       downstreamPort: 8081
     arguments: '--urls {{downstreamScheme}}://*:{{downstreamPort}} --Kestrel:EndpointDefaults:Protocols {% if downstreamProtocol == "http2" %}http2{% else %}http1{% endif %} {{downstreamArguments}}'
+
   yarp:
     source:
       repository: https://github.com/microsoft/reverse-proxy.git
@@ -111,12 +135,19 @@ scenarios:
   proxy-httpclient:
     downstream:
       job: downstream
-    application: # custom name for a service to deploy
+    application:
       job: httpclientproxy
     load:
       job: bombardier
-      variables:
-        serverPort: 8080
+
+  proxy-httpclient-h2load:
+    downstream:
+      job: downstream
+    application:
+      job: httpclientproxy
+    load:
+      job: h2LoadClient
+
   proxy-nginx:
     downstream:
       job: downstream
@@ -124,8 +155,15 @@ scenarios:
       job: nginxproxy
     load:
       job: bombardier
-      variables:
-        serverPort: 8080
+
+  proxy-nginx-h2load:
+    downstream:
+      job: downstream
+    application:
+      job: nginxproxy
+    load:
+      job: h2LoadClient
+
   proxy-haproxy:
     downstream:
       job: downstream
@@ -133,8 +171,7 @@ scenarios:
       job: haproxyproxy
     load:
       job: bombardier
-      variables:
-        serverPort: 8080
+
   proxy-envoy:
     downstream:
       job: downstream
@@ -142,8 +179,15 @@ scenarios:
       job: envoyproxy
     load:
       job: bombardier
-      variables:
-        serverPort: 8080
+
+  proxy-envoy-h2load:
+    downstream:
+      job: downstream
+    application:
+      job: envoyproxy
+    load:
+      job: h2LoadClient
+
   proxy-yarp:
     downstream:
       job: downstream
@@ -151,8 +195,14 @@ scenarios:
       job: yarp
     load:
       job: bombardier
-      variables:
-        serverPort: 8080
+
+  proxy-yarp-h2load:
+    downstream:
+      job: downstream
+    application:
+      job: yarp
+    load:
+      job: h2LoadClient
 
 profiles:
   aspnet-perf-lin:


### PR DESCRIPTION
This adds `-h2load` variants of yarp, httpclient, envoy and nginx scenarios for proxies. I got Envoy and Nginx to work with h2.

Envoy seems to start spitting out some errors during high load on citrine, haven't figured out why. It's still a lot better than the current numbers on our dashboard.

I also removed the `--channel edge` in a few places.

@sebastienros I was able to test that the new crank scenarios work fine, but I have no idea how to validate the pipelines changes.
The idea is that I'd want the `-h2load` variant of the scenario to be used anytime the proxy needs to accept http2 (a way to swap the load job from `bombardier` to `h2LoadClient` in those cases)