### PR TITLE
Adds TodosApi app (native AOT "goldilocks" stage 2)

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -66,24 +66,26 @@
     <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.17</MicrosoftEntityFrameworkCoreSqliteVersion50>
     <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.14</MicrosoftEntityFrameworkCoreSqliteVersion60>
     <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.1.23111.4</MicrosoftEntityFrameworkCoreSqliteVersion80>
+
+    <MicrosoftAspNetCoreAppPackageVersion80>8.0.0-preview.3.23177.8</MicrosoftAspNetCoreAppPackageVersion80>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <MicrosoftAspNetCoreAppPackageVersion>2.1.3</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp2.2'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
     <MicrosoftAspNetCoreAppPackageVersion>2.2.0</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <MicrosoftAspNetCoreAppPackageVersion>3.0.0</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'netcoreapp3.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <MicrosoftAspNetCoreAppPackageVersion>3.1.0</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <MicrosoftAspNetCoreAppPackageVersion>6.0.14</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
-    <MicrosoftAspNetCoreAppPackageVersion>8.0.0-preview.1.23112.2</MicrosoftAspNetCoreAppPackageVersion>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion80)</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 </Project>

--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -40,6 +40,32 @@ parameters:
     arguments: --scenario basicminimalapipublishaot $(goldilocksJobs) --property scenario=Stage1AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.buildArguments \"/p:ServerGarbageCollection=true\"
     condition: 'true'
 
+  - displayName: Goldilocks Stage 2 (CoreCLR)
+    arguments: --scenario todosapivanilla $(goldilocksJobs) --property scenario=Stage2 --property publish=coreclr
+    condition: 'true'
+
+  - displayName: Goldilocks Stage 2 (CoreCLR - Server GC)
+    arguments: --scenario todosapivanilla $(goldilocksJobs) --property scenario=Stage2ServerGC --property publish=coreclr --application.buildArguments \"/p:ServerGarbageCollection=true\"
+    condition: 'true'
+
+  - displayName: Goldilocks Stage 2 (CoreCLR - PGO)
+    arguments: --scenario todosapivanilla $(goldilocksJobs) --property scenario=Stage2Pgo --property publish=coreclr --application.environmentVariables DOTNET_TieredPGO=1
+    condition: Math.round(Date.now() / 43200000) % 6 == 1 # once every 6 half-days (43200000 ms per half-day)
+
+  - displayName: Goldilocks Stage 2 (CoreCLR - Trim R2R SingleFile)
+    arguments: --scenario todosapipublishtrimr2rsinglefile $(goldilocksJobs) --property scenario=Stage2TrimR2RSingleFile --property publish=coreclr
+    condition: 'true'
+
+  - displayName: Goldilocks Stage 2 (NativeAOT - Workstation GC)
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --scenario todosapipublishaot $(goldilocksJobs) --property scenario=Stage2Aot --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    condition: 'true'
+
+  - displayName: Goldilocks Stage 2 (NativeAOT - Server GC)
+    # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
+    arguments: --scenario todosapipublishaot $(goldilocksJobs) --property scenario=Stage2AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.buildArguments \"/p:ServerGarbageCollection=true\"
+    condition: 'true'
+
   - displayName: Goldilocks gRPC Stage 1 (CoreCLR)
     arguments: --scenario basicgrpcvanilla $(goldilocksJobs) --property scenario=Stage1Grpc --property publish=coreclr
     condition: 'true'

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -98,7 +98,6 @@ scenarios:
       buildArguments: 
         - "/p:PublishAot=true"
         - "/p:StripSymbols=true"
-        - "/p:EnableRequestDelegateGenerator=true"
     load:
       job: wrk
       variables:

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -111,7 +111,7 @@ scenarios:
         - "/p:PublishAot=true"
         - "/p:StripSymbols=true"
       environmentVariables:
-        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -131,7 +131,7 @@ scenarios:
         - "/p:TrimMode=full"
         - "/p:EnableRequestDelegateGenerator=true"
       environmentVariables:
-        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -147,7 +147,7 @@ scenarios:
         - "/p:PublishAot=false"
         - "/p:EnableRequestDelegateGenerator=false"
       environmentVariables:
-        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -21,6 +21,16 @@ jobs:
       serverScheme: http
       serverPort: 5000
     arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}}"
+  todosapiaspnetbenchmarks:
+    source:
+      repository: https://github.com/aspnet/benchmarks.git
+      branchOrCommit: main
+      project: src/BenchmarksApps/TodosApi/TodosApi.csproj
+    readyStateText: Application started.
+    variables:
+      serverScheme: http
+      serverPort: 5000
+    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}}"
   basicgrpcaspnetbenchmarks:
     source:
       repository: https://github.com/aspnet/benchmarks.git
@@ -81,6 +91,47 @@ scenarios:
       variables:
         presetHeaders: json
         path: /todos
+
+  todosapipublishaot:
+    application:
+      job: todosapiaspnetbenchmarks
+      buildArguments: 
+        - "/p:PublishAot=true"
+        - "/p:StripSymbols=true"
+        - "/p:EnableRequestDelegateGenerator=true"
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /api/todos
+
+  todosapipublishtrimr2rsinglefile:
+    application:
+      job: todosapiaspnetbenchmarks
+      buildArguments: 
+        - "/p:PublishAot=false"
+        - "/p:PublishTrimmed=true"
+        - "/p:PublishReadyToRun=true"
+        - "/p:PublishSingleFile=true"
+        - "/p:TrimMode=full"
+        - "/p:EnableRequestDelegateGenerator=true"
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /api/todos
+
+  todosapivanilla:
+    application:
+      job: todosapiaspnetbenchmarks
+      buildArguments: 
+        - "/p:PublishAot=false"
+        - "/p:EnableRequestDelegateGenerator=false"
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /api/todos
 
   basicgrpcpublishaot:
     application:

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -52,6 +52,16 @@ jobs:
     waitForExit: false
     options:
       requiredOperatingSystem: linux
+  postgresql:
+    source:
+      repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
+      branchOrCommit: master
+      dockerFile: toolset/databases/postgres/postgres.dockerfile
+      dockerImageName: postgres_te
+      dockerContextDirectory: toolset/databases/postgres
+    readyStateText: ready to accept connections
+    noClean: true
+
 
 scenarios:
 
@@ -93,11 +103,15 @@ scenarios:
         path: /todos
 
   todosapipublishaot:
+    db:
+      job: postgresql
     application:
       job: todosapiaspnetbenchmarks
       buildArguments: 
         - "/p:PublishAot=true"
         - "/p:StripSymbols=true"
+      environmentVariables:
+        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -105,6 +119,8 @@ scenarios:
         path: /api/todos
 
   todosapipublishtrimr2rsinglefile:
+    db:
+      job: postgresql
     application:
       job: todosapiaspnetbenchmarks
       buildArguments: 
@@ -114,6 +130,8 @@ scenarios:
         - "/p:PublishSingleFile=true"
         - "/p:TrimMode=full"
         - "/p:EnableRequestDelegateGenerator=true"
+      environmentVariables:
+        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -121,11 +139,15 @@ scenarios:
         path: /api/todos
 
   todosapivanilla:
+    db:
+      job: postgresql
     application:
       job: todosapiaspnetbenchmarks
       buildArguments: 
         - "/p:PublishAot=false"
         - "/p:EnableRequestDelegateGenerator=false"
+      environmentVariables:
+        connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -111,7 +111,7 @@ scenarios:
         - "/p:PublishAot=true"
         - "/p:StripSymbols=true"
       environmentVariables:
-        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODODB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -131,7 +131,7 @@ scenarios:
         - "/p:TrimMode=full"
         - "/p:EnableRequestDelegateGenerator=true"
       environmentVariables:
-        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODODB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -147,7 +147,7 @@ scenarios:
         - "/p:PublishAot=false"
         - "/p:EnableRequestDelegateGenerator=false"
       environmentVariables:
-        CONNECTIONSTRINGS__TODOSDB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
+        CONNECTIONSTRINGS__TODODB: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:

