### PR TITLE
Adds Fortunes implementation using Blazor United

### DIFF
--- a/src/BenchmarksApps.sln
+++ b/src/BenchmarksApps.sln
@@ -50,6 +50,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchmarkServer", "Benchmar
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TcpEcho", "BenchmarksApps\TcpEcho\TcpEcho.csproj", "{436118C1-B9A7-4966-86AB-6F2477B6B201}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorUnited", "BenchmarksApps\TechEmpower\BlazorUnited\BlazorUnited.csproj", "{FE3606FF-CBC9-421A-A0B5-836E312E7719}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug_Database|Any CPU = Debug_Database|Any CPU
@@ -186,6 +188,14 @@ Global
 		{436118C1-B9A7-4966-86AB-6F2477B6B201}.Release_Database|Any CPU.Build.0 = Release_Database|Any CPU
 		{436118C1-B9A7-4966-86AB-6F2477B6B201}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{436118C1-B9A7-4966-86AB-6F2477B6B201}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Debug_Database|Any CPU.ActiveCfg = Debug_Database|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Debug_Database|Any CPU.Build.0 = Debug_Database|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release_Database|Any CPU.ActiveCfg = Release_Database|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release_Database|Any CPU.Build.0 = Release_Database|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -199,6 +209,7 @@ Global
 		{ACA43671-AD28-4F72-AAAB-6C32B388C2F0} = {B6DB234C-8F80-4160-B95D-D70AFC444A3D}
 		{D8F11F87-823F-4864-926D-5F66448A5C13} = {398A40DA-FE1D-4B4D-A580-A33E29885553}
 		{3D2573DE-CE7A-4CB8-A980-8C8636EE059E} = {6A69DE6C-07A6-4ABE-A4D2-0F983A33BBF8}
