### PR TITLE
Respond to latest SlimBuilder changes in BasicGrpc

### DIFF
--- a/src/BenchmarksApps/Grpc/BasicGrpc/Program.cs
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/Program.cs
@@ -1,18 +1,9 @@
-using System.Text;
 using BasicGrpc.Services;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 var builder = WebApplication.CreateSlimBuilder(args);
-// No logging for benchmark scenario, template has AddConsole();
+builder.Logging.ClearProviders();
 
 builder.Services.AddGrpc();
-builder.WebHost.ConfigureKestrel(options =>
-{
-    options.ConfigureEndpointDefaults(listenOptions =>
-    {
-        listenOptions.Protocols = HttpProtocols.Http2;
-    });
-});
 
 var app = builder.Build();
 

--- a/src/BenchmarksApps/Grpc/BasicGrpc/Properties/launchSettings.json
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "BasicGrpc": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:55262",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/BenchmarksApps/Grpc/BasicGrpc/appsettings.Development.json
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/BenchmarksApps/Grpc/BasicGrpc/appsettings.json
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
- Add appsettings
- Clear logging providers
- Add launchSettings

The BasicGrpc RPS took a dive due to console logging getting enabled.

![image](https://user-images.githubusercontent.com/8291187/234985737-189265f5-2dc1-4d76-a3da-79b08692a300.png)