--- a/src/BenchmarksApps.sln
+++ b/src/BenchmarksApps.sln
@@ -34,9 +34,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlatformBenchmarks", "BenchmarksApps\TechEmpower\PlatformBenchmarks\PlatformBenchmarks.csproj", "{ACA43671-AD28-4F72-AAAB-6C32B388C2F0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{689C58F6-8DF0-4565-887F-C9A9BDA757D8}"
-	ProjectSection(SolutionItems) = preProject
-		BenchmarksApps\Directory.Build.props = BenchmarksApps\Directory.Build.props
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildPerformance", "BenchmarksApps\BuildPerformance\BuildPerformance.csproj", "{2E953AFB-4900-4B5D-9E78-819E950CD365}"
 EndProject
@@ -52,7 +49,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TcpEcho", "BenchmarksApps\T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorUnited", "BenchmarksApps\TechEmpower\BlazorUnited\BlazorUnited.csproj", "{FE3606FF-CBC9-421A-A0B5-836E312E7719}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodosApi", "BenchmarksApps\TodosApi\TodosApi.csproj", "{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodosApi", "BenchmarksApps\TodosApi\TodosApi.csproj", "{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/BenchmarksApps.sln
+++ b/src/BenchmarksApps.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TcpEcho", "BenchmarksApps\T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorUnited", "BenchmarksApps\TechEmpower\BlazorUnited\BlazorUnited.csproj", "{FE3606FF-CBC9-421A-A0B5-836E312E7719}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodosApi", "BenchmarksApps\TodosApi\TodosApi.csproj", "{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug_Database|Any CPU = Debug_Database|Any CPU
@@ -196,6 +198,14 @@ Global
 		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release_Database|Any CPU.Build.0 = Release_Database|Any CPU
 		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE3606FF-CBC9-421A-A0B5-836E312E7719}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Debug_Database|Any CPU.ActiveCfg = Debug_Database|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Debug_Database|Any CPU.Build.0 = Debug_Database|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Release_Database|Any CPU.ActiveCfg = Release_Database|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Release_Database|Any CPU.Build.0 = Release_Database|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E1A1F61-43E4-4629-A25B-7E5FA82697D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BenchmarksApps/Directory.Build.props
+++ b/src/BenchmarksApps/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <Configurations>Debug;Release;Debug_Database;Release_Database</Configurations>
-    <IsDatabase Condition="$(Configuration.EndsWith('_Database'))">true</IsDatabase>
-  </PropertyGroup>
-</Project>

--- a/src/BenchmarksApps/DistributedCache/DistributedCache.csproj
+++ b/src/BenchmarksApps/DistributedCache/DistributedCache.csproj
@@ -1,10 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <MicrosoftAspNetCoreAppPackageVersion Condition="$(MicrosoftAspNetCoreAppPackageVersion) == ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
+
+    <!-- Set package versions to float to latest based on TFM if not defined -->
+    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/Mvc/Mvc.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+
+    <!-- Set package versions to float to latest based on TFM if not defined -->
+    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/SignalR/BenchmarkServer.csproj
+++ b/src/BenchmarksApps/SignalR/BenchmarkServer.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    
+    <!-- Set package versions to float to latest based on TFM if not defined -->
+    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/StaticFiles/StaticFiles.csproj
+++ b/src/BenchmarksApps/StaticFiles/StaticFiles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/TodosApi/DataExtensions.cs
+++ b/src/BenchmarksApps/TodosApi/DataExtensions.cs
@@ -86,7 +86,6 @@ internal static class DataExtensions
         }
     }
 
-
     public static Task<T?> MapSingleAsync<T>(this NpgsqlDataReader reader)
         where T : IDataReaderMapper<T>
         => MapSingleAsync(reader, T.Map);
@@ -142,10 +141,8 @@ internal static class DataExtensions
     public static Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command, CancellationToken cancellationToken = default)
         => QueryAsync(command, CommandBehavior.Default, cancellationToken);
 
-    public static async Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command, CommandBehavior commandBehavior, CancellationToken cancellationToken = default)
-    {
-        return await command.ExecuteReaderAsync(commandBehavior, cancellationToken);
-    }
+    public static Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command, CommandBehavior commandBehavior, CancellationToken cancellationToken = default)
+        => command.ExecuteReaderAsync(commandBehavior, cancellationToken);
 
     public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, int? initialCapacity = null, CancellationToken cancellationToken = default)
     {

--- a/src/BenchmarksApps/TodosApi/DataExtensions.cs
+++ b/src/BenchmarksApps/TodosApi/DataExtensions.cs
@@ -27,6 +27,13 @@ internal static class DataExtensions
         return await cmd.ExecuteNonQueryAsync();
     }
 
+    public static async Task<object?> ExecuteScalarAsync(this NpgsqlDataSource dataSource, string commandText)
+    {
+        await using var cmd = dataSource.CreateCommand(commandText);
+
+        return await cmd.ExecuteScalarAsync(CancellationToken.None);
+    }
+
     public static async Task<int> ExecuteAsync(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters)
     {
         await using var cmd = connection.CreateCommand(commandText, parameters);

--- a/src/BenchmarksApps/TodosApi/DataExtensions.cs
+++ b/src/BenchmarksApps/TodosApi/DataExtensions.cs
@@ -1,0 +1,340 @@
+﻿using System.Data;
+using System.Runtime.CompilerServices;
+
+namespace Npgsql;
+
+public static class DataExtensions
+{
+    public static async ValueTask OpenIfClosedAsync(this NpgsqlConnection connection)
+    {
+        if (connection.State == ConnectionState.Closed)
+        {
+            await connection.OpenAsync();
+        }
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlConnection connection, string commandText)
+    {
+        await using var cmd = connection.CreateCommand(commandText);
+
+        await connection.OpenIfClosedAsync();
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlDataSource dataSource, string commandText)
+    {
+        await using var cmd = dataSource.CreateCommand(commandText);
+
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters)
+    {
+        await using var cmd = connection.CreateCommand(commandText, parameters);
+
+        await connection.OpenIfClosedAsync();
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlDataSource dataSource, string commandText, params NpgsqlParameter[] parameters)
+    {
+        await using var cmd = dataSource.CreateCommand(commandText, parameters);
+
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlConnection connection, string commandText, Action<NpgsqlParameterCollection> configureParameters)
+    {
+        await using var cmd = connection.CreateCommand(commandText, configureParameters);
+
+        await connection.OpenIfClosedAsync();
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<int> ExecuteAsync(this NpgsqlDataSource dataSource, string commandText, Action<NpgsqlParameterCollection> configureParameters)
+    {
+        await using var cmd = dataSource.CreateCommand(commandText, configureParameters);
+
+        return await cmd.ExecuteNonQueryAsync();
+    }
+
+    public static async Task<T?> QuerySingleAsync<T>(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters)
+        where T : IDataReaderMapper<T>
+    {
+        await connection.OpenIfClosedAsync();
+        await using var reader = await connection.QuerySingleAsync(commandText, parameters);
+
+        return await reader.MapSingleAsync<T>();
+    }
+
+    public static async Task<T?> QuerySingleAsync<T>(this NpgsqlDataSource dataSource, string commandText, params NpgsqlParameter[] parameters)
+        where T : IDataReaderMapper<T>
+    {
+        await using var reader = await dataSource.QuerySingleAsync(commandText, parameters);
+
+        return await reader.MapSingleAsync<T>();
+    }
+
+    public static async Task<T?> QuerySingleAsync<T>(this NpgsqlConnection connection, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null)
+        where T : IDataReaderMapper<T>
+    {
+        await using var cmd = connection.CreateCommand(commandText, configureParameters);
+
+        await using var reader = await connection.QuerySingleAsync(cmd);
+
+        return await reader.MapSingleAsync<T>();
+    }
+
+    public static async Task<T?> QuerySingleAsync<T>(this NpgsqlDataSource dataSource, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null)
+        where T : IDataReaderMapper<T>
+    {
+        await using var cmd = dataSource.CreateCommand(commandText, configureParameters);
+
+        await using var reader = await cmd.QuerySingleAsync();
+
+        return await reader.MapSingleAsync<T>();
+    }
+
+    public static async IAsyncEnumerable<T> QueryAsync<T>(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters)
+        where T : IDataReaderMapper<T>
+    {
+        var query = connection.QueryAsync<T>(commandText, parameterCollection => parameterCollection.AddRange(parameters));
+
+        await foreach (var item in query)
+        {
+            yield return item;
+        }
+    }
+
+    public static async IAsyncEnumerable<T> QueryAsync<T>(this NpgsqlDataSource dataSource, string commandText, params NpgsqlParameter[] parameters)
+        where T : IDataReaderMapper<T>
+    {
+        var query = dataSource.QueryAsync<T>(commandText, parameterCollection => parameterCollection.AddRange(parameters));
+
+        await foreach (var item in query)
+        {
+            yield return item;
+        }
+    }
+
+    public static async IAsyncEnumerable<T> QueryAsync<T>(this NpgsqlConnection connection, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null)
+        where T : IDataReaderMapper<T>
+    {
+        await using var cmd = connection.CreateCommand(commandText, configureParameters);
+
+        await connection.OpenIfClosedAsync();
+
+        await using var reader = await connection.QueryAsync(cmd);
+
+        await foreach (var item in MapAsync<T>(reader))
+        {
+            yield return item;
+        }
+    }
+
+    public static async IAsyncEnumerable<T> QueryAsync<T>(this NpgsqlDataSource dataSource, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null)
+        where T : IDataReaderMapper<T>
+    {
+        await using var cmd = dataSource.CreateCommand(commandText, configureParameters);
+
+        await using var reader = await cmd.QueryAsync();
+
+        await foreach (var item in MapAsync<T>(reader))
+        {
+            yield return item;
+        }
+    }
+
+
+    public static Task<T?> MapSingleAsync<T>(this NpgsqlDataReader reader)
+        where T : IDataReaderMapper<T>
+        => MapSingleAsync(reader, T.Map);
+
+    public static async Task<T?> MapSingleAsync<T>(this NpgsqlDataReader reader, Func<NpgsqlDataReader, T> mapper)
+    {
+        if (!reader.HasRows)
+        {
+            return default;
+        }
+
+        await reader.ReadAsync();
+
+        return mapper(reader);
+    }
+
+    public static IAsyncEnumerable<T> MapAsync<T>(this NpgsqlDataReader reader)
+        where T : IDataReaderMapper<T>
+        => MapAsync(reader, T.Map);
+
+    public static async IAsyncEnumerable<T> MapAsync<T>(this NpgsqlDataReader reader, Func<NpgsqlDataReader, T> mapper)
+    {
+        if (!reader.HasRows)
+        {
+            yield break;
+        }
+
+        while (await reader.ReadAsync())
+        {
+            yield return mapper(reader);
+        }
+    }
+
+    public static Task<NpgsqlDataReader> QuerySingleAsync(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters)
+        => QueryAsync(connection, commandText, CommandBehavior.SingleResult | CommandBehavior.SingleRow, parameters);
+
+    public static Task<NpgsqlDataReader> QuerySingleAsync(this NpgsqlDataSource dataSource, string commandText, params NpgsqlParameter[] parameters)
+        => QueryAsync(dataSource, commandText, CommandBehavior.SingleResult | CommandBehavior.SingleRow, parameters);
+
+    public static Task<NpgsqlDataReader> QuerySingleAsync(this NpgsqlConnection connection, NpgsqlCommand command)
+        => QueryAsync(connection, command, CommandBehavior.SingleResult | CommandBehavior.SingleRow);
+
+    public static Task<NpgsqlDataReader> QuerySingleAsync(this NpgsqlCommand command)
+        => QueryAsync(command, CommandBehavior.SingleResult | CommandBehavior.SingleRow);
+
+    public static async Task<NpgsqlDataReader> QueryAsync(this NpgsqlConnection connection, string commandText, CommandBehavior commandBehavior, params NpgsqlParameter[] parameters)
+    {
+        await using var cmd = connection.CreateCommand(commandText, parameters);
+
+        await connection.OpenIfClosedAsync();
+        return await cmd.ExecuteReaderAsync(commandBehavior);
+    }
+
+    public static async Task<NpgsqlDataReader> QueryAsync(this NpgsqlDataSource dataSource, string commandText, CommandBehavior commandBehavior, params NpgsqlParameter[] parameters)
+    {
+        await using var cmd = dataSource.CreateCommand(commandText, parameters);
+
+        return await cmd.ExecuteReaderAsync(commandBehavior);
+    }
+
+    public static Task<NpgsqlDataReader> QueryAsync(this NpgsqlConnection connection, NpgsqlCommand command)
+        => QueryAsync(connection, command, CommandBehavior.Default);
+
+    public static Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command)
+        => QueryAsync(command, CommandBehavior.Default);
+
+    public static async Task<NpgsqlDataReader> QueryAsync(this NpgsqlConnection connection, NpgsqlCommand command, CommandBehavior commandBehavior)
+    {
+        await connection.OpenIfClosedAsync();
+        return await command.ExecuteReaderAsync(commandBehavior);
+    }
+
+    public static async Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command, CommandBehavior commandBehavior)
+    {
+        return await command.ExecuteReaderAsync(commandBehavior);
+    }
+
+    public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, int? initialCapacity = null)
+    {
+        var list = initialCapacity.HasValue ? new List<T>(initialCapacity.Value) : new List<T>();
+
+        await foreach (var item in enumerable)
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public static NpgsqlParameterCollection AddTyped<T>(this NpgsqlParameterCollection parameters, T? value)
+    {
+        parameters.Add(new NpgsqlParameter<T>
+        {
+            TypedValue = value
+        });
+        return parameters;
+    }
+
+    public static NpgsqlParameter<T> AsTypedDbParameter<T>(this T value)
+    {
+        var parameter = new NpgsqlParameter<T>
+        {
+            TypedValue = value
+        };
+
+        return parameter;
+    }
+
+    public static (string Name, object? Value) AsNamedDbParameter(this string? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this DateTime? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this DateTimeOffset? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this bool value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this bool? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this int value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this int? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this long value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this long? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this double value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object)value, name);
+
+    public static (string Name, object? Value) AsNamedDbParameter(this double? value, [CallerArgumentExpression(nameof(value))] string name = null!) =>
+        AsNamedDbParameter((object?)value, name);
+
+    private static (string Name, object? Value) AsNamedDbParameter(this object? value, [CallerArgumentExpression(nameof(value))] string name = null!)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        return (CleanParameterName(name), value ?? DBNull.Value);
+    }
+
+    private static NpgsqlCommand CreateCommand(this NpgsqlConnection connection, string commandText, params NpgsqlParameter[] parameters) =>
+        ConfigureCommand(connection.CreateCommand(), commandText, parameters);
+
+    private static NpgsqlCommand CreateCommand(this NpgsqlDataSource dataSource, string commandText, params NpgsqlParameter[] parameters) =>
+        ConfigureCommand(dataSource.CreateCommand(), commandText, parameters);
+
+    private static NpgsqlCommand ConfigureCommand(NpgsqlCommand cmd, string commandText, NpgsqlParameter[] parameters)
+    {
+        cmd.CommandText = commandText;
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            cmd.Parameters.Add(parameters[i]);
+        }
+
+        return cmd;
+    }
+
+    private static NpgsqlCommand CreateCommand(this NpgsqlConnection connection, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null) =>
+        ConfigureCommand(connection.CreateCommand(commandText), configureParameters);
+
+    private static NpgsqlCommand CreateCommand(this NpgsqlDataSource dataSource, string commandText, Action<NpgsqlParameterCollection>? configureParameters = null) =>
+        ConfigureCommand(dataSource.CreateCommand(commandText), configureParameters);
+
+    private static NpgsqlCommand ConfigureCommand(NpgsqlCommand cmd, Action<NpgsqlParameterCollection>? configureParameters = null)
+    {
+        if (configureParameters is not null)
+        {
+            configureParameters(cmd.Parameters);
+        }
+
+        return cmd;
+    }
+
+    private static string CleanParameterName(string name)
+    {
+        var lastIndexOfPeriod = name.LastIndexOf('.');
+        return lastIndexOfPeriod > 0 ? name[(lastIndexOfPeriod + 1)..] : name;
+    }
+}
+
+public interface IDataReaderMapper<T> where T : IDataReaderMapper<T>
+{
+    abstract static T Map(NpgsqlDataReader dataReader);
+}