+		{FE3606FF-CBC9-421A-A0B5-836E312E7719} = {B6DB234C-8F80-4160-B95D-D70AFC444A3D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {117072DC-DE12-4F74-90CA-692FA2BE8DCB}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/AppSettings.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/AppSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace BlazorUnited;
+
+public class AppSettings
+{
+    public string? ConnectionString { get; set; }
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational " Version="8.0.0-preview.3.23174.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <UserSecretsId>38063504-d08c-495a-89c9-daaad2f60f31</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
+  </ItemGroup>
+</Project>

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Components/Fortunes.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Components/Fortunes.razor
@@ -1,0 +1,27 @@
+﻿@inject Db Db
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Fortunes</title>
+</head>
+<body>
+    @if (Rows is not null)
+    {
+        <table>
+            <tr><th>id</th><th>message</th></tr>
+            @foreach (var item in Rows)
+            {
+                <tr><td>@item.Id</td><td>@item.Message</td></tr>
+            }
+        </table>
+    }
+</body>
+</html>
+@code {
+    List<Fortune>? Rows;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Rows = await Db.LoadFortunesRows();
+    }
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Components/Fortunes.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Components/Fortunes.razor
@@ -1,4 +1,6 @@
-﻿@inject Db Db
+﻿@using Microsoft.EntityFrameworkCore;
+@inject Db Db
+@inject AppDbContext DbContext
 <!DOCTYPE html>
 <html>
 <head>
@@ -22,6 +24,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Rows = await Db.LoadFortunesRows();
+        //Rows = await Db.LoadFortunesRowsDapper();
+        Rows = await Db.LoadFortunesRowsEf(DbContext);
+        //Rows = await Db.LoadFortunesRows();
     }
 }

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Database/AppDbContext.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Database/AppDbContext.cs
@@ -1,0 +1,27 @@
+﻿using BlazorUnited.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BlazorUnited.Database;
+
+public class AppDbContext : DbContext
+{
+    public static readonly Func<AppDbContext, IAsyncEnumerable<Fortune>> FortunesQuery =
+        EF.CompileAsyncQuery((AppDbContext context) => context.Fortunes);
+
+    public AppDbContext(DbContextOptions<AppDbContext> options)
+        : base(options)
+    {
+        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        ChangeTracker.AutoDetectChangesEnabled = false;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var fortune = modelBuilder.Entity<Fortune>()
+            .ToTable("fortune");
+        fortune.Property(f => f.Id).HasColumnName("id");
+        fortune.Property(f => f.Message).HasColumnName("message");
+    }
+
+    public required DbSet<Fortune> Fortunes { get; set; }
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Database/Db.cs
@@ -1,0 +1,40 @@
+﻿using BlazorUnited.Models;
+using Npgsql;
+
+namespace BlazorUnited.Database;
+
+public sealed class Db : IAsyncDisposable
+{
+    private static readonly Comparison<Fortune> FortuneSortComparison = (a, b) => string.CompareOrdinal(a.Message, b.Message);
+
+    private readonly NpgsqlDataSource _dataSource;
+
+    public Db(AppSettings appSettings)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(appSettings.ConnectionString);
+
+        _dataSource = new NpgsqlSlimDataSourceBuilder(appSettings.ConnectionString).Build();
+    }
+
+    public async Task<List<Fortune>> LoadFortunesRows()
+    {
+        var result = new List<Fortune>();
+
+        await using (var cmd = _dataSource.CreateCommand("SELECT id, message FROM fortune"))
+        {
+            await using var rdr = await cmd.ExecuteReaderAsync();
+
+            while (await rdr.ReadAsync())
+            {
+                result.Add(new Fortune { Id = rdr.GetInt32(0), Message = rdr.GetString(1) });
+            }
+        }
+
+        result.Add(new Fortune { Id = 0, Message = "Additional fortune added at request time." });
+        result.Sort(FortuneSortComparison);
+
+        return result;
+    }
+
+    ValueTask IAsyncDisposable.DisposeAsync() => _dataSource.DisposeAsync();
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Models/Fortune.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Models/Fortune.cs
@@ -1,0 +1,8 @@
+namespace BlazorUnited.Models;
+
+public class Fortune
+{
+    public int Id { get; set; }
+
+    public string? Message { get; set; }
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
@@ -1,0 +1,36 @@
+using BlazorUnited;
+using BlazorUnited.Components;
+using BlazorUnited.Database;
+using Microsoft.AspNetCore.Components.Endpoints;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Disable logging as this is not required for the benchmark
+#if RELEASE
+builder.Logging.ClearProviders();
+#endif
+
+// Load custom configuration
+var appSettings = new AppSettings();
+builder.Configuration.Bind(appSettings);
+
+// Add services to the container.
+builder.Services.AddSingleton(new Db(appSettings));
+builder.Services.AddRazorComponents();
+
+var app = builder.Build();
+
+app.MapGet("/fortunes", () => new RazorComponentResult<Fortunes>());
+
+app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
+app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));
+
+app.Run();
+
+// TODO: Blazor doesn't let you set the HtmlEncoder instance today, need to fix that.
+//static HtmlEncoder CreateHtmlEncoder()
+//{
+//    var settings = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Katakana, UnicodeRanges.Hiragana);
+//    settings.AllowCharacter('\u2014'); // allow EM DASH through
+//    return HtmlEncoder.Create(settings);
+//}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
@@ -6,9 +6,7 @@ using Microsoft.AspNetCore.Components.Endpoints;
 var builder = WebApplication.CreateBuilder(args);
 
 // Disable logging as this is not required for the benchmark
-#if RELEASE
 builder.Logging.ClearProviders();
-#endif
 
 // Load custom configuration
 var appSettings = new AppSettings();

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/Program.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using BlazorUnited;
 using BlazorUnited.Components;
 using BlazorUnited.Database;
-using Microsoft.AspNetCore.Components.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +15,10 @@ var appSettings = new AppSettings();
 builder.Configuration.Bind(appSettings);
 
 // Add services to the container.
+builder.Services.AddDbContextPool<AppDbContext>(options => options
+    .UseNpgsql(appSettings.ConnectionString, npgsql => npgsql.ExecutionStrategy(d => new NonRetryingExecutionStrategy(d)))
+    .EnableThreadSafetyChecks(false));
+
 builder.Services.AddSingleton(new Db(appSettings));
 builder.Services.AddRazorComponents();
 
@@ -25,7 +31,7 @@ app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application i
 
 app.Run();
 
