### PR TITLE
 Stop UTF8 decoding/reencoding in Fortunes platform

### DIFF
--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
@@ -53,7 +53,7 @@ namespace PlatformBenchmarks
                 writer.Write(_fortunesRowStart);
                 writer.WriteNumeric((uint)item.Id);
                 writer.Write(_fortunesColumn);
-                HtmlEncoder.EncodeUtf8(item.Message.Span, writer.Span, out var bytesConsumed, out var bytesWritten, isFinalBlock: true);
+                HtmlEncoder.EncodeUtf8(item.Message.AsSpan(), writer.Span, out var bytesConsumed, out var bytesWritten, isFinalBlock: true);
                 Debug.Assert(bytesConsumed == item.Message.Length, "Not enough remaining space in the buffer");
                 writer.Advance(bytesWritten);
                 writer.Write(_fortunesRowEnd);

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -32,6 +34,37 @@ namespace PlatformBenchmarks
         }
 
         private void OutputFortunes(PipeWriter pipeWriter, List<Fortune> model)
+        {
+            var writer = GetWriter(pipeWriter, sizeHint: 1600); // in reality it's 1361
+
+            writer.Write(_fortunesPreamble);
+
+            var lengthWriter = writer;
+            writer.Write(_contentLengthGap);
+
+            // Date header
+            writer.Write(DateHeader.HeaderBytes);
+
+            var bodyStart = writer.Buffered;
+            // Body
+            writer.Write(_fortunesTableStart);
+            foreach (var item in model)
+            {
+                writer.Write(_fortunesRowStart);
+                writer.WriteNumeric((uint)item.Id);
+                writer.Write(_fortunesColumn);
+                HtmlEncoder.EncodeUtf8(item.Message.Span, writer.Span, out var bytesConsumed, out var bytesWritten, isFinalBlock: true);
+                Debug.Assert(bytesConsumed == item.Message.Length, "Not enough remaining space in the buffer");
+                writer.Advance(bytesWritten);
+                writer.Write(_fortunesRowEnd);
+            }
+            writer.Write(_fortunesTableEnd);
+            lengthWriter.WriteNumeric((uint)(writer.Buffered - bodyStart));
+
+            writer.Commit();
+        }
+
+        private void OutputFortunes(PipeWriter pipeWriter, List<FortuneDapper> model)
         {
             var writer = GetWriter(pipeWriter, sizeHint: 1600); // in reality it's 1361
 

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BufferWriter.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BufferWriter.cs
@@ -45,7 +45,7 @@ namespace PlatformBenchmarks
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Write(ReadOnlySpan<byte> source)
+        public void Write(scoped ReadOnlySpan<byte> source)
         {
             if (_span.Length >= source.Length)
             {
@@ -78,7 +78,7 @@ namespace PlatformBenchmarks
             _span = _output.GetSpan(count);
         }
 
-        private void WriteMultiBuffer(ReadOnlySpan<byte> source)
+        private void WriteMultiBuffer(scoped ReadOnlySpan<byte> source)
         {
             while (source.Length > 0)
             {

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/DapperDb.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/DapperDb.cs
@@ -13,17 +13,17 @@ namespace PlatformBenchmarks
         public DapperDb(AppSettings appSettings)
             => _connectionString = appSettings.ConnectionString;
 
-        public async Task<List<Fortune>> LoadFortunesRows()
+        public async Task<List<FortuneDapper>> LoadFortunesRows()
         {
-            List<Fortune> result;
+            List<FortuneDapper> result;
 
             using (var db = new NpgsqlConnection(_connectionString))
             {
                 // Note: don't need to open connection if only doing one thing; let dapper do it
-                result = (await db.QueryAsync<Fortune>("SELECT id, message FROM fortune")).AsList();
+                result = (await db.QueryAsync<FortuneDapper>("SELECT id, message FROM fortune")).AsList();
             }
 
-            result.Add(new Fortune(id: 0, message: "Additional fortune added at request time." ));
+            result.Add(new FortuneDapper(id: 0, message: "Additional fortune added at request time." ));
             result.Sort();
 
             return result;

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/Fortune.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/Fortune.cs
@@ -7,7 +7,7 @@ namespace PlatformBenchmarks
 {
     public readonly struct Fortune : IComparable<Fortune>, IComparable
     {
-        public Fortune(int id, Memory<byte> message)
+        public Fortune(int id, byte[] message)
         {
             Id = id;
             Message = message;
@@ -15,11 +15,11 @@ namespace PlatformBenchmarks
 
         public int Id { get; }
 
-        public Memory<byte> Message { get; }
+        public byte[] Message { get; }
 
         public int CompareTo(object obj) => throw new InvalidOperationException("The non-generic CompareTo should not be used");
 
         // Performance critical, using culture insensitive comparison
-        public int CompareTo(Fortune other) => Message.Span.SequenceCompareTo(other.Message.Span);
+        public int CompareTo(Fortune other) => Message.AsSpan().SequenceCompareTo(other.Message.AsSpan());
     }
 }

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/FortuneDapper.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/FortuneDapper.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace PlatformBenchmarks
 {
-    public readonly struct Fortune : IComparable<Fortune>, IComparable
+    public readonly struct FortuneDapper : IComparable<FortuneDapper>, IComparable
     {
-        public Fortune(int id, Memory<byte> message)
+        public FortuneDapper(int id, string message)
         {
             Id = id;
             Message = message;
@@ -15,11 +15,11 @@ namespace PlatformBenchmarks
 
         public int Id { get; }
 
-        public Memory<byte> Message { get; }
+        public string Message { get; }
 
         public int CompareTo(object obj) => throw new InvalidOperationException("The non-generic CompareTo should not be used");
 
         // Performance critical, using culture insensitive comparison
-        public int CompareTo(Fortune other) => Message.Span.SequenceCompareTo(other.Message.Span);
+        public int CompareTo(FortuneDapper other) => string.CompareOrdinal(Message, other.Message);
     }
 }

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/FortuneEf.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/FortuneEf.cs
@@ -17,14 +17,7 @@ namespace PlatformBenchmarks
         [Required]
         public string Message { get; set; }
 
-        public int CompareTo(object obj)
-        {
-            return CompareTo((FortuneEf)obj);
-        }
-
-        public int CompareTo(FortuneEf other)
-        {
-            return String.CompareOrdinal(Message, other.Message);
-        }
+        public int CompareTo(object obj) => CompareTo((FortuneEf)obj);
+        public int CompareTo(FortuneEf other) => String.CompareOrdinal(Message, other.Message);
     }
 }

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/RawDb.cs
@@ -266,7 +266,7 @@ namespace PlatformBenchmarks
             return result;
         }
 
-        private readonly Memory<byte> AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
+        private readonly byte[] AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
 
         private (NpgsqlCommand readCmd, NpgsqlParameter<int> idParameter) CreateReadCommand(NpgsqlConnection connection)
         {

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/RawDb.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/Data/RawDb.cs
@@ -255,16 +255,18 @@ namespace PlatformBenchmarks
                     result.Add(new Fortune
                     (
                         id: rdr.GetInt32(0),
-                        message: rdr.GetString(1)
+                        message: rdr.GetFieldValue<byte[]>(1)
                     ));
                 }
             }
 
-            result.Add(new Fortune(id: 0, message: "Additional fortune added at request time." ));
+            result.Add(new Fortune(id: 0, AdditionalFortune));
             result.Sort();
 
             return result;
         }
+
+        private readonly Memory<byte> AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
 
         private (NpgsqlCommand readCmd, NpgsqlParameter<int> idParameter) CreateReadCommand(NpgsqlConnection connection)
         {


### PR DESCRIPTION
Here's a hacky attempt to do UTF8 all the way in Fortunes; since PostgreSQL delivers text encoded in UTF8, it's silly to decode it to .NET UTF-16 strings, only to re-encode it back to UTF8 for sending to the web client. tl;dr this seems to bring a 4.19% throughput increase.

Npgsql already supports reading strings as raw binary data:

```c#
await using var command = new NpgsqlCommand("SELECT 'hello'", conn);
await using var reader = await command.ExecuteReaderAsync();

await reader.ReadAsync();

// Can just get the string as a byte array, but this allocates the buffer inside the driver:
var bytes = reader.GetFieldValue<byte[]>(0);
Console.WriteLine(Encoding.UTF8.GetString(bytes));

// Can use a stream to avoid allocating the byte array (the stream gets recycled internally):
var buf = new byte[1024];
var stream = reader.GetStream(0);
var len = stream.Read(buf);
Console.WriteLine(Encoding.UTF8.GetString(bytes, 0, len));
```

This all works pretty well; the one problem is the the Fortunes scenario mandates that we sort the returned message. I'm not sure if there's a built-in way to compare UTF8 strings (as byte[]), **maybe** it's OK to compare byte (wink wink)? IIRC other scenarios don't have sorting requirements so this may be more appropriate there.

For now I removed sorting from both the baseline and the UTF8 version for an apples-to-apples comparison. 4.19% is maybe a bit disappointing, I'll take a look with perfivew to ensure everything s what it should be.

Results (remember: both are without sortng and so not actual Fortunes results):

| db                  | baseline | change  |         |
| ------------------- | -------- | ------- | ------- |
| CPU Usage (%)       |       36 |      36 |   0.00% |
| Cores usage (%)     |      994 |   1,018 |  +2.41% |
| Working Set (MB)    |       45 |      44 |  -2.22% |
| Build Time (ms)     |    1,414 |   1,676 | +18.53% |
| Start Time (ms)     |      437 |     405 |  -7.32% |
| Published Size (KB) |  523,872 | 523,872 |   0.00% |


| application           | baseline                  | change                    |         |
| --------------------- | ------------------------- | ------------------------- | ------- |
| CPU Usage (%)         |                        96 |                        97 |  +1.04% |
| Cores usage (%)       |                     2,691 |                     2,705 |  +0.52% |
| Working Set (MB)      |                       568 |                       569 |  +0.18% |
| Private Memory (MB)   |                     1,318 |                     1,319 |  +0.08% |
| Build Time (ms)       |                     2,975 |                     3,116 |  +4.74% |
| Start Time (ms)       |                     1,789 |                       260 | -85.47% |
| Published Size (KB)   |                    96,484 |                    96,483 |  -0.00% |
| Symbols Size (KB)     |                        45 |                        45 |   0.00% |
| .NET Core SDK Version | 8.0.100-preview.3.23159.6 | 8.0.100-preview.3.23159.6 |         |


| load                   | baseline  | change    |          |
| ---------------------- | --------- | --------- | -------- |
| CPU Usage (%)          |        40 |        41 |   +2.50% |
| Cores usage (%)        |     1,118 |     1,135 |   +1.52% |
| Working Set (MB)       |        48 |        49 |   +2.08% |
| Private Memory (MB)    |       363 |       363 |    0.00% |
| Start Time (ms)        |         0 |         0 |          |
| First Request (ms)     |       101 |       292 | +189.11% |
| Requests/sec           |   481,301 |   501,449 |   +4.19% |
| Requests               | 7,267,478 | 7,571,817 |   +4.19% |
| Mean latency (ms)      |      1.14 |      1.06 |   -7.02% |
| Max latency (ms)       |     37.09 |     20.74 |  -44.08% |
| Bad responses          |         0 |         0 |          |
| Socket errors          |         0 |         0 |          |
| Read throughput (MB/s) |    624.71 |    650.86 |   +4.19% |
| Latency 50th (ms)      |      1.00 |      0.97 |   -3.00% |
| Latency 75th (ms)      |      1.19 |      1.13 |   -5.04% |
| Latency 90th (ms)      |      1.48 |      1.37 |   -7.43% |
| Latency 99th (ms)      |      3.78 |      3.59 |   -5.03% |

/cc @DamianEdwards @davidfowl @ajcvickers 
/cc @vonzshik @NinoFloris @Brar