--- a/src/BenchmarksApps/TodosApi/Database.cs
+++ b/src/BenchmarksApps/TodosApi/Database.cs
@@ -1,0 +1,45 @@
+﻿using Npgsql;
+
+namespace TodosApi;
+
+internal static class Database
+{
+    public static async Task Initialize(IServiceProvider services, ILogger logger)
+    {
+        var db = services.GetRequiredService<NpgsqlDataSource>();
+
+        if (Environment.GetEnvironmentVariable("SUPPRESS_DB_INIT") != "true")
+        {
+            logger.LogInformation("Ensuring database exists and is up to date at connection string '{connectionString}'", ObscurePassword(db.ConnectionString));
+
+            var sql = $"""
+                  CREATE TABLE IF NOT EXISTS public.todos
+                  (
+                      {nameof(Todo.Id)} SERIAL PRIMARY KEY,
+                      {nameof(Todo.Title)} text NOT NULL,
+                      {nameof(Todo.IsComplete)} boolean NOT NULL DEFAULT false
+                  );
+                  ALTER TABLE IF EXISTS public.todos
+                      OWNER to "TodosApp";
+                  DELETE FROM public.todos;
+                  """;
+            await db.ExecuteAsync(sql);
+        }
+        else
+        {
+            logger.LogInformation("Database initialization disabled for connection string '{connectionString}'", ObscurePassword(db.ConnectionString));
+        }
+
+        string ObscurePassword(string connectionString)
+        {
+            var passwordKey = "Password=";
+            var passwordIndex = connectionString.IndexOf(passwordKey, 0, StringComparison.OrdinalIgnoreCase);
+            if (passwordIndex < 0)
+            {
+                return connectionString;
+            }
+            var semiColonIndex = connectionString.IndexOf(";", passwordIndex, StringComparison.OrdinalIgnoreCase);
+            return string.Concat(connectionString.AsSpan(0, passwordIndex + passwordKey.Length), "*****", semiColonIndex >= 0 ? connectionString[semiColonIndex..] : "");
+        }
+    }
+}

--- a/src/BenchmarksApps/TodosApi/Database.cs
+++ b/src/BenchmarksApps/TodosApi/Database.cs
@@ -17,11 +17,20 @@ internal static class Database
                   (
                       {nameof(Todo.Id)} SERIAL PRIMARY KEY,
                       {nameof(Todo.Title)} text NOT NULL,
+                      {nameof(Todo.DueBy)} date NULL,
                       {nameof(Todo.IsComplete)} boolean NOT NULL DEFAULT false
                   );
                   ALTER TABLE IF EXISTS public.todos
                       OWNER to "TodosApp";
                   DELETE FROM public.todos;
+                  INSERT INTO
+                      public.todos ({nameof(Todo.Title)}, {nameof(Todo.DueBy)}, {nameof(Todo.IsComplete)})
+                  VALUES
+                      ('Wash the dishes.', CURRENT_DATE, true),
+                      ('Dry the dishes.', CURRENT_DATE, true),
+                      ('Turn the dishes over.', CURRENT_DATE, false),
+                      ('Walk the kangaroo.', CURRENT_DATE + INTERVAL '1 day', false),
+                      ('Call Grandma.', CURRENT_DATE + INTERVAL '1 day', false);
                   """;
             await db.ExecuteAsync(sql);
         }

--- a/src/BenchmarksApps/TodosApi/Database.cs
+++ b/src/BenchmarksApps/TodosApi/Database.cs
@@ -10,7 +10,8 @@ internal static class Database
 
         if (Environment.GetEnvironmentVariable("SUPPRESS_DB_INIT") != "true")
         {
-            logger.LogInformation("Ensuring database exists and is up to date at connection string '{connectionString}'", ObscurePassword(db.ConnectionString));
+            // NOTE: Npgsql removes the password from the connection string
+            logger.LogInformation("Ensuring database exists and is up to date at connection string '{connectionString}'", db.ConnectionString);
 
             var sql = $"""
                   CREATE TABLE IF NOT EXISTS public.todos
