### PR TITLE
Bump Npgsql to 8.0.0-preview.3

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -30,7 +30,7 @@
 
     <NpgsqlVersion50>5.0.5</NpgsqlVersion50>
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>
-    <NpgsqlVersion80>8.0.0-preview.2</NpgsqlVersion80>
+    <NpgsqlVersion80>8.0.0-preview.3</NpgsqlVersion80>
 
     <MicrosoftDataSqlClientVersion60>4.0.0</MicrosoftDataSqlClientVersion60>
     <MicrosoftDataSqlClientVersion80>5.1.0</MicrosoftDataSqlClientVersion80>
@@ -42,7 +42,7 @@
     <NpgsqlEntityFrameworkCorePostgreSQLVersion31>3.1.18</NpgsqlEntityFrameworkCorePostgreSQLVersion31>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion50>5.0.10</NpgsqlEntityFrameworkCorePostgreSQLVersion50>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.8</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion80>8.0.0-preview.2</NpgsqlEntityFrameworkCorePostgreSQLVersion80>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion80>8.0.0-preview.3</NpgsqlEntityFrameworkCorePostgreSQLVersion80>
 
     <PomeloEntityFrameworkCoreMySqlVersion20>2.0.1</PomeloEntityFrameworkCoreMySqlVersion20>
     <PomeloEntityFrameworkCoreMySqlVersion21>2.1.4</PomeloEntityFrameworkCoreMySqlVersion21>
@@ -57,7 +57,7 @@
     <MicrosoftEntityFrameworkCoreSqlServerVersion31>3.1.32</MicrosoftEntityFrameworkCoreSqlServerVersion31>
     <MicrosoftEntityFrameworkCoreSqlServerVersion50>5.0.17</MicrosoftEntityFrameworkCoreSqlServerVersion50>
     <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.14</MicrosoftEntityFrameworkCoreSqlServerVersion60>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion80>8.0.0-preview.1.23111.4</MicrosoftEntityFrameworkCoreSqlServerVersion80>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion80>8.0.0-preview.3.23174.2</MicrosoftEntityFrameworkCoreSqlServerVersion80>
 
     <MicrosoftEntityFrameworkCoreSqliteVersion21>2.1.14</MicrosoftEntityFrameworkCoreSqliteVersion21>
     <MicrosoftEntityFrameworkCoreSqliteVersion22>2.2.6</MicrosoftEntityFrameworkCoreSqliteVersion22>
@@ -65,7 +65,7 @@
     <MicrosoftEntityFrameworkCoreSqliteVersion31>3.1.32</MicrosoftEntityFrameworkCoreSqliteVersion31>
     <MicrosoftEntityFrameworkCoreSqliteVersion50>5.0.17</MicrosoftEntityFrameworkCoreSqliteVersion50>
     <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.14</MicrosoftEntityFrameworkCoreSqliteVersion60>
-    <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.1.23111.4</MicrosoftEntityFrameworkCoreSqliteVersion80>
+    <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.3.23174.2</MicrosoftEntityFrameworkCoreSqliteVersion80>
 
     <MicrosoftAspNetCoreAppPackageVersion80>8.0.0-preview.3.23177.8</MicrosoftAspNetCoreAppPackageVersion80>
   </PropertyGroup>

--- a/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
+++ b/src/BenchmarksApps/TechEmpower/BlazorUnited/BlazorUnited.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-preview.2.23128.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0-preview.3.23174.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.3" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="RazorSlices" Version="0.4.0" />
   </ItemGroup>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.2" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.3" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.2" />
+    <PackageReference Include="Npgsql" Version="8.0.0-preview.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
| db                  | before  | after   |        |
| ------------------- | ------- | ------- | ------ |
| CPU Usage (%)       |      35 |      35 |  0.00% |
| Cores usage (%)     |     978 |     970 | -0.82% |
| Working Set (MB)    |      54 |      54 |  0.00% |
| Build Time (ms)     |   1,182 |   1,149 | -2.79% |
| Start Time (ms)     |   1,201 |   1,113 | -7.33% |
| Published Size (KB) | 369,869 | 369,869 |  0.00% |


| application           | before                     | after                      |         |
| --------------------- | -------------------------- | -------------------------- | ------- |
| CPU Usage (%)         |                         96 |                         95 |  -1.04% |
| Cores usage (%)       |                      2,698 |                      2,666 |  -1.19% |
| Working Set (MB)      |                        568 |                        566 |  -0.35% |
| Private Memory (MB)   |                      1,324 |                      1,322 |  -0.15% |
| Build Time (ms)       |                     11,817 |                      6,657 | -43.67% |
| Start Time (ms)       |                      1,916 |                      1,881 |  -1.83% |
| Published Size (KB)   |                     95,765 |                     95,768 |  +0.00% |
| Symbols Size (KB)     |                         54 |                         54 |   0.00% |
| .NET Core SDK Version | 8.0.100-preview.4.23224.11 | 8.0.100-preview.4.23224.11 |         |


| load                   | before    | after     |        |
| ---------------------- | --------- | --------- | ------ |
| CPU Usage (%)          |        38 |        38 |  0.00% |
| Cores usage (%)        |     1,070 |     1,056 | -1.31% |
| Working Set (MB)       |        48 |        48 |  0.00% |
| Private Memory (MB)    |       363 |       363 |  0.00% |
| Start Time (ms)        |         0 |         0 |        |
| First Request (ms)     |       121 |       123 | +1.65% |
| Requests/sec           |   447,705 |   442,244 | -1.22% |
| Requests               | 6,760,029 | 6,677,935 | -1.21% |
| Mean latency (ms)      |      1.21 |      1.21 |  0.00% |
| Max latency (ms)       |     21.40 |     20.86 | -2.52% |
| Bad responses          |         0 |         0 |        |
| Socket errors          |         0 |         0 |        |
| Read throughput (MB/s) |    587.50 |    580.34 | -1.22% |
| Latency 50th (ms)      |      1.07 |      1.08 | +0.93% |
| Latency 75th (ms)      |      1.33 |      1.34 | +0.75% |
| Latency 90th (ms)      |      1.69 |      1.70 | +0.59% |
| Latency 99th (ms)      |      4.60 |      4.50 | -2.17% |