### PR TITLE
Use .NET 8 SDK to build YARP .NET 7 runs

### DIFF
--- a/build/proxies-scenarios.yml
+++ b/build/proxies-scenarios.yml
@@ -30,7 +30,7 @@ parameters:
     condition: 'true'
   - displayName: YARP-net70
     scenario: proxy-yarp
-    arguments: $(proxyJobs) --property proxy=yarp-net70 --application.framework net7.0
+    arguments: $(proxyJobs) --property proxy=yarp-net70 --application.framework net7.0 --application.sdkVersion 8.0.100-preview.4.23221.1
     supportsHttp: true
     supportsServerHttps: true
     supportsServerHttp2: true


### PR DESCRIPTION
@sebastienros do we have a better way of saying "use the latest SDK, but X runtime version"?

The SDK version I hardcoded is the one YARP is [currently targeting](https://github.com/microsoft/reverse-proxy/blob/763871adcdc04fe059080d0dc4ef0c66b9f16b7d/global.json#LL3C17-L3C42).