@@ -36,19 +37,7 @@ internal static class Database
         }
         else
         {
-            logger.LogInformation("Database initialization disabled for connection string '{connectionString}'", ObscurePassword(db.ConnectionString));
-        }
-
-        string ObscurePassword(string connectionString)
-        {
-            var passwordKey = "Password=";
-            var passwordIndex = connectionString.IndexOf(passwordKey, 0, StringComparison.OrdinalIgnoreCase);
-            if (passwordIndex < 0)
-            {
-                return connectionString;
-            }
-            var semiColonIndex = connectionString.IndexOf(";", passwordIndex, StringComparison.OrdinalIgnoreCase);
-            return string.Concat(connectionString.AsSpan(0, passwordIndex + passwordKey.Length), "*****", semiColonIndex >= 0 ? connectionString[semiColonIndex..] : "");
+            logger.LogInformation("Database initialization disabled for connection string '{connectionString}'", db.ConnectionString);
         }
     }
 }

--- a/src/BenchmarksApps/TodosApi/Database.cs
+++ b/src/BenchmarksApps/TodosApi/Database.cs
@@ -21,8 +21,6 @@ internal static class Database
                       {nameof(Todo.DueBy)} date NULL,
                       {nameof(Todo.IsComplete)} boolean NOT NULL DEFAULT false
                   );
-                  ALTER TABLE IF EXISTS public.todos
-                      OWNER to "TodosApp";
                   DELETE FROM public.todos;
                   INSERT INTO
                       public.todos ({nameof(Todo.Title)}, {nameof(Todo.DueBy)}, {nameof(Todo.IsComplete)})

