### PR TITLE
Fix NativeAOT Linux runs

### DIFF
--- a/build/ci.profile.yml
+++ b/build/ci.profile.yml
@@ -62,6 +62,17 @@ profiles:
           - warmup
           - secondary
 
+  intel-db-app:
+    variables:
+      serverAddress: 10.0.0.103
+      cores: 28
+    agents:
+      application:
+        endpoints: 
+          - http://asp-citrine-db:5001
+        aliases:
+          - main
+
   intel-db-db:
     variables:
       databaseServer: 10.0.0.103


### PR DESCRIPTION
Getting error "Could not find a profile named 'intel-db-app'."

Fix by adding an intel-db-app profile.