### PR TITLE
Set InvariantGlobalization in BasicMinimalApi

### DIFF
--- a/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
+++ b/src/BenchmarksApps/BasicMinimalApi/BasicMinimalApi.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <!--
       Work around https://github.com/dotnet/linker/issues/3061.
       This is needed even with EnableRequestDelegateGenerator because not all MapGet methods are supported yet.

--- a/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The api template is updating, see https://github.com/dotnet/aspnetcore/pull/47066. This syncs that change here.

~@JamesNK - I didn't update the Grpc app because we aren't updating the grpc template. Do you think we should make a similar change to the grpc template?~