--- a/src/BenchmarksApps/TodosApi/Database.cs
+++ b/src/BenchmarksApps/TodosApi/Database.cs
@@ -4,7 +4,7 @@ namespace TodosApi;
 
 internal static class Database
 {
-    public static async Task Initialize(IServiceProvider services, ILogger logger)
+    public static async Task Initialize(IServiceProvider services, ILogger logger, CancellationToken cancellationToken = default)
     {
         var db = services.GetRequiredService<NpgsqlDataSource>();
 
@@ -33,7 +33,7 @@ internal static class Database
                       ('Walk the kangaroo.', CURRENT_DATE + INTERVAL '1 day', false),
                       ('Call Grandma.', CURRENT_DATE + INTERVAL '1 day', false);
                   """;
-            await db.ExecuteAsync(sql);
+            await db.ExecuteAsync(sql, cancellationToken);
         }
         else
         {

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -25,9 +25,9 @@ public class DatabaseHealthCheck : IHealthCheck
             exception = ex;
         }
         
-        return result switch
+        return exception switch
         {
-            null or int => HealthCheckResult.Healthy("Database health verified successfully"),
+            null => HealthCheckResult.Healthy("Database health verified successfully"),
             _ => HealthCheckResult.Unhealthy("Error occurred when checking database health", exception: exception)
         };
     }

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -14,11 +14,21 @@ public class DatabaseHealthCheck : IHealthCheck
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1");
+        object? result = null;
+        Exception? exception = null;
+        try
+        {
+            result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1");
+        }
+        catch (Exception ex)
+        {
+            exception = ex;
+        }
+        
         return result switch
         {
-            null or int => HealthCheckResult.Healthy(),
-            _ => HealthCheckResult.Unhealthy()
+            null or int => HealthCheckResult.Healthy("Database health verified successfully"),
+            _ => HealthCheckResult.Unhealthy("Error occurred when checking database health", exception: exception)
         };
     }
 }

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -14,10 +14,10 @@ public class DatabaseHealthCheck : IHealthCheck
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var result = await _dataSource.ExecuteScalarAsync("SELECT COUNT(id) FROM public.todos");
+        var result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1");
         return result switch
         {
-            long count when count >= 0 => HealthCheckResult.Healthy(),
+            null or int => HealthCheckResult.Healthy(),
             _ => HealthCheckResult.Unhealthy()
         };
     }

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -14,11 +14,10 @@ public class DatabaseHealthCheck : IHealthCheck
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        object? result = null;
         Exception? exception = null;
         try
         {
-            result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1", cancellationToken);
+            await _dataSource.ExecuteScalarAsync("SELECT 1", cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -18,7 +18,7 @@ public class DatabaseHealthCheck : IHealthCheck
         Exception? exception = null;
         try
         {
-            result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1");
+            result = await _dataSource.ExecuteScalarAsync("SELECT id FROM public.todos LIMIT 1", cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Npgsql;
+
+namespace TodosApi;
+
+public class DatabaseHealthCheck : IHealthCheck
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public DatabaseHealthCheck(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var result = await _dataSource.ExecuteScalarAsync("SELECT COUNT(id) FROM public.todos");
+        return result switch
+        {
+            long count when count >= 0 => HealthCheckResult.Healthy(),
+            _ => HealthCheckResult.Unhealthy()
+        };
+    }
+}

--- a/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
+++ b/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
@@ -1,0 +1,94 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.AspNetCore.Builder;
+
+internal static class JwtConfiguration
+{
+    /// <summary>
+    /// Configures JWT Bearer to load the signing key from an environment variable when not running in Development.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException">Thrown when the signing key is not found in non-Development environments.</exception>
+    public static Action<JwtBearerOptions> ConfigureJwtBearer(WebApplicationBuilder builder)
+    {
+        return options =>
+        {
+            if (!builder.Environment.IsDevelopment())
+            {
+                // When not running in development configure the JWT signing key from environment variable
+                var jwtKeyMaterialValue = builder.Configuration["JWT_SIGNING_KEY"];
+
+                if (string.IsNullOrEmpty(jwtKeyMaterialValue))
+                {
+                    throw new InvalidOperationException("JWT signing key not found!");
+                }
+
+                var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
+                var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
+                options.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
+            }
+
+            // Validate the JWT options
+            builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+                .Validate<IHostEnvironment, ILoggerFactory>(ValidateJwtOptions,
+                    "JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.")
+                .ValidateOnStart();
+        };
+    }
+
+    private const string JwtOptionsLogMessage = "JwtBearerAuthentication options configuration: {JwtOptions}";
+
+    /// <summary>
+    /// Validates that JWT Bearer authentication has been configured correctly.
+    /// </summary>
+    /// <param name="options"></param>
+    /// <param name="hostEnvironment"></param>
+    /// <param name="loggerFactory"></param>
+    /// <returns><c>true</c> if required JWT Bearer settings are loaded, otherwise <c>false</c>.</returns>
+    public static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
+    {
+        var relevantOptions = new JwtOptionsSummary
+        {
+            Audience = options.Audience,
+            ClaimsIssuer = options.ClaimsIssuer,
+            Audiences = options.TokenValidationParameters?.ValidAudiences,
+            Issuers = options.TokenValidationParameters?.ValidIssuers,
+            IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey,
+            IssuerSigningKeys = options.TokenValidationParameters?.IssuerSigningKeys
+        };
+
+        var logger = loggerFactory.CreateLogger(hostEnvironment.ApplicationName ?? nameof(Program));
+        var jwtOptionsJson = JsonSerializer.Serialize(relevantOptions, JwtOptionsJsonSerializerContext.Default.JwtOptionsSummary);
+
+        if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
+            || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
+            || (relevantOptions.IssuerSigningKey is null && relevantOptions.IssuerSigningKeys?.Any() != true))
+        {
+            logger.LogError(JwtOptionsLogMessage, jwtOptionsJson);
+            return false;
+        }
+
+        logger.LogInformation(JwtOptionsLogMessage, jwtOptionsJson);
+        return true;
+    }
+}
+
+
+internal class JwtOptionsSummary
+{
+    public string? Audience { get; set; }
+    public string? ClaimsIssuer { get; set; }
+    public IEnumerable<string>? Audiences { get; set; }
+    public IEnumerable<string>? Issuers { get; set; }
+    public SecurityKey? IssuerSigningKey { get; set; }
+    public IEnumerable<SecurityKey>? IssuerSigningKeys { get; set; }
+}
+
+[JsonSerializable(typeof(JwtOptionsSummary))]
+internal partial class JwtOptionsJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
+++ b/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
@@ -32,19 +32,3 @@ internal static class JwtConfiguration
         };
     }
 }
-
-
-internal class JwtOptionsSummary
-{
-    public string? Audience { get; set; }
-    public string? ClaimsIssuer { get; set; }
-    public IEnumerable<string>? Audiences { get; set; }
-    public IEnumerable<string>? Issuers { get; set; }
-    public SecurityKey? IssuerSigningKey { get; set; }
-    public IEnumerable<SecurityKey>? IssuerSigningKeys { get; set; }
-}
-
-[JsonSerializable(typeof(JwtOptionsSummary))]
-internal partial class JwtOptionsJsonSerializerContext : JsonSerializerContext
-{
-}

--- a/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
+++ b/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
@@ -22,14 +22,12 @@ internal static class JwtConfiguration
                 // When not running in development configure the JWT signing key from environment variable
                 var jwtKeyMaterialValue = builder.Configuration["JWT_SIGNING_KEY"];
 
-                if (string.IsNullOrEmpty(jwtKeyMaterialValue))
+                if (!string.IsNullOrEmpty(jwtKeyMaterialValue))
                 {
-                    throw new InvalidOperationException("JWT signing key not found!");
+                    var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
+                    var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
+                    options.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
                 }
-
-                var jwtKeyMaterial = Convert.FromBase64String(jwtKeyMaterialValue);
-                var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
-                options.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
             }
         };
     }

--- a/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
+++ b/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.AspNetCore.Builder;

--- a/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
+++ b/src/BenchmarksApps/TodosApi/JwtConfiguration.cs
@@ -31,49 +31,7 @@ internal static class JwtConfiguration
                 var jwtSigningKey = new SymmetricSecurityKey(jwtKeyMaterial);
                 options.TokenValidationParameters.IssuerSigningKey = jwtSigningKey;
             }
-
-            // Validate the JWT options
-            builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
-                .Validate<IHostEnvironment, ILoggerFactory>(ValidateJwtOptions,
-                    "JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.")
-                .ValidateOnStart();
         };
-    }
-
-    private const string JwtOptionsLogMessage = "JwtBearerAuthentication options configuration: {JwtOptions}";
-
-    /// <summary>
-    /// Validates that JWT Bearer authentication has been configured correctly.
-    /// </summary>
-    /// <param name="options"></param>
-    /// <param name="hostEnvironment"></param>
-    /// <param name="loggerFactory"></param>
-    /// <returns><c>true</c> if required JWT Bearer settings are loaded, otherwise <c>false</c>.</returns>
-    public static bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
-    {
-        var relevantOptions = new JwtOptionsSummary
-        {
-            Audience = options.Audience,
-            ClaimsIssuer = options.ClaimsIssuer,
-            Audiences = options.TokenValidationParameters?.ValidAudiences,
-            Issuers = options.TokenValidationParameters?.ValidIssuers,
-            IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey,
-            IssuerSigningKeys = options.TokenValidationParameters?.IssuerSigningKeys
-        };
-
-        var logger = loggerFactory.CreateLogger(hostEnvironment.ApplicationName ?? nameof(Program));
-        var jwtOptionsJson = JsonSerializer.Serialize(relevantOptions, JwtOptionsJsonSerializerContext.Default.JwtOptionsSummary);
-
-        if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
-            || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
-            || (relevantOptions.IssuerSigningKey is null && relevantOptions.IssuerSigningKeys?.Any() != true))
-        {
-            logger.LogError(JwtOptionsLogMessage, jwtOptionsJson);
-            return false;
-        }
-
-        logger.LogInformation(JwtOptionsLogMessage, jwtOptionsJson);
-        return true;
     }
 }
 

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -20,7 +20,7 @@ public class JwtHealthCheck : IHealthCheck
     {
         var valid = ValidateJwtOptions(_jwtOptions.CurrentValue);
         var status = valid
-            ? HealthCheckResult.Healthy("")
+            ? HealthCheckResult.Healthy("JWT options configured correctly")
             : HealthCheckResult.Degraded("JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.");
         return Task.FromResult(status);
     }

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -1,0 +1,57 @@
+﻿using System.Text.Json;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+namespace TodosApi;
+
+public class JwtHealthCheck : IHealthCheck
+{
+    private readonly IOptionsMonitor<JwtBearerOptions> _jwtOptions;
+    private readonly IHostEnvironment _hostEnvironment;
+    private readonly ILogger<JwtHealthCheck> _logger;
+
+    public JwtHealthCheck(IOptionsMonitor<JwtBearerOptions> jwtOptions, IHostEnvironment hostEnvironment, ILogger<JwtHealthCheck> logger)
+    {
+        _jwtOptions = jwtOptions;
+        _hostEnvironment = hostEnvironment;
+        _logger = logger;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var valid = ValidateJwtOptions(_jwtOptions.CurrentValue, _hostEnvironment);
+        var status = valid
+            ? HealthCheckResult.Healthy("")
+            : HealthCheckResult.Degraded("JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.");
+        return Task.FromResult(status);
+    }
+
+    private const string JwtOptionsLogMessage = "JwtBearerAuthentication options configuration: {JwtOptions}";
+    
+    private bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment)
+    {
+        var relevantOptions = new JwtOptionsSummary
+        {
+            Audience = options.Audience,
+            ClaimsIssuer = options.ClaimsIssuer,
+            Audiences = options.TokenValidationParameters?.ValidAudiences,
+            Issuers = options.TokenValidationParameters?.ValidIssuers,
+            IssuerSigningKey = options.TokenValidationParameters?.IssuerSigningKey,
+            IssuerSigningKeys = options.TokenValidationParameters?.IssuerSigningKeys
+        };
+        
+        var jwtOptionsJson = JsonSerializer.Serialize(relevantOptions, JwtOptionsJsonSerializerContext.Default.JwtOptionsSummary);
+
+        if ((string.IsNullOrEmpty(relevantOptions.Audience) && relevantOptions.Audiences?.Any() != true)
+            || (relevantOptions.ClaimsIssuer is null && relevantOptions.Issuers?.Any() != true)
+            || (relevantOptions.IssuerSigningKey is null && relevantOptions.IssuerSigningKeys?.Any() != true))
+        {
+            _logger.LogWarning(JwtOptionsLogMessage, jwtOptionsJson);
+            return false;
+        }
+
+        _logger.LogInformation(JwtOptionsLogMessage, jwtOptionsJson);
+        return true;
+    }
+}

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace TodosApi;
 
-public class JwtHealthCheck : IHealthCheck
+internal class JwtHealthCheck : IHealthCheck
 {
     private readonly IOptionsMonitor<JwtBearerOptions> _jwtOptions;
     private readonly ILogger<JwtHealthCheck> _logger;
@@ -52,4 +52,19 @@ public class JwtHealthCheck : IHealthCheck
         _logger.LogInformation(JwtOptionsLogMessage, jwtOptionsJson);
         return true;
     }
+}
+
+internal class JwtOptionsSummary
+{
+    public string? Audience { get; set; }
+    public string? ClaimsIssuer { get; set; }
+    public IEnumerable<string>? Audiences { get; set; }
+    public IEnumerable<string>? Issuers { get; set; }
+    public SecurityKey? IssuerSigningKey { get; set; }
+    public IEnumerable<SecurityKey>? IssuerSigningKeys { get; set; }
+}
+
+[JsonSerializable(typeof(JwtOptionsSummary))]
+internal partial class JwtOptionsJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -21,7 +21,7 @@ public class JwtHealthCheck : IHealthCheck
         var valid = ValidateJwtOptions(_jwtOptions.CurrentValue);
         var status = valid
             ? HealthCheckResult.Healthy("JWT options configured correctly")
-            : HealthCheckResult.Degraded("JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.");
+            : HealthCheckResult.Degraded("JWT options are not configured. Verify the JWT signing key is correctly configured for the current environment.");
         return Task.FromResult(status);
     }
 

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 namespace TodosApi;
 

--- a/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/JwtHealthCheck.cs
@@ -8,19 +8,17 @@ namespace TodosApi;
 public class JwtHealthCheck : IHealthCheck
 {
     private readonly IOptionsMonitor<JwtBearerOptions> _jwtOptions;
-    private readonly IHostEnvironment _hostEnvironment;
     private readonly ILogger<JwtHealthCheck> _logger;
 
-    public JwtHealthCheck(IOptionsMonitor<JwtBearerOptions> jwtOptions, IHostEnvironment hostEnvironment, ILogger<JwtHealthCheck> logger)
+    public JwtHealthCheck(IOptionsMonitor<JwtBearerOptions> jwtOptions, ILogger<JwtHealthCheck> logger)
     {
         _jwtOptions = jwtOptions;
-        _hostEnvironment = hostEnvironment;
         _logger = logger;
     }
 
     public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
-        var valid = ValidateJwtOptions(_jwtOptions.CurrentValue, _hostEnvironment);
+        var valid = ValidateJwtOptions(_jwtOptions.CurrentValue);
         var status = valid
             ? HealthCheckResult.Healthy("")
             : HealthCheckResult.Degraded("JWT options are not configured. Run 'dotnet user-jwts create' in project directory to configure JWT.");
@@ -29,7 +27,7 @@ public class JwtHealthCheck : IHealthCheck
 
     private const string JwtOptionsLogMessage = "JwtBearerAuthentication options configuration: {JwtOptions}";
     
-    private bool ValidateJwtOptions(JwtBearerOptions options, IHostEnvironment hostEnvironment)
+    private bool ValidateJwtOptions(JwtBearerOptions options)
     {
         var relevantOptions = new JwtOptionsSummary
         {

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateSlimBuilder(args);
 var settingsFiles = new[] { "appsettings.json", $"appsettings.{builder.Environment.EnvironmentName}.json" };
 foreach (var settingsFile in settingsFiles)
 {
-    builder.Configuration.AddJsonFile(builder.Environment.ContentRootFileProvider, settingsFile, optional: false, reloadOnChange: true);
+    builder.Configuration.AddJsonFile(builder.Environment.ContentRootFileProvider, settingsFile, optional: true, reloadOnChange: true);
 }
 #if DEBUG || DEBUG_DATABASE
 builder.Configuration.AddUserSecrets<Program>();
@@ -16,7 +16,7 @@ builder.Configuration.AddUserSecrets<Program>();
 
 // Configure logging
 builder.Logging
-    .AddConfiguration(builder.Configuration)
+    .AddConfiguration(builder.Configuration.GetSection("Logging"))
     .AddSimpleConsole();
 
 // Configure authentication & authorization
@@ -34,7 +34,6 @@ builder.Services.AddSingleton(_ => new NpgsqlSlimDataSourceBuilder(connectionStr
 // Configure JSON serialization
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
-    options.SerializerOptions.TypeInfoResolverChain.Insert(0, JwtOptionsJsonSerializerContext.Default);
     options.SerializerOptions.TypeInfoResolverChain.Insert(0, TodoApiJsonSerializerContext.Default);
 });
 

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Microsoft.Extensions.Logging.Configuration;
 using Npgsql;
 using TodosApi;
@@ -45,7 +46,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 
 // Configure health checks
 builder.Services.AddHealthChecks()
-    .AddCheck<DatabaseHealthCheck>("Database")
+    .AddCheck<DatabaseHealthCheck>("Database", timeout: TimeSpan.FromSeconds(2))
     .AddCheck<JwtHealthCheck>("JwtAuthentication");
 
 // Problem details

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -4,15 +4,18 @@ using TodosApi;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
-#if ENABLE_LOGGING
 // Load custom configuration
 var settingsFiles = new[] { "appsettings.json", $"appsettings.{builder.Environment.EnvironmentName}.json" };
 foreach (var settingsFile in settingsFiles)
 {
     builder.Configuration.AddJsonFile(builder.Environment.ContentRootFileProvider, settingsFile, optional: true, reloadOnChange: true);
 }
-builder.Configuration.AddUserSecrets<Program>();
 
+#if DEBUG || DEBUG_DATABASE
+builder.Configuration.AddUserSecrets<Program>();
+#endif
+
+#if ENABLE_LOGGING
 // Configure logging
 builder.Logging
     .AddConfiguration(builder.Configuration.GetSection("Logging"))

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -62,11 +62,14 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.MapHealthChecks("/health");
-
-app.MapTodoApi();
-
 // Enables testing request exception handling behavior
 app.MapGet("/throw", void () => throw new InvalidOperationException("You hit the throw endpoint"));
+
+// These need to manually registered until https://github.com/dotnet/aspnetcore/issues/47507 is fixed
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapTodoApi();
 
 #if !ENABLE_LOGGING
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -30,7 +30,6 @@ builder.Services.AddAuthorization();
 
 // Configure data access
 var connectionString = builder.Configuration.GetConnectionString("TodoDb")
-    ?? builder.Configuration["CONNECTION_STRING"]
     ?? throw new InvalidOperationException("""
         Connection string not found.
         If running locally, set the connection string in user secrets for key 'ConnectionStrings:TodoDb'.

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -41,9 +41,16 @@ builder.Services.ConfigureHttpJsonOptions(options =>
     options.SerializerOptions.TypeInfoResolverChain.Insert(0, TodoApiJsonSerializerContext.Default);
 });
 
+// Configure health checks
+builder.Services.AddHealthChecks()
+    .AddCheck<DatabaseHealthCheck>("Database")
+    .AddCheck<JwtHealthCheck>("JwtAuthentication");
+
 var app = builder.Build();
 
 await Database.Initialize(app.Services, app.Logger);
+
+app.MapHealthChecks("/health");
 
 app.MapTodoApi();
 

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging.Configuration;
+using Npgsql;
+using TodosApi;
+
+var builder = WebApplication.CreateSlimBuilder(args);
+
+// Load custom configuration
+var settingsFiles = new[] { "appsettings.json", $"appsettings.{builder.Environment.EnvironmentName}.json" };
+foreach (var settingsFile in settingsFiles)
+{
+    builder.Configuration.AddJsonFile(builder.Environment.ContentRootFileProvider, settingsFile, optional: false, reloadOnChange: true);
+}
+#if DEBUG || DEBUG_DATABASE
+builder.Configuration.AddUserSecrets<Program>();
+#endif
+
+// Configure logging
+builder.Logging
+    .AddConfiguration(builder.Configuration)
+    .AddSimpleConsole();
+
+// Configure authentication & authorization
+builder.Services.AddAuthentication()
+    .AddJwtBearer(JwtConfiguration.ConfigureJwtBearer(builder));
+
+builder.Services.AddAuthorization();
+
+// Configure data access
+var connectionString = builder.Configuration.GetConnectionString("TodoDb")
+    ?? builder.Configuration["CONNECTION_STRING"]
+    ?? throw new InvalidOperationException("Connection string not found. If running locally, set the connection string in user secrets for key 'ConnectionStrings:TodoDb'.");
+builder.Services.AddSingleton(_ => new NpgsqlSlimDataSourceBuilder(connectionString).Build());
+
+// Configure JSON serialization
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, JwtOptionsJsonSerializerContext.Default);
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, TodoApiJsonSerializerContext.Default);
+});
+
+var app = builder.Build();
+
+await Database.Initialize(app.Services, app.Logger);
+
+app.MapTodoApi();
+
+app.Run();

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -65,7 +65,7 @@ app.MapHealthChecks("/health");
 app.MapTodoApi();
 
 // Enables testing request exception handling behavior