-// TODO: Blazor doesn't let you set the HtmlEncoder instance today, need to fix that.
+// TODO: Use this custom configured HtmlEncoder when Blazor supports it: https://github.com/dotnet/aspnetcore/issues/47477
 //static HtmlEncoder CreateHtmlEncoder()
 //{
 //    var settings = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Katakana, UnicodeRanges.Hiragana);

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/_Imports.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/_Imports.razor
@@ -1,0 +1,2 @@
+﻿@using BlazorUnited.Database
+@using BlazorUnited.Models

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/appsettings.Development.json
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionString": "This should be set in user secrets or environment config"
+}

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/blazorunited.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/blazorunited.benchmarks.yml
@@ -1,0 +1,52 @@
+﻿imports:
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
+  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+
+variables:
+    serverPort: 5000
+    
+jobs:
+  blazorunited:
+    source:
+      repository: https://github.com/aspnet/benchmarks.git
+      branchOrCommit: main
+      project: src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
+    readyStateText: Application started.
+    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}}"
+    variables:
+      serverScheme: http
+    environmentVariables:
+      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4;Multiplexing=true;Write Coalescing Buffer Threshold Bytes=1000
+
+  postgresql:
+    source:
+      repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
+      branchOrCommit: master
+      dockerFile: toolset/databases/postgres/postgres.dockerfile
+      dockerImageName: postgres_te
+      dockerContextDirectory: toolset/databases/postgres
+    readyStateText: ready to accept connections
+    noClean: true
+
+scenarios:
+  fortunes:
+    db:
+      job: postgresql
+    application:
+      job: blazorunited
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes
+
+profiles:
+  # this profile uses the local folder as the source 
+  # instead of the public repository
+  source:
+    agents:
+      main:
+        source:
+          localFolder: .
+          respository: ''
+          project: BlazorUnited.csproj

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.1" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="RazorSlices" Version="0.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Adds a Blazor United implementation of the TechEmpower Fortunes bechmark.

I experimented with a few different approaches for the component and endpoint factoring, as well as the data access.

For the component and endpoint side, this included:

- Using `MapRazorComponenets<RootComponent>()`
  - This seems geared towards multi-page apps using layout, etc. and as such was a bit cumbersome for this one-page implementation.
  - `MapGet()` call that performs the data access in the route handler delegate and passes the rows to the component via parameters. This was quite a bit slower than the next approach so didn't go with it.
  - `MapGet()` call that simply returns a new `RazorComponentResult` with the component itself performing the data access in its `OnInitializedAsync` method. This was the fastest approach and also seems suitably idiomatic for this scenario.

For the data access I tried:
- raw ADO.NET (fastest)
- Dapper (a bit slower but not by much)
- Numerous approaches with EF Core:
  - Raw SQL query (slowest)
  - Plain `dbContext.Fortunes.ToListAsync()`
  - A precompiled query of `dbContext.Fortunes.ToListAsync()` (fastest)

The current Minimal project uses Dapper so we could choose to just stay with that to keep it consistent for now, but I admit I was hoping that the EF Core query approach would be in the same ballpark as Dapper here and we could use that.

We need to make a call on what data access approach to use:

| Scenario | RPS |
| ------------- | --: |
| Razor Slices + Dapper | 271K |
| Razor Copmonents + ADO.NET | 164K |
| Razor Copmonents + Dapper | 152K |
| Razor Copmonents + EF Core | 126K |

For reference, here's the full crank comparison of the Minimal Fortunes implementation, to the three different data access approaches for the Blazor United implementation.

<details>
<summary>crank compare .\minimal_fortunes.json .\blazorunited_fortunes.json .\blazorunited_dapper_fortunes.json .\blazorunited_ef_fortunes.json</summary>

| db                  | minimal_fortunes | blazorunited_fortunes |         | blazorunited_dapper_fortunes |         | blazorunited_ef_fortunes |         |
| ------------------- | ---------------- | --------------------- | ------- | ---------------------------- | ------- | ------------------------ | ------- |
| CPU Usage (%)       |               26 |                    20 | -23.08% |                           19 | -26.92% |                       17 | -34.62% |
| Cores usage (%)     |              735 |                   560 | -23.81% |                          539 | -26.67% |                      473 | -35.65% |
| Working Set (MB)    |               53 |                    54 |  +1.89% |                           54 |  +1.89% |                       54 |  +1.89% |
| Build Time (ms)     |            1,179 |                 1,161 |  -1.53% |                        1,180 |  +0.08% |                    1,175 |  -0.34% |
| Start Time (ms)     |            1,097 |                 1,103 |  +0.55% |                        1,087 |  -0.91% |                    1,092 |  -0.46% |
| Published Size (KB) |          369,845 |               369,845 |   0.00% |                      369,845 |   0.00% |                  369,845 |   0.00% |


