### PR TITLE
Use Npgsql 8.0.0-preview.1

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -30,16 +30,19 @@
 
     <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>
+    <NpgsqlVersion80>8.0.0-preview.1</NpgsqlVersion80>
 
     <MicrosoftDataSqlClientVersion60>4.0.0</MicrosoftDataSqlClientVersion60>
+    <MicrosoftDataSqlClientVersion80>5.1.0</MicrosoftDataSqlClientVersion80>
 
     <NpgsqlEntityFrameworkCorePostgreSQLVersion20>2.0.2</NpgsqlEntityFrameworkCorePostgreSQLVersion20>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion21>2.1.2</NpgsqlEntityFrameworkCorePostgreSQLVersion21>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion22>2.2.4</NpgsqlEntityFrameworkCorePostgreSQLVersion22>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion30>3.0.1</NpgsqlEntityFrameworkCorePostgreSQLVersion30>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.11</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.6</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.0</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.18</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.10</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.8</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion80>8.0.0-preview.1</NpgsqlEntityFrameworkCorePostgreSQLVersion80>
 
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
@@ -47,19 +50,22 @@
     <PomeloEntityFrameworkCoreMySqlVersion30>3.0.1</PomeloEntityFrameworkCoreMySqlVersion30>
     <PomeloEntityFrameworkCoreMySqlVersion31>3.1.1</PomeloEntityFrameworkCoreMySqlVersion31>
     <PomeloEntityFrameworkCoreMySqlVersion50>5.0.2</PomeloEntityFrameworkCoreMySqlVersion50>
-    <PomeloEntityFrameworkCoreMySqlVersion60>6.0.0-preview.7</PomeloEntityFrameworkCoreMySqlVersion60>
+    <PomeloEntityFrameworkCoreMySqlVersion60>6.0.2</PomeloEntityFrameworkCoreMySqlVersion60>
+    <PomeloEntityFrameworkCoreMySqlVersion80>7.0.0</PomeloEntityFrameworkCoreMySqlVersion80>
 
     <MicrosoftEntityFrameworkCoreSqlServerVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqlServerVersion30>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqlServerVersion31>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.10</MicrosoftEntityFrameworkCoreSqlServerVersion50>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.0</MicrosoftEntityFrameworkCoreSqlServerVersion60>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion31>3.1.32</MicrosoftEntityFrameworkCoreSqlServerVersion31>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.17</MicrosoftEntityFrameworkCoreSqlServerVersion50>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.14</MicrosoftEntityFrameworkCoreSqlServerVersion60>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion80>8.0.0-preview.1.23111.4</MicrosoftEntityFrameworkCoreSqlServerVersion80>
 
     <MicrosoftEntityFrameworkCoreSqliteVersion21>2.1.14</MicrosoftEntityFrameworkCoreSqliteVersion21>
     <MicrosoftEntityFrameworkCoreSqliteVersion22>2.2.6</MicrosoftEntityFrameworkCoreSqliteVersion22>
     <MicrosoftEntityFrameworkCoreSqliteVersion30>3.0.3</MicrosoftEntityFrameworkCoreSqliteVersion30>
-    <MicrosoftEntityFrameworkCoreSqliteVersion31>3.1.13</MicrosoftEntityFrameworkCoreSqliteVersion31>
-    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.10</MicrosoftEntityFrameworkCoreSqliteVersion50>
-    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.0</MicrosoftEntityFrameworkCoreSqliteVersion60>
+    <MicrosoftEntityFrameworkCoreSqliteVersion31>3.1.32</MicrosoftEntityFrameworkCoreSqliteVersion31>
+    <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.17</MicrosoftEntityFrameworkCoreSqliteVersion50>
+    <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.14</MicrosoftEntityFrameworkCoreSqliteVersion60>
+    <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.1.23111.4</MicrosoftEntityFrameworkCoreSqliteVersion80>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">
@@ -73,5 +79,11 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
     <MicrosoftAspNetCoreAppPackageVersion>3.1.0</MicrosoftAspNetCoreAppPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'net6.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>6.0.14</MicrosoftAspNetCoreAppPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>8.0.0-preview.1.23112.2</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -116,7 +116,7 @@
     <!--PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion50)" /-->
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0' or $(TargetFramework) == 'net8.0' ">
+  <ItemGroup Condition="$(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
 
     <!-- Pinning version as the feeds don't include this anymore as of 4/25/2020 -->