-app.MapGet("/throw", (HttpContext httpContext) => throw new InvalidOperationException("You hit the throw endpoint"));
+app.MapGet("/throw", (HttpContext _) => throw new InvalidOperationException("You hit the throw endpoint"));
 
 #if !ENABLE_LOGGING
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -46,13 +46,24 @@ builder.Services.AddHealthChecks()
     .AddCheck<DatabaseHealthCheck>("Database")
     .AddCheck<JwtHealthCheck>("JwtAuthentication");
 
+// Problem details
+builder.Services.AddProblemDetails();
+
 var app = builder.Build();
 
 await Database.Initialize(app.Services, app.Logger);
 
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler();
+}
+
 app.MapHealthChecks("/health");
 
 app.MapTodoApi();
+
+// Enables testing request exception handling behavior
+app.MapGet("/throw", (HttpContext httpContext) => throw new InvalidOperationException("You hit the throw endpoint"));
 
 #if !ENABLE_LOGGING
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -4,20 +4,20 @@ using TodosApi;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
+#if ENABLE_LOGGING
 // Load custom configuration
 var settingsFiles = new[] { "appsettings.json", $"appsettings.{builder.Environment.EnvironmentName}.json" };
 foreach (var settingsFile in settingsFiles)
 {
     builder.Configuration.AddJsonFile(builder.Environment.ContentRootFileProvider, settingsFile, optional: true, reloadOnChange: true);
 }
-#if DEBUG || DEBUG_DATABASE
 builder.Configuration.AddUserSecrets<Program>();
-#endif
 
 // Configure logging
 builder.Logging
     .AddConfiguration(builder.Configuration.GetSection("Logging"))
     .AddSimpleConsole();
+#endif
 
 // Configure authentication & authorization
 builder.Services.AddAuthentication()
@@ -28,7 +28,11 @@ builder.Services.AddAuthorization();
 // Configure data access
 var connectionString = builder.Configuration.GetConnectionString("TodoDb")
     ?? builder.Configuration["CONNECTION_STRING"]
-    ?? throw new InvalidOperationException("Connection string not found. If running locally, set the connection string in user secrets for key 'ConnectionStrings:TodoDb'.");
+    ?? throw new InvalidOperationException("""
+        Connection string not found.
+        If running locally, set the connection string in user secrets for key 'ConnectionStrings:TodoDb'.
+        If running after deployment, set the connection string via the environment variable 'CONNECTIONSTRINGS__TODODB'.
+        """);
 builder.Services.AddSingleton(_ => new NpgsqlSlimDataSourceBuilder(connectionString).Build());
 
 // Configure JSON serialization
@@ -42,5 +46,10 @@ var app = builder.Build();
 await Database.Initialize(app.Services, app.Logger);
 
 app.MapTodoApi();
+
+#if !ENABLE_LOGGING
+app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
+app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));
+#endif
 
 app.Run();

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -65,7 +65,7 @@ app.MapHealthChecks("/health");
 app.MapTodoApi();
 
 // Enables testing request exception handling behavior
-app.MapGet("/throw", (HttpContext _) => throw new InvalidOperationException("You hit the throw endpoint"));
+app.MapGet("/throw", Task () => throw new InvalidOperationException("You hit the throw endpoint"));
 
 #if !ENABLE_LOGGING
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -65,7 +65,7 @@ app.MapHealthChecks("/health");
 app.MapTodoApi();
 
 // Enables testing request exception handling behavior
-app.MapGet("/throw", Task () => throw new InvalidOperationException("You hit the throw endpoint"));
+app.MapGet("/throw", void () => throw new InvalidOperationException("You hit the throw endpoint"));
 
 #if !ENABLE_LOGGING
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Microsoft.Extensions.Logging.Configuration;
 using Npgsql;
 using TodosApi;

--- a/src/BenchmarksApps/TodosApi/Todo.cs
+++ b/src/BenchmarksApps/TodosApi/Todo.cs
@@ -2,7 +2,7 @@ using Npgsql;
 
 namespace TodosApi;
 