| application                             | minimal_fortunes          | blazorunited_fortunes     |          | blazorunited_dapper_fortunes |          | blazorunited_ef_fortunes  |          |
| --------------------------------------- | ------------------------- | ------------------------- | -------- | ---------------------------- | -------- | ------------------------- | -------- |
| CPU Usage (%)                           |                        96 |                        98 |   +2.08% |                           98 |   +2.08% |                        99 |   +3.12% |
| Cores usage (%)                         |                     2,701 |                     2,740 |   +1.44% |                        2,746 |   +1.67% |                     2,761 |   +2.22% |
| Working Set (MB)                        |                       525 |                       537 |   +2.29% |                          582 |  +10.86% |                       588 |  +12.00% |
| Private Memory (MB)                     |                     1,276 |                     1,293 |   +1.33% |                        1,292 |   +1.25% |                     1,322 |   +3.61% |
| Build Time (ms)                         |                     3,521 |                     3,752 |   +6.56% |                        3,440 |   -2.30% |                     3,371 |   -4.26% |
| Start Time (ms)                         |                       241 |                       238 |   -1.24% |                          235 |   -2.49% |                       240 |   -0.41% |
| Published Size (KB)                     |                    95,161 |                    99,396 |   +4.45% |                       99,597 |   +4.66% |                    99,595 |   +4.66% |
| Symbols Size (KB)                       |                        26 |                        26 |    0.00% |                           26 |    0.00% |                        25 |   -3.85% |
| .NET Core SDK Version                   | 8.0.100-preview.3.23178.7 | 8.0.100-preview.3.23178.7 |          |    8.0.100-preview.3.23178.7 |          | 8.0.100-preview.3.23178.7 |          |
| Max CPU Usage (%)                       |                        97 |                        98 |   +0.87% |                           98 |   +0.62% |                        99 |   +2.00% |
| Max Working Set (MB)                    |                       550 |                       563 |   +2.32% |                          609 |  +10.80% |                       616 |  +11.96% |
| Max GC Heap Size (MB)                   |                       344 |                       353 |   +2.59% |                          388 |  +12.82% |                       399 |  +16.09% |
| Size of committed memory by the GC (MB) |                       451 |                       469 |   +4.00% |                          506 |  +12.21% |                       491 |   +9.05% |
| Max Number of Gen 0 GCs / sec           |                      6.00 |                     13.00 | +116.67% |                        12.00 | +100.00% |                     11.00 |  +83.33% |
| Max Number of Gen 1 GCs / sec           |                      1.00 |                      7.00 | +600.00% |                         6.00 | +500.00% |                      2.00 | +100.00% |
| Max Number of Gen 2 GCs / sec           |                      1.00 |                      1.00 |    0.00% |                         1.00 |    0.00% |                      1.00 |    0.00% |
| Max Time in GC (%)                      |                      1.00 |                      2.00 | +100.00% |                         3.00 | +200.00% |                      2.00 | +100.00% |
| Max Gen 0 Size (B)                      |                 8,586,440 |                 3,830,584 |  -55.39% |                    8,980,504 |   +4.59% |                11,063,208 |  +28.85% |
| Max Gen 1 Size (B)                      |                21,058,928 |                40,647,880 |  +93.02% |                   40,239,952 |  +91.08% |                43,105,360 | +104.69% |
| Max Gen 2 Size (B)                      |                 6,514,176 |                15,766,272 | +142.03% |                   11,454,120 |  +75.83% |                12,278,648 |  +88.49% |
| Max LOH Size (B)                        |                    88,368 |                    92,208 |   +4.35% |                       92,456 |   +4.63% |                   190,840 | +115.96% |
| Max POH Size (B)                        |                 1,231,336 |                 1,165,416 |   -5.35% |                    1,230,720 |   -0.05% |                 1,210,120 |   -1.72% |
| Max Allocation Rate (B/sec)             |             1,561,404,592 |             4,047,728,624 | +159.24% |                3,936,380,048 | +152.11% |             3,386,474,448 | +116.89% |
| Max GC Heap Fragmentation               |                        64 |                        27 |  -57.62% |                           23 |  -63.97% |                         6 |  -90.57% |
| # of Assemblies Loaded                  |                       109 |                       106 |   -2.75% |                          112 |   +2.75% |                       116 |   +6.42% |
| Max Exceptions (#/s)                    |                       454 |                       468 |   +3.08% |                          450 |   -0.88% |                       466 |   +2.64% |
| Max Lock Contention (#/s)               |                     1,539 |                       774 |  -49.71% |                          955 |  -37.95% |                       482 |  -68.68% |
| Max ThreadPool Threads Count            |                        48 |                        48 |    0.00% |                           48 |    0.00% |                        48 |    0.00% |
| Max ThreadPool Queue Length             |                        43 |                        88 | +104.65% |                          158 | +267.44% |                        86 | +100.00% |
| Max ThreadPool Items (#/s)              |                   537,176 |                   802,720 |  +49.43% |                    1,053,630 |  +96.14% |                   858,122 |  +59.75% |
| Max Active Timers                       |                         9 |                        10 |  +11.11% |                           13 |  +44.44% |                        10 |  +11.11% |
| IL Jitted (B)                           |                   512,553 |                   516,327 |   +0.74% |                      551,537 |   +7.61% |                   946,047 |  +84.58% |
| Methods Jitted                          |                     5,233 |                     5,488 |   +4.87% |                        5,829 |  +11.39% |                    11,361 | +117.10% |


| load                   | minimal_fortunes | blazorunited_fortunes |         | blazorunited_dapper_fortunes |          | blazorunited_ef_fortunes |          |
| ---------------------- | ---------------- | --------------------- | ------- | ---------------------------- | -------- | ------------------------ | -------- |
| CPU Usage (%)          |               28 |                    23 | -17.86% |                           22 |  -21.43% |                       20 |  -28.57% |
| Cores usage (%)        |              782 |                   642 | -17.90% |                          611 |  -21.87% |                      550 |  -29.67% |
| Working Set (MB)       |               48 |                    48 |   0.00% |                           48 |    0.00% |                       48 |    0.00% |
| Private Memory (MB)    |              358 |                   358 |   0.00% |                          358 |    0.00% |                      358 |    0.00% |
| Start Time (ms)        |                0 |                     0 |         |                            0 |          |                        0 |          |
| First Request (ms)     |              440 |                   352 | -20.00% |                          407 |   -7.50% |                      924 | +110.00% |
| Requests/sec           |          271,125 |               164,386 | -39.37% |                      151,657 |  -44.06% |                  126,252 |  -53.43% |
| Requests               |        4,093,820 |             2,482,161 | -39.37% |                    2,289,957 |  -44.06% |                1,906,239 |  -53.44% |
| Mean latency (ms)      |             1.01 |                  1.69 | +67.33% |                         1.88 |  +86.14% |                     2.18 | +115.84% |
| Max latency (ms)       |            19.69 |                 37.19 | +88.88% |                        43.61 | +121.48% |                    37.86 |  +92.28% |
| Bad responses          |                0 |                     0 |         |                            0 |          |                        0 |          |
| Socket errors          |                0 |                     0 |         |                            0 |          |                        0 |          |
| Read throughput (MB/s) |           366.13 |                235.16 | -35.77% |                       216.95 |  -40.75% |                   180.61 |  -50.67% |
| Latency 50th (ms)      |             0.84 |                  1.43 | +69.43% |                         1.54 |  +82.46% |                     1.88 | +122.75% |
| Latency 75th (ms)      |             1.23 |                  2.00 | +62.60% |                         2.20 |  +78.86% |                     2.58 | +109.76% |
| Latency 90th (ms)      |             1.65 |                  2.69 | +63.03% |                         2.98 |  +80.61% |                     3.38 | +104.85% |
| Latency 99th (ms)      |             4.05 |                  7.32 | +80.74% |                         8.95 | +120.99% |                     9.13 | +125.43% |

</details> 