@@ -129,6 +129,21 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftDataSqlClientVersion60)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion60)" />
     <!--PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion60)" /-->
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+
+    <!-- Pinning version as the feeds don't include this anymore as of 4/25/2020 -->
+    <!-- <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="$(MicrosoftAspNetCoreAppPackageVersion)" /> -->
+    <!-- <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="5.0.0-preview.6.20303.1" /> -->
+
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftEntityFrameworkCoreSqlServerVersion80)" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftDataSqlClientVersion80)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion80)" />
+    <!--PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(PomeloEntityFrameworkCoreMySqlVersion80)" /-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="7.0.1" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />
   </ItemGroup>
 

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="7.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.1" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -43,8 +43,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="7.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.1" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Starting out with monthly updates for 8.0.

Also did a bit of general version bumps.

For completeness, here are the two runs, before and after:

| db                  | before  | 8.0.0-preview |        |
| ------------------- | ------- | ------------- | ------ |
| CPU Usage (%)       |      35 |            34 | -2.86% |
| Cores usage (%)     |     972 |           961 | -1.13% |
| Working Set (MB)    |      46 |            45 | -2.17% |
| Build Time (ms)     |   1,460 |         1,447 | -0.89% |
| Start Time (ms)     |     436 |           429 | -1.61% |
| Published Size (KB) | 523,834 |       523,834 |  0.00% |


| application           | before                    | 8.0.0-preview             |        |
| --------------------- | ------------------------- | ------------------------- | ------ |
| CPU Usage (%)         |                        97 |                        96 | -1.03% |
| Cores usage (%)       |                     2,711 |                     2,690 | -0.77% |
| Working Set (MB)      |                       564 |                       571 | +1.24% |
| Private Memory (MB)   |                     1,313 |                     1,319 | +0.46% |
| Build Time (ms)       |                     2,965 |                     2,953 | -0.40% |
| Start Time (ms)       |                     1,693 |                     1,820 | +7.50% |
| Published Size (KB)   |                    96,349 |                    96,438 | +0.09% |
| Symbols Size (KB)     |                        45 |                        45 |  0.00% |
| .NET Core SDK Version | 8.0.100-preview.3.23156.1 | 8.0.100-preview.3.23156.1 |        |


| load                   | before    | 8.0.0-preview |         |
| ---------------------- | --------- | ------------- | ------- |
| CPU Usage (%)          |        39 |            39 |   0.00% |
| Cores usage (%)        |     1,103 |         1,099 |  -0.36% |
| Working Set (MB)       |        48 |            48 |   0.00% |
| Private Memory (MB)    |       363 |           363 |   0.00% |
| Start Time (ms)        |         0 |             0 |         |
| First Request (ms)     |       108 |           108 |   0.00% |
| Requests/sec           |   474,946 |       475,633 |  +0.14% |
| Requests               | 7,171,775 |     7,181,739 |  +0.14% |
| Mean latency (ms)      |      1.22 |          1.13 |  -7.38% |
| Max latency (ms)       |     49.73 |         22.23 | -55.30% |
| Bad responses          |         0 |             0 |         |
| Socket errors          |         0 |             0 |         |
| Read throughput (MB/s) |    616.46 |        617.35 |  +0.14% |
| Latency 50th (ms)      |      1.01 |          1.01 |   0.00% |
| Latency 75th (ms)      |      1.22 |          1.21 |  -0.82% |
| Latency 90th (ms)      |      1.55 |          1.50 |  -3.23% |
| Latency 99th (ms)      |      5.39 |          3.94 | -26.90% |