### PR TITLE
Fix NativeAOT Stage2 on Windows

### DIFF
--- a/build/benchmarks-ci-01.yml
+++ b/build/benchmarks-ci-01.yml
@@ -269,7 +269,7 @@ jobs:
   - template: nativeaot-scenarios.yml
     parameters:
       connection: ASP.NET Benchmarks Queue 3
-      arguments: "$(ciProfile) --profile intel-win-app --profile intel-lin-load "
+      arguments: "$(ciProfile) --profile intel-win-app --profile intel-lin-load --profile amd-lin2-db "
       
 # GROUP 8
 

--- a/build/benchmarks-ci-02.yml
+++ b/build/benchmarks-ci-02.yml
@@ -371,7 +371,7 @@ jobs:
   - template: crossgen2-scenarios.yml
     parameters:
       connection: ASP.NET Benchmarks Queue 1
-      arguments: "$(ciProfile) --profile arm-lin-28-app --profile amd-lin-load --profile intel-db-db "
+      arguments: "$(ciProfile) --profile arm-lin-28-app --profile amd-lin-load "
       
 - job: Crossgen_Intel_Linux
   displayName: 10- Crossgen Intel Linux

--- a/build/benchmarks-ci-02.yml
+++ b/build/benchmarks-ci-02.yml
@@ -93,13 +93,25 @@ jobs:
       connection: ASP.NET Benchmarks Queue 2
       arguments: "$(ciProfile) --profile intel-lin-app --profile intel-load-load "
       
+- job: Native_Aot_Intel_Linux
+  displayName: 2- Native Aot Intel Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Mono_Database_Intel_Linux, Mono_Database_Arm_28_Linux, GC_Intel_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: nativeaot-scenarios.yml
+    parameters:
+      connection: ASP.NET Benchmarks Queue 3
+      arguments: "$(ciProfile) --profile intel-db-app --profile amd-lin-load --profile amd-lin2-db "
+      
 # GROUP 3
 
 - job: PGO_Arm_28_Linux
   displayName: 3- PGO Arm 28 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Mono_Arm_28_Linux, Mono_Intel_Linux]
+  dependsOn: [Mono_Arm_28_Linux, Mono_Intel_Linux, Native_Aot_Intel_Linux]
   condition: succeededOrFailed()
   steps:
   - template: pgo-scenarios.yml
@@ -111,7 +123,7 @@ jobs:
   displayName: 3- Grpc Intel Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Mono_Arm_28_Linux, Mono_Intel_Linux]
+  dependsOn: [Mono_Arm_28_Linux, Mono_Intel_Linux, Native_Aot_Intel_Linux]
   condition: succeededOrFailed()
   steps:
   - template: grpc-scenarios.yml
@@ -373,25 +385,13 @@ jobs:
       connection: ASP.NET Benchmarks Queue 2
       arguments: "$(ciProfile) --profile intel-lin-app --profile intel-load-load "
       
-- job: Native_Aot_Intel_Linux
-  displayName: 10- Native Aot Intel Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Proxies_Intel_Linux, Frameworks_Arm_28_Linux, GC_Intel_Windows]
-  condition: succeededOrFailed()
-  steps:
-  - template: nativeaot-scenarios.yml
-    parameters:
-      connection: ASP.NET Benchmarks Queue 3
-      arguments: "$(ciProfile) --profile intel-load2-app --profile amd-lin2-load --profile amd-lin2-db "
-      
 # GROUP 11
 
 - job: Crossgen_Intel_Windows
   displayName: 11- Crossgen Intel Windows
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux, Native_Aot_Intel_Linux]
+  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux]
   condition: succeededOrFailed()
   steps:
   - template: crossgen2-scenarios.yml
@@ -403,7 +403,7 @@ jobs:
   displayName: 11- Crossgen Amd Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux, Native_Aot_Intel_Linux]
+  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux]
   condition: succeededOrFailed()
   steps:
   - template: crossgen2-scenarios.yml
@@ -415,7 +415,7 @@ jobs:
   displayName: 11- HttpClient Intel Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux, Native_Aot_Intel_Linux]
+  dependsOn: [Crossgen_Arm_28_Linux, Crossgen_Intel_Linux]
   condition: succeededOrFailed()
   steps:
   - template: httpclient-scenarios.yml

--- a/build/benchmarks.matrix.01.yml
+++ b/build/benchmarks.matrix.01.yml
@@ -159,6 +159,7 @@ groups:
       profiles:
       - intel-win-app 
       - intel-lin-load
+      - amd-lin2-db
 
   - jobs:
 

--- a/build/benchmarks.matrix.02.yml
+++ b/build/benchmarks.matrix.02.yml
@@ -207,7 +207,6 @@ groups:
       profiles:
       - arm-lin-28-app 
       - amd-lin-load
-      - intel-db-db
 
     - name: Crossgen Intel Linux
       template: crossgen2-scenarios.yml

--- a/build/benchmarks.matrix.02.yml
+++ b/build/benchmarks.matrix.02.yml
@@ -46,7 +46,14 @@ groups:
       profiles:
       - intel-lin-app 
       - intel-load-load
-      
+
+    - name: Native Aot Intel Linux
+      template: nativeaot-scenarios.yml
+      profiles:
+      - intel-db-app
+      - amd-lin-load
+      - amd-lin2-db
+
   - jobs:
 
     - name: PGO Arm 28 Linux
@@ -207,13 +214,6 @@ groups:
       profiles:
       - intel-lin-app 
       - intel-load-load
-
-    - name: Native Aot Intel Linux
-      template: nativeaot-scenarios.yml
-      profiles:
-      - intel-load2-app
-      - amd-lin2-load
-      - amd-lin2-db
 
   - jobs:
 

--- a/build/ci.profile.yml
+++ b/build/ci.profile.yml
@@ -31,7 +31,7 @@ profiles:
 
   intel-lin-load:
     variables:
-      secondaryAddress: 10.0.0.105
+      secondaryAddress: 10.0.0.102
     agents:
       load:
         endpoints: 
@@ -76,7 +76,7 @@ profiles:
 
   intel-db-load:
     variables:
-      secondaryAddress: 10.0.0.105
+      secondaryAddress: 10.0.0.103
     agents:
       load:
         endpoints: 


### PR DESCRIPTION
Stage2 on Windows is currently failing `Could not find an agent named 'db'.` This is because we aren't adding a db profile for Windows. Adding the db profile used by Linux.