### PR TITLE
Add validation to TodosApi & workaround JSON unspeakable issue

### DIFF
--- a/src/BenchmarksApps.sln
+++ b/src/BenchmarksApps.sln
@@ -34,6 +34,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlatformBenchmarks", "BenchmarksApps\TechEmpower\PlatformBenchmarks\PlatformBenchmarks.csproj", "{ACA43671-AD28-4F72-AAAB-6C32B388C2F0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{689C58F6-8DF0-4565-887F-C9A9BDA757D8}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildPerformance", "BenchmarksApps\BuildPerformance\BuildPerformance.csproj", "{2E953AFB-4900-4B5D-9E78-819E950CD365}"
 EndProject

--- a/src/BenchmarksApps/TodosApi/DataExtensions.cs
+++ b/src/BenchmarksApps/TodosApi/DataExtensions.cs
@@ -144,6 +144,9 @@ internal static class DataExtensions
     public static Task<NpgsqlDataReader> QueryAsync(this NpgsqlCommand command, CommandBehavior commandBehavior, CancellationToken cancellationToken = default)
         => command.ExecuteReaderAsync(commandBehavior, cancellationToken);
 
+    public static Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, CancellationToken cancellationToken)
+        => ToListAsync(enumerable, null, cancellationToken);
+
     public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable, int? initialCapacity = null, CancellationToken cancellationToken = default)
     {
         var list = initialCapacity.HasValue ? new List<T>(initialCapacity.Value) : new List<T>();

--- a/src/BenchmarksApps/TodosApi/ProducesResponseTypeMetadata.cs
+++ b/src/BenchmarksApps/TodosApi/ProducesResponseTypeMetadata.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Http;
+
+internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
+{
+    private readonly IEnumerable<string> _contentTypes;
+
+    public ProducesResponseTypeMetadata(int statusCode)
+        : this(typeof(void), statusCode, Enumerable.Empty<string>())
+    {
+    }
+
+    public ProducesResponseTypeMetadata(Type type, int statusCode)
+    {
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        StatusCode = statusCode;
+        _contentTypes = Enumerable.Empty<string>();
+    }
+
+    public ProducesResponseTypeMetadata(int statusCode, string contentType)
+    {
+        StatusCode = statusCode;
+        MediaTypeHeaderValue.Parse(contentType);
+        _contentTypes = GetContentTypes(contentType, Array.Empty<string>());
+    }
+
+    public ProducesResponseTypeMetadata(Type type, int statusCode, string contentType, params string[] additionalContentTypes)
+    {
+        ArgumentNullException.ThrowIfNull(contentType);
+
+        Type = type ?? throw new ArgumentNullException(nameof(type));
+        StatusCode = statusCode;
+
+        MediaTypeHeaderValue.Parse(contentType);
+        for (var i = 0; i < additionalContentTypes.Length; i++)
+        {
+            MediaTypeHeaderValue.Parse(additionalContentTypes[i]);
+        }
+
+        _contentTypes = GetContentTypes(contentType, additionalContentTypes);
+    }
+
+    // Only for internal use where validation is unnecessary.
+    private ProducesResponseTypeMetadata(Type? type, int statusCode, IEnumerable<string> contentTypes)
+    {
+
+        Type = type;
+        StatusCode = statusCode;
+        _contentTypes = contentTypes;
+    }
+
+    /// <summary>
+    /// Gets or sets the type of the value returned by an action.
+    /// </summary>
+    public Type? Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HTTP status code of the response.
+    /// </summary>
+    public int StatusCode { get; set; }
+
+    public IEnumerable<string> ContentTypes => _contentTypes;
+
+    //internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes) => new(type, statusCode, contentTypes);
+
+    private static List<string> GetContentTypes(string contentType, string[] additionalContentTypes)
+    {
+        var contentTypes = new List<string>(additionalContentTypes.Length + 1);
+        ValidateContentType(contentType);
+        contentTypes.Add(contentType);
+        foreach (var type in additionalContentTypes)
+        {
+            ValidateContentType(type);
+            contentTypes.Add(type);
+        }
+
+        return contentTypes;
+
+        static void ValidateContentType(string type)
+        {
+            if (type.Contains('*', StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Could not parse '{type}'. Content types with wildcards are not supported.");
+            }
+        }
+    }
+}

--- a/src/BenchmarksApps/TodosApi/ProducesResponseTypeMetadata.cs
+++ b/src/BenchmarksApps/TodosApi/ProducesResponseTypeMetadata.cs
@@ -7,25 +7,6 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
 {
     private readonly IEnumerable<string> _contentTypes;
 
-    public ProducesResponseTypeMetadata(int statusCode)
-        : this(typeof(void), statusCode, Enumerable.Empty<string>())
-    {
-    }
-
-    public ProducesResponseTypeMetadata(Type type, int statusCode)
-    {
-        Type = type ?? throw new ArgumentNullException(nameof(type));
-        StatusCode = statusCode;
-        _contentTypes = Enumerable.Empty<string>();
-    }
-
-    public ProducesResponseTypeMetadata(int statusCode, string contentType)
-    {
-        StatusCode = statusCode;
-        MediaTypeHeaderValue.Parse(contentType);
-        _contentTypes = GetContentTypes(contentType, Array.Empty<string>());
-    }
-
     public ProducesResponseTypeMetadata(Type type, int statusCode, string contentType, params string[] additionalContentTypes)
     {
         ArgumentNullException.ThrowIfNull(contentType);
@@ -42,15 +23,6 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
         _contentTypes = GetContentTypes(contentType, additionalContentTypes);
     }
 
-    // Only for internal use where validation is unnecessary.
-    private ProducesResponseTypeMetadata(Type? type, int statusCode, IEnumerable<string> contentTypes)
-    {
-
-        Type = type;
-        StatusCode = statusCode;
-        _contentTypes = contentTypes;
-    }
-
     /// <summary>
     /// Gets or sets the type of the value returned by an action.
     /// </summary>
@@ -62,8 +34,6 @@ internal sealed class ProducesResponseTypeMetadata : IProducesResponseTypeMetada
     public int StatusCode { get; set; }
 
     public IEnumerable<string> ContentTypes => _contentTypes;
-
-    //internal static ProducesResponseTypeMetadata CreateUnvalidated(Type? type, int statusCode, IEnumerable<string> contentTypes) => new(type, statusCode, contentTypes);
 
     private static List<string> GetContentTypes(string contentType, string[] additionalContentTypes)
     {

--- a/src/BenchmarksApps/TodosApi/Todo.cs
+++ b/src/BenchmarksApps/TodosApi/Todo.cs
@@ -1,8 +1,9 @@
+using System.ComponentModel.DataAnnotations;
 using Npgsql;
 
 namespace TodosApi;
 
-internal sealed class Todo : IDataReaderMapper<Todo>
+internal sealed class Todo : IDataReaderMapper<Todo>, IValidatable
 {
     public int Id { get; set; }
 
@@ -20,5 +21,18 @@ internal sealed class Todo : IDataReaderMapper<Todo>
             Title = dataReader.GetString(dataReader.GetOrdinal(nameof(Title))),
             IsComplete = dataReader.GetBoolean(dataReader.GetOrdinal(nameof(IsComplete)))
         };
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (string.IsNullOrEmpty(Title))
+        {
+            yield return new ValidationResult($"A value is required for {nameof(Title)}.", new[] { nameof(Title) });
+            yield break;
+        }
+        if (DueBy.HasValue && DueBy.Value < DateOnly.FromDateTime(DateTime.UtcNow))
+        {
+            yield return new ValidationResult($"{nameof(DueBy)} cannot be in the past.", new[] { nameof(DueBy) });
+        }
     }
 }

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -13,7 +13,7 @@ internal static class TodoApi
 
         group.AddValidationFilter();
 
-        // BUG: Having to call ToListAsync() on query results until JSON support for unspeakable types is resolved
+        // BUG: Having to call ToListAsync() on query results until JSON support for unspeakable types (https://github.com/dotnet/aspnetcore/issues/47548) is resolved
 
         group.MapGet("/", (NpgsqlDataSource db, CancellationToken ct) =>
             db.QueryAsync<Todo>("SELECT * FROM Todos", ct).ToListAsync(ct))

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -11,13 +11,20 @@ internal static class TodoApi
     {
         var group = routes.MapGroup("/api/todos");
 
-        group.MapGet("/", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos", ct))
+        group.AddValidationFilter();
+
+        // BUG: Having to call ToListAsync() on query results until JSON support for unspeakable types is resolved
+
+        group.MapGet("/", (NpgsqlDataSource db, CancellationToken ct) =>
+            db.QueryAsync<Todo>("SELECT * FROM Todos", ct).ToListAsync(ct))
             .WithName("GetAllTodos");
 
-        group.MapGet("/complete", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = true", ct))
+        group.MapGet("/complete", (NpgsqlDataSource db, CancellationToken ct) =>
+            db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = true", ct).ToListAsync(ct))
             .WithName("GetCompleteTodos");
 
-        group.MapGet("/incomplete", (NpgsqlDataSource db, CancellationToken ct) => db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = false", ct))
+        group.MapGet("/incomplete", (NpgsqlDataSource db, CancellationToken ct) =>
+            db.QueryAsync<Todo>("SELECT * FROM Todos WHERE IsComplete = false", ct).ToListAsync(ct))
             .WithName("GetIncompleteTodos");
 
         group.MapGet("/{id:int}", async Task<Results<Ok<Todo>, NotFound>> (int id, NpgsqlDataSource db, CancellationToken ct) =>
@@ -39,7 +46,7 @@ internal static class TodoApi
                     : TypedResults.NotFound())
             .WithName("FindTodo");
 
-        group.MapPost("/", async Task<Results<Created<Todo>, ValidationProblem>> (Todo todo, NpgsqlDataSource db, CancellationToken ct) =>
+        group.MapPost("/", async Task<Created<Todo>> (Todo todo, NpgsqlDataSource db, CancellationToken ct) =>
         {
             var createdTodo = await db.QuerySingleAsync<Todo>(
                 "INSERT INTO Todos(Title, IsComplete) Values($1, $2) RETURNING *",
@@ -51,7 +58,7 @@ internal static class TodoApi
         })
         .WithName("CreateTodo");
 
-        group.MapPut("/{id}", async Task<Results<NoContent, NotFound, ValidationProblem>> (int id, Todo inputTodo, NpgsqlDataSource db, CancellationToken ct) =>
+        group.MapPut("/{id}", async Task<Results<NoContent, NotFound>> (int id, Todo inputTodo, NpgsqlDataSource db, CancellationToken ct) =>
         {
             inputTodo.Id = id;
             
@@ -97,8 +104,8 @@ internal static class TodoApi
 }
 
 [JsonSerializable(typeof(Todo))]
+[JsonSerializable(typeof(List<Todo>))]
 [JsonSerializable(typeof(IAsyncEnumerable<Todo>))]
-[JsonSerializable(typeof(IEnumerable<Todo>))]
 internal partial class TodoApiJsonSerializerContext : JsonSerializerContext
 {
 

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -6,8 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <LangVersion>preview</LangVersion>
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
-    <PublishAot>false</PublishAot>
+    <PublishAot>true</PublishAot>
     <EnableLogging Condition="$(Configuration.StartsWith('Debug'))">true</EnableLogging>
     <DefineConstants Condition=" '$(EnableLogging)' == 'true' ">$(DefineConstants);ENABLE_LOGGING</DefineConstants>
   </PropertyGroup>

--- a/src/BenchmarksApps/TodosApi/TodosApi.http
+++ b/src/BenchmarksApps/TodosApi/TodosApi.http
@@ -4,6 +4,11 @@
 
 # For more info on HTTP files go to https://aka.ms/vs/httpfile
 
+Get {{TodosApi_HostAddress}}/api/todos/
+Accept: application/json
+
+###
+
 Post {{TodosApi_HostAddress}}/api/todos/
 Content-Type: application/json
 Accept: application/json
@@ -12,6 +17,23 @@ Accept: application/json
 
 ###
 
-Get {{TodosApi_HostAddress}}/api/todos/
+Get {{TodosApi_HostAddress}}/api/todos/1
+Accept: application/json
+
+###
+
+Get {{TodosApi_HostAddress}}/api/todos/find
+Accept: application/json
+
+###
+
+Get {{TodosApi_HostAddress}}/throw
+Accept: application/json
+
+###
+
+Delete {{TodosApi_HostAddress}}/api/todos/delete-all
+Accept: application/json 
+Authorization: Bearer <put a JWT here>
 
 ###

--- a/src/BenchmarksApps/TodosApi/TodosApi.http
+++ b/src/BenchmarksApps/TodosApi/TodosApi.http
@@ -1,0 +1,17 @@
+@TodosApi_HostAddress = http://localhost:5054
+# Uncomment following line if sending requests to published app
+#@TodosApi_HostAddress = http://localhost:5000
+
+# For more info on HTTP files go to https://aka.ms/vs/httpfile
+
+Post {{TodosApi_HostAddress}}/api/todos/
+Content-Type: application/json
+Accept: application/json
+
+{ "title" : "Update the stage 2 app" }
+
+###
+
+Get {{TodosApi_HostAddress}}/api/todos/
+
+###

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -136,6 +136,7 @@ internal static class ValidationExtensions
                 if (validatableParametersMap?.Count > 0)
                 {
                     builder.Metadata.Add(new ValidationMetadata(validatableParametersMap.ToArray()));
+                    builder.Metadata.Add(new ProducesResponseTypeMetadata(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest, "application/problem+json"));
                     builder.FilterFactories.Add((effc, next) =>
                     {
                         var filter = new ValidationFilter(effc.ApplicationServices.GetRequiredService<ILogger<ValidationFilter>>());

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -1,0 +1,158 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace TodosApi;
+
+internal class ValidationFilter : IEndpointFilter
+{
+    private readonly ILogger<ValidationFilter> _logger;
+
+    public ValidationFilter(ILogger<ValidationFilter> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var validatableParametersMap = context.HttpContext.GetEndpoint()?.Metadata.OfType<ValidationMetadata>()
+            .FirstOrDefault()?.ValidatableParametersMap;
+
+        if (validatableParametersMap is null)
+        {
+            return next(context);
+        }
+
+        Dictionary<string, List<string>>? workingErrors = null;
+
+        foreach (var index in validatableParametersMap)
+        {
+            var validatable = context.GetArgument<IValidatableObject?>(index);
+            if (validatable is not null)
+            {
+                var requiresServices = validatable is IValidatable v && v.RequiresServiceProvider;
+                var validationContext = GetValidationContext(validatable, requiresServices ? context.HttpContext.RequestServices : null);
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Validating argument at index {index} of type {type}", index, validatable.GetType().Name);
+                }
+                var results = validatable.Validate(validationContext);
+
+                if (results.Any())
+                {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                    {
+                        _logger.LogInformation("Argument at index {index} of type {type} has validation errors", index, validatable.GetType().Name);
+                    }
+                    workingErrors ??= new();
+
+                    foreach (var result in results)
+                    {
+                        foreach (var member in result.MemberNames)
+                        {
+                            List<string>? messages;
+                            if (!workingErrors.ContainsKey(member))
+                            {
+                                messages = new();
+                                workingErrors.Add(member, messages);
+                            }
+                            else
+                            {
+                                messages = workingErrors[member];
+                            }
+                            messages.Add(result.ErrorMessage ?? "The value provided was invalid.");
+                        }
+                    }
+
+                    var errors = MapToFinalErrorsResult(workingErrors);
+                    var problem = TypedResults.ValidationProblem(errors);
+                    return ValueTask.FromResult((object?)problem);
+                }
+            }
+        }
+        return next(context);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+        Justification = "Instance type is statically represented in generic argument declared as dynamically accessing public properties.")]
+    private static ValidationContext GetValidationContext<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>
+        (TTarget instance, IServiceProvider? serviceProvider)
+        where TTarget : notnull
+    {
+        return new ValidationContext(instance, serviceProvider, null);
+    }
+
+    private static Dictionary<string, string[]> MapToFinalErrorsResult(Dictionary<string, List<string>> workingErrors)
+    {
+        var result = new Dictionary<string, string[]>(workingErrors.Count);
+
+        foreach (var fieldErrors in workingErrors)
+        {
+            if (!result.ContainsKey(fieldErrors.Key))
+            {
+                result.Add(fieldErrors.Key, fieldErrors.Value.ToArray());
+            }
+            else
+            {
+                var existingFieldErrors = result[fieldErrors.Key];
+                result[fieldErrors.Key] = existingFieldErrors.Concat(fieldErrors.Value).ToArray();
+            }
+        }
+
+        return result;
+    }
+}
+
+internal class ValidationMetadata(int[] map)
+{
+#pragma warning disable CA1822 // Mark members as static (This seems to be a bug with the analyzer not supporting primary constructors)
+    public int[] ValidatableParametersMap => map;
+#pragma warning restore CA1822
+}
+
+internal static class ValidationExtensions
+{
+    public static IEndpointConventionBuilder AddValidationFilter<TBuilder>(this TBuilder endpoint)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        endpoint.Add(static builder =>
+        {
+            if (builder.Metadata.OfType<MethodInfo>().FirstOrDefault() is { } methodInfo)
+            {
+                var parameters = methodInfo.GetParameters();
+                List<int>? validatableParametersMap = null;
+
+                for (var i = 0; i < parameters.Length; i++)
+                {
+                    var parameter = parameters[i];
+                    if (parameter.ParameterType.IsAssignableTo(typeof(IValidatableObject)))
+                    {
+                        validatableParametersMap ??= new();
+                        validatableParametersMap.Add(i);
+                    }
+                }
+
+                if (validatableParametersMap?.Count > 0)
+                {
+                    builder.Metadata.Add(new ValidationMetadata(validatableParametersMap.ToArray()));
+                    builder.FilterFactories.Add((effc, next) =>
+                    {
+                        var filter = new ValidationFilter(effc.ApplicationServices.GetRequiredService<ILogger<ValidationFilter>>());
+                        return (efic) =>
+                        {
+                            return filter.InvokeAsync(efic, next);
+                        };
+                    });
+                }
+            }
+        });
+
+        return endpoint;
+    }
+}
+
+internal interface IValidatable : IValidatableObject
+{
+    public bool RequiresServiceProvider => false;
+}

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -113,7 +113,7 @@ internal class ValidationFilter : IEndpointFilter
 
 internal class ValidationMetadata(int[] map)
 {
-#pragma warning disable CA1822 // Mark members as static (This seems to be a bug with the analyzer not supporting primary constructors)
+#pragma warning disable CA1822 // Mark members as static: BUG https://github.com/dotnet/roslyn/issues/67783
     public int[] ValidatableParametersMap => map;
 #pragma warning restore CA1822
 }

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -81,7 +81,11 @@ internal class ValidationFilter : IEndpointFilter
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
-        Justification = "Instance type is statically represented in generic argument declared as dynamically accessing public properties.")]
+        Justification = """
+                        Instance type is statically represented in generic argument TTarget and is declared as dynamically
+                        accessing public properties and no recursion into TTarget's property types (which won't be preserved)
+                        is occurring.
+                        """)]
     private static ValidationContext GetValidationContext<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>
         (TTarget instance, IServiceProvider? serviceProvider)

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -80,7 +80,7 @@ internal class ValidationFilter : IEndpointFilter
         return next(context);
     }
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = "Instance type is statically represented in generic argument declared as dynamically accessing public properties.")]
     private static ValidationContext GetValidationContext<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -83,8 +83,8 @@ internal class ValidationFilter : IEndpointFilter
     [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
         Justification = """
                         Instance type is statically represented in generic argument TTarget and is declared as dynamically
-                        accessing public properties and no recursion into TTarget's property types (which won't be preserved)
-                        is occurring.
+                        accessing public properties. This ensures the properties on TTarget are preserved. Note that recursive
+                        properties of those properties are still not preserved, but this validation doesn't recurse.
                         """)]
     private static ValidationContext GetValidationContext<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TTarget>

--- a/src/BenchmarksApps/TodosApi/ValidationFilter.cs
+++ b/src/BenchmarksApps/TodosApi/ValidationFilter.cs
@@ -113,7 +113,7 @@ internal class ValidationFilter : IEndpointFilter
 
 internal class ValidationMetadata(int[] map)
 {
-#pragma warning disable CA1822 // Mark members as static: BUG https://github.com/dotnet/roslyn/issues/67783
+#pragma warning disable CA1822 // Mark members as static: BUG https://github.com/dotnet/roslyn-analyzers/issues/6573
     public int[] ValidatableParametersMap => map;
 #pragma warning restore CA1822
 }


### PR DESCRIPTION
This makes the stage 2 TodosApi project work properly when published native AOT by working around the JSON unspeakble types issue for now. It also adds a validation filter based on `IValidatableObject` which is much easier to make native AOT friendly.

Published exe size on win-x64 is 29,528,064 bytes with these changes.