-sealed class Todo : IDataReaderMapper<Todo>
+internal sealed class Todo : IDataReaderMapper<Todo>
 {
     public int Id { get; set; }
 

--- a/src/BenchmarksApps/TodosApi/Todo.cs
+++ b/src/BenchmarksApps/TodosApi/Todo.cs
@@ -1,0 +1,24 @@
+using Npgsql;
+
+namespace TodosApi;
+
+sealed class Todo : IDataReaderMapper<Todo>
+{
+    public int Id { get; set; }
+
+    public string Title { get; set; } = default!;
+
+    public DateOnly? DueBy { get; set; }
+
+    public bool IsComplete { get; set; }
+
+    public static Todo Map(NpgsqlDataReader dataReader)
+    {
+        return !dataReader.HasRows ? new() : new()
+        {
+            Id = dataReader.GetInt32(dataReader.GetOrdinal(nameof(Id))),
+            Title = dataReader.GetString(dataReader.GetOrdinal(nameof(Title))),
+            IsComplete = dataReader.GetBoolean(dataReader.GetOrdinal(nameof(IsComplete)))
+        };
+    }
+}

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -11,26 +11,27 @@ internal static class TodoApi
     {
         var group = routes.MapGroup("/api/todos");
 
-        group.MapGet("/", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos"))
+        group.MapGet("/", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos", ct))
             .WithName("GetAllTodos");
 
-        group.MapGet("/complete", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = true"))
+        group.MapGet("/complete", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = true", ct))
             .WithName("GetCompleteTodos");
 
-        group.MapGet("/incomplete", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = false"))
+        group.MapGet("/incomplete", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = false", ct))
             .WithName("GetIncompleteTodos");
 
-        group.MapGet("/{id:int}", async Task<Results<Ok<Todo>, NotFound>> (int id, NpgsqlDataSource db) =>
+        group.MapGet("/{id:int}", async Task<Results<Ok<Todo>, NotFound>> (int id, NpgsqlDataSource db, CancellationToken ct) =>
             await db.QuerySingleAsync<Todo>(
-                "SELECT * FROM Todos WHERE Id = $1", id.AsTypedDbParameter())
+                "SELECT * FROM Todos WHERE Id = $1", ct, id.AsTypedDbParameter())
                 is Todo todo
                     ? TypedResults.Ok(todo)
                     : TypedResults.NotFound())
             .WithName("GetTodoById");
 
-        group.MapGet("/find", async Task<Results<Ok<Todo>, NotFound>> (string title, bool? isComplete, NpgsqlDataSource db) =>
+        group.MapGet("/find", async Task<Results<Ok<Todo>, NotFound>> (string title, bool? isComplete, NpgsqlDataSource db, CancellationToken ct) =>
             await db.QuerySingleAsync<Todo>(
                 "SELECT * FROM Todos WHERE LOWER(Title) = LOWER($1) AND ($2 is NULL OR IsComplete = $2)",
+                ct,
                 title.AsTypedDbParameter(),
                 isComplete.AsTypedDbParameter())
                 is Todo todo
@@ -38,10 +39,11 @@ internal static class TodoApi
                     : TypedResults.NotFound())
             .WithName("FindTodo");
 
-        group.MapPost("/", async Task<Results<Created<Todo>, ValidationProblem>> (Todo todo, NpgsqlDataSource db) =>
+        group.MapPost("/", async Task<Results<Created<Todo>, ValidationProblem>> (Todo todo, NpgsqlDataSource db, CancellationToken ct) =>
         {
             var createdTodo = await db.QuerySingleAsync<Todo>(
                 "INSERT INTO Todos(Title, IsComplete) Values($1, $2) RETURNING *",
+                ct,
                 todo.Title.AsTypedDbParameter(),
                 todo.IsComplete.AsTypedDbParameter());
 
@@ -49,12 +51,13 @@ internal static class TodoApi
         })
         .WithName("CreateTodo");
 
-        group.MapPut("/{id}", async Task<Results<NoContent, NotFound, ValidationProblem>> (int id, Todo inputTodo, NpgsqlDataSource db) =>
+        group.MapPut("/{id}", async Task<Results<NoContent, NotFound, ValidationProblem>> (int id, Todo inputTodo, NpgsqlDataSource db, CancellationToken ct) =>
         {
             inputTodo.Id = id;
             
             return await db.ExecuteAsync(
                 "UPDATE Todos SET Title = $1, IsComplete = $2 WHERE Id = $3",
+                ct,
                 inputTodo.Title.AsTypedDbParameter(),
                 inputTodo.IsComplete.AsTypedDbParameter(),
                 id.AsTypedDbParameter()) == 1
@@ -63,28 +66,28 @@ internal static class TodoApi
         })
         .WithName("UpdateTodo");
 
-        group.MapPut("/{id}/mark-complete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+        group.MapPut("/{id}/mark-complete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db, CancellationToken ct) =>
             await db.ExecuteAsync(
-                "UPDATE Todos SET IsComplete = true WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                "UPDATE Todos SET IsComplete = true WHERE Id = $1", ct, id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("MarkComplete");
 
-        group.MapPut("/{id}/mark-incomplete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+        group.MapPut("/{id}/mark-incomplete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db, CancellationToken ct) =>
             await db.ExecuteAsync(
-                "UPDATE Todos SET IsComplete = false WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                "UPDATE Todos SET IsComplete = false WHERE Id = $1", ct, id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("MarkIncomplete");
 
-        group.MapDelete("/{id}", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+        group.MapDelete("/{id}", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db, CancellationToken ct) =>
             await db.ExecuteAsync(
-                "DELETE FROM Todos WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                "DELETE FROM Todos WHERE Id = $1", ct, id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("DeleteTodo");
 
-        group.MapDelete("/delete-all", async (NpgsqlDataSource db) => TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos")))
+        group.MapDelete("/delete-all", async (NpgsqlDataSource db, CancellationToken ct) => TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos", ct)))
             .WithName("DeleteAll")
             .RequireAuthorization(policy => policy.RequireAuthenticatedUser().RequireRole("admin"));
 

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -5,13 +5,11 @@ using TodosApi;
 
 namespace Microsoft.AspNetCore.Routing;
 
-public static class TodoApi
+internal static class TodoApi
 {
     public static RouteGroupBuilder MapTodoApi(this IEndpointRouteBuilder routes)
     {
         var group = routes.MapGroup("/api/todos");
-
-        group.WithTags("Todos");
 
         group.MapGet("/", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos"))
             .WithName("GetAllTodos");
@@ -23,14 +21,16 @@ public static class TodoApi
             .WithName("GetIncompleteTodos");
 
         group.MapGet("/{id:int}", async Task<Results<Ok<Todo>, NotFound>> (int id, NpgsqlDataSource db) =>
-            await db.QuerySingleAsync<Todo>("SELECT * FROM Todos WHERE Id = $1", id.AsTypedDbParameter())
+            await db.QuerySingleAsync<Todo>(
+                "SELECT * FROM Todos WHERE Id = $1", id.AsTypedDbParameter())
                 is Todo todo
                     ? TypedResults.Ok(todo)
                     : TypedResults.NotFound())
             .WithName("GetTodoById");
 
         group.MapGet("/find", async Task<Results<Ok<Todo>, NotFound>> (string title, bool? isComplete, NpgsqlDataSource db) =>
-            await db.QuerySingleAsync<Todo>("SELECT * FROM Todos WHERE LOWER(Title) = LOWER($1) AND ($2 is NULL OR IsComplete = $2)",
+            await db.QuerySingleAsync<Todo>(
+                "SELECT * FROM Todos WHERE LOWER(Title) = LOWER($1) AND ($2 is NULL OR IsComplete = $2)",
                 title.AsTypedDbParameter(),
                 isComplete.AsTypedDbParameter())
                 is Todo todo
@@ -53,29 +53,33 @@ public static class TodoApi
         {
             inputTodo.Id = id;
             
-            return await db.ExecuteAsync("UPDATE Todos SET Title = $1, IsComplete = $2 WHERE Id = $3",
-                                         inputTodo.Title.AsTypedDbParameter(),
-                                         inputTodo.IsComplete.AsTypedDbParameter(),
-                                         id.AsTypedDbParameter()) == 1
-                    ? TypedResults.NoContent()
-                    : TypedResults.NotFound();
+            return await db.ExecuteAsync(
+                "UPDATE Todos SET Title = $1, IsComplete = $2 WHERE Id = $3",
+                inputTodo.Title.AsTypedDbParameter(),
+                inputTodo.IsComplete.AsTypedDbParameter(),
+                id.AsTypedDbParameter()) == 1
+                ? TypedResults.NoContent()
+                : TypedResults.NotFound();
         })
         .WithName("UpdateTodo");
 
         group.MapPut("/{id}/mark-complete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
-            await db.ExecuteAsync("UPDATE Todos SET IsComplete = true WHERE Id = $1", id.AsTypedDbParameter()) == 1
+            await db.ExecuteAsync(
+                "UPDATE Todos SET IsComplete = true WHERE Id = $1", id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("MarkComplete");
 
         group.MapPut("/{id}/mark-incomplete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
-            await db.ExecuteAsync("UPDATE Todos SET IsComplete = false WHERE Id = $1", id.AsTypedDbParameter()) == 1
+            await db.ExecuteAsync(
+                "UPDATE Todos SET IsComplete = false WHERE Id = $1", id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("MarkIncomplete");
 
         group.MapDelete("/{id}", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
-            await db.ExecuteAsync("DELETE FROM Todos WHERE Id = $1", id.AsTypedDbParameter()) == 1
+            await db.ExecuteAsync(
+                "DELETE FROM Todos WHERE Id = $1", id.AsTypedDbParameter()) == 1
                 ? TypedResults.NoContent()
                 : TypedResults.NotFound())
         .WithName("DeleteTodo");

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -1,0 +1,99 @@
+﻿using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Npgsql;
+using TodosApi;
+
+namespace Microsoft.AspNetCore.Routing;
+
+public static class TodoApi
+{
+    public static RouteGroupBuilder MapTodoApi(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/todos");
+
+        group.WithTags("Todos");
+
+        group.MapGet("/", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos"))
+            .WithName("GetAllTodos");
+
+        group.MapGet("/complete", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = true"))
+            .WithName("GetCompleteTodos");
+
+        group.MapGet("/incomplete", (NpgsqlDataSource db) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = false"))
+            .WithName("GetIncompleteTodos");
+
+        group.MapGet("/{id:int}", async Task<Results<Ok<Todo>, NotFound>> (int id, NpgsqlDataSource db) =>
+            await db.QuerySingleAsync<Todo>("SELECT * FROM Todos WHERE Id = $1", id.AsTypedDbParameter())
+                is Todo todo
+                    ? TypedResults.Ok(todo)
+                    : TypedResults.NotFound())
+            .WithName("GetTodoById");
+
+        group.MapGet("/find", async Task<Results<Ok<Todo>, NotFound>> (string title, bool? isComplete, NpgsqlDataSource db) =>
+            await db.QuerySingleAsync<Todo>("SELECT * FROM Todos WHERE LOWER(Title) = LOWER($1) AND ($2 is NULL OR IsComplete = $2)",
+                title.AsTypedDbParameter(),
+                isComplete.AsTypedDbParameter())
+                is Todo todo
+                    ? TypedResults.Ok(todo)
+                    : TypedResults.NotFound())
+            .WithName("FindTodo");
+
+        group.MapPost("/", async Task<Results<Created<Todo>, ValidationProblem>> (Todo todo, NpgsqlDataSource db) =>
+        {
+            var createdTodo = await db.QuerySingleAsync<Todo>(
+                "INSERT INTO Todos(Title, IsComplete) Values($1, $2) RETURNING *",
+                todo.Title.AsTypedDbParameter(),
+                todo.IsComplete.AsTypedDbParameter());
+
+            return TypedResults.Created($"/todos/{createdTodo?.Id}", createdTodo);
+        })
+        .WithName("CreateTodo");
+
+        group.MapPut("/{id}", async Task<Results<NoContent, NotFound, ValidationProblem>> (int id, Todo inputTodo, NpgsqlDataSource db) =>
+        {
+            inputTodo.Id = id;
+            
+            return await db.ExecuteAsync("UPDATE Todos SET Title = $1, IsComplete = $2 WHERE Id = $3",
+                                         inputTodo.Title.AsTypedDbParameter(),
+                                         inputTodo.IsComplete.AsTypedDbParameter(),
+                                         id.AsTypedDbParameter()) == 1
+                    ? TypedResults.NoContent()
+                    : TypedResults.NotFound();
+        })
+        .WithName("UpdateTodo");
+
+        group.MapPut("/{id}/mark-complete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+            await db.ExecuteAsync("UPDATE Todos SET IsComplete = true WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                ? TypedResults.NoContent()
+                : TypedResults.NotFound())
+        .WithName("MarkComplete");
+
+        group.MapPut("/{id}/mark-incomplete", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+            await db.ExecuteAsync("UPDATE Todos SET IsComplete = false WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                ? TypedResults.NoContent()
+                : TypedResults.NotFound())
+        .WithName("MarkIncomplete");
+
+        group.MapDelete("/{id}", async Task<Results<NoContent, NotFound>> (int id, NpgsqlDataSource db) =>
+            await db.ExecuteAsync("DELETE FROM Todos WHERE Id = $1", id.AsTypedDbParameter()) == 1
+                ? TypedResults.NoContent()
+                : TypedResults.NotFound())
+        .WithName("DeleteTodo");
+
+        group.MapDelete("/delete-all", async (NpgsqlDataSource db) => TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos")))
+            .WithName("DeleteAll")
+            .RequireAuthorization(policy => policy.RequireAuthenticatedUser().RequireRole("admin"));
+
+        return group;
+    }
+}
+
+
+
+[JsonSerializable(typeof(Todo))]
+[JsonSerializable(typeof(IAsyncEnumerable<Todo>))]
+[JsonSerializable(typeof(IEnumerable<Todo>))]
+internal partial class TodoApiJsonSerializerContext : JsonSerializerContext
+{
+
+}

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -87,15 +87,14 @@ internal static class TodoApi
                 : TypedResults.NotFound())
         .WithName("DeleteTodo");
 
-        group.MapDelete("/delete-all", async (NpgsqlDataSource db, CancellationToken ct) => TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos", ct)))
+        group.MapDelete("/delete-all", async (NpgsqlDataSource db, CancellationToken ct) =>
+            TypedResults.Ok(await db.ExecuteAsync("DELETE FROM Todos", ct)))
             .WithName("DeleteAll")
             .RequireAuthorization(policy => policy.RequireAuthenticatedUser().RequireRole("admin"));
 
         return group;
     }
 }
-
-
 
 [JsonSerializable(typeof(Todo))]
 [JsonSerializable(typeof(IAsyncEnumerable<Todo>))]

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.3.23177.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.*" />
     <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -8,6 +8,7 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+    <PublishRelease>true</PublishRelease>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.3.23177.8" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
+  </ItemGroup>
+</Project>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -9,6 +9,8 @@
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <PublishRelease>true</PublishRelease>
+    <EnableLogging Condition="$(Configuration.StartsWith('Debug'))">true</EnableLogging>
+    <DefineConstants Condition=" '$(EnableLogging)' == 'true' ">$(DefineConstants);ENABLE_LOGGING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -7,8 +7,7 @@
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
-    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-    <PublishRelease>true</PublishRelease>
+    <PublishAot>true</PublishAot>
     <EnableLogging Condition="$(Configuration.StartsWith('Debug'))">true</EnableLogging>
     <DefineConstants Condition=" '$(EnableLogging)' == 'true' ">$(DefineConstants);ENABLE_LOGGING</DefineConstants>
   </PropertyGroup>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -7,7 +7,7 @@
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <InvariantGlobalization>true</InvariantGlobalization>
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
-    <PublishAot>true</PublishAot>
+    <PublishAot>false</PublishAot>
     <EnableLogging Condition="$(Configuration.StartsWith('Debug'))">true</EnableLogging>
     <DefineConstants Condition=" '$(EnableLogging)' == 'true' ">$(DefineConstants);ENABLE_LOGGING</DefineConstants>
   </PropertyGroup>

--- a/src/BenchmarksApps/TodosApi/appsettings.Development.json
+++ b/src/BenchmarksApps/TodosApi/appsettings.Development.json
@@ -4,15 +4,5 @@
       "Default": "Debug",
       "Microsoft.AspNetCore": "Debug"
     }
-  },
-  "Authentication": {
-    "Schemes": {
-      "Bearer": {
-        "ValidAudiences": [
-          "http://localhost:5054"
-        ],
-        "ValidIssuer": "dotnet-user-jwts"
-      }
-    }
   }
 }

--- a/src/BenchmarksApps/TodosApi/appsettings.Development.json
+++ b/src/BenchmarksApps/TodosApi/appsettings.Development.json
@@ -1,0 +1,18 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Debug"
+    }
+  },
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": [
+          "http://localhost:5054"
+        ],
+        "ValidIssuer": "dotnet-user-jwts"
+      }
+    }
+  }
+}

--- a/src/BenchmarksApps/TodosApi/appsettings.json
+++ b/src/BenchmarksApps/TodosApi/appsettings.json
@@ -10,7 +10,8 @@
     "Schemes": {
       "Bearer": {
         "ValidAudiences": [
-          "http://localhost:5054"
+          "http://localhost:5054",
+          "http://localhost:5000"
         ],
         "ValidIssuer": "dotnet-user-jwts"
       }

--- a/src/BenchmarksApps/TodosApi/appsettings.json
+++ b/src/BenchmarksApps/TodosApi/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": [
+          "http://localhost:5054"
+        ],
+        "ValidIssuer": "dotnet-user-jwts"
+      }
+    }
+  }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,6 +12,10 @@
 
     <!-- Repo contains only test code -->
     <EnableApiCheck>false</EnableApiCheck>
+
+    <!-- Create database build configurations -->
+    <Configurations>Debug;Release;Debug_Database;Release_Database</Configurations>
+    <IsDatabase Condition="$(Configuration.EndsWith('_Database'))">true</IsDatabase>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This adds a refactored version of the [TrimmedTodo app](https://github.com/DamianEdwards/TrimmedTodo/tree/minimalpostgres/no-jwt-swagger-validation/src/TrimmedTodo.MinimalApi.PostgreSQL) configured to align with our goals for the [native AOT "stage 2" app](https://github.com/dotnet/aspnetcore/issues/45910).

The app uses:
- Minimal APIs
- JSON serialization
- Configuration & logging
- JWT bearer authentication
- Npgsql for data access
- Exception handler middleware with problem details
- Health checks (with a check for database access and another for JWT configuration)

When published native AOT with the `-p:EnableLogging=true` property, the exe size is currently **20,135 KB** on Windows. Everything except the JWT authentication and data access works in native AOT right now, the latter will start working once the [JSON support for `IAsyncEnumerable`](https://github.com/dotnet/runtime/issues/82457) lands.

Native AOT published sizes from Crank runs:

Platform | exe size (KB)
---------- | --:
win-x64 | 28,316
linux-x64 | 31,121
