### PR TITLE
Improve multiple updates SQL

### DIFF
--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Program.cs
@@ -37,8 +37,6 @@ namespace PlatformBenchmarks
             DateHeader.SyncDateTimer();
 
             var host = BuildWebHost(args);
-            var config = (IConfiguration)host.Services.GetService(typeof(IConfiguration));
-            BatchUpdateString.DatabaseServer = config.Get<AppSettings>().Database;
 #if DATABASE
             await BenchmarkApplication.RawDb.PopulateCache();
 #endif


### PR DESCRIPTION
This PR is mainly about synchronizing our update SQL to be the same as what we use [in the TechEmpower implementation](https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/CSharp/aspnetcore/PlatformBenchmarks/Data/BatchUpdateString.cs#L30), I'll be submitting changes to make them 100% the same in parallel (see https://github.com/TechEmpower/FrameworkBenchmarks/pull/8005).

One run gave me +3.52%, but the variance in updates is huge (another run showed a slight decrease). So this isn't about perf, but rather synchronization and also having simpler SQL.

| db                  | baseline | new_update_sql |        |
| ------------------- | -------- | -------------- | ------ |
| CPU Usage (%)       |       66 |             66 |  0.00% |
| Cores usage (%)     |    1,850 |          1,836 | -0.76% |
| Working Set (MB)    |       57 |             57 |  0.00% |
| Build Time (ms)     |    1,499 |          1,450 | -3.27% |
| Start Time (ms)     |      443 |            420 | -5.19% |
| Published Size (KB) |  523,872 |        523,872 |  0.00% |


| application           | baseline                  | new_update_sql            |        |
| --------------------- | ------------------------- | ------------------------- | ------ |
| CPU Usage (%)         |                        63 |                        62 | -1.59% |
| Cores usage (%)       |                     1,757 |                     1,749 | -0.46% |
| Working Set (MB)      |                       570 |                       547 | -4.04% |
| Private Memory (MB)   |                     1,229 |                     1,181 | -3.91% |
| Build Time (ms)       |                     3,044 |                     3,153 | +3.58% |
| Start Time (ms)       |                     1,619 |                     1,676 | +3.52% |
| Published Size (KB)   |                    96,483 |                    96,483 |  0.00% |
| Symbols Size (KB)     |                        45 |                        45 |  0.00% |
| .NET Core SDK Version | 8.0.100-preview.3.23159.6 | 8.0.100-preview.3.23159.6 |        |


| load                   | baseline | new_update_sql |        |
| ---------------------- | -------- | -------------- | ------ |
| CPU Usage (%)          |        4 |              4 |  0.00% |
| Cores usage (%)        |      112 |            114 | +1.79% |
| Working Set (MB)       |       48 |             48 |  0.00% |
| Private Memory (MB)    |      363 |            363 |  0.00% |
| Start Time (ms)        |        0 |              0 |        |
| First Request (ms)     |      110 |            112 | +1.82% |
| Requests/sec           |   25,636 |         26,537 | +3.52% |
| Requests               |  387,079 |        400,695 | +3.52% |
| Mean latency (ms)      |    23.58 |          22.69 | -3.77% |
| Max latency (ms)       |   186.13 |         168.41 | -9.52% |
| Bad responses          |        0 |              0 |        |
| Socket errors          |        0 |              0 |        |
| Read throughput (MB/s) |    18.52 |          19.17 | +3.51% |
| Latency 50th (ms)      |    18.17 |          17.60 | -3.14% |
| Latency 75th (ms)      |    25.53 |          24.68 | -3.33% |
| Latency 90th (ms)      |    37.52 |          35.67 | -4.93% |
| Latency 99th (ms)      |   127.31 |         119.09 | -6.46% |