### PR TITLE
Update to latest RazorSlices & Nanorm

### DIFF
--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="RazorSlices" Version="0.6.0" />
+    <PackageReference Include="RazorSlices" Version="0.6.1" />
   </ItemGroup>
 
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="RazorSlices" Version="0.5.0" />
+    <PackageReference Include="RazorSlices" Version="0.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="RazorSlices" Version="0.5.0" />
+    <PackageReference Include="RazorSlices" Version="0.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'net8.0'">

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="RazorSlices" Version="0.6.0" />
+    <PackageReference Include="RazorSlices" Version="0.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'net8.0'">

--- a/src/BenchmarksApps/TodosApi/DatabaseInitializer.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseInitializer.cs
@@ -41,7 +41,7 @@ internal class DatabaseInitializer : IHostedService
             _logger.LogInformation("Ensuring database exists and is up to date");
         }
 
-        var sql = $"""
+        const string sql = $"""
                 CREATE TABLE IF NOT EXISTS public.todos
                 (
                     {nameof(Todo.Id)} SERIAL PRIMARY KEY,

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.4.23260.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-preview.4.23259.5" />
     <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
-    <PackageReference Include="Nanorm.Npgsql" Version="0.0.4" />
+    <PackageReference Include="Nanorm.Npgsql" Version="0.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.0-preview.4.23260.4">
       <PrivateAssets>all</PrivateAssets>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -32,8 +32,6 @@
 
   <ItemGroup>
     <Content Update="appSettings.Development.json" CopyToPublishDirectory="false" />
-    <!-- Workaround for https://github.com/dotnet/aspnetcore/issues/47941 -->
-    <IlcArg Include="--nopreinitstatics" />
   </ItemGroup>
 
   <Import Project="..\AspNetCore.OpenApi\build\AspNetCore.OpenApi.targets" />

--- a/src/BenchmarksApps/TodosApi/TodosApi.http
+++ b/src/BenchmarksApps/TodosApi/TodosApi.http
@@ -9,6 +9,16 @@ Accept: application/json
 
 ###
 
+Get {{TodosApi_HostAddress}}/api/todos/incomplete
+Accept: application/json
+
+###
+
+Get {{TodosApi_HostAddress}}/api/todos/complete
+Accept: application/json
+
+###
+
 Post {{TodosApi_HostAddress}}/api/todos/
 Content-Type: application/json
 Accept: application/json
@@ -17,7 +27,30 @@ Accept: application/json
 
 ###
 
-Get {{TodosApi_HostAddress}}/api/todos/1
+Get {{TodosApi_HostAddress}}/api/todos/619
+Accept: application/json
+
+###
+
+Put {{TodosApi_HostAddress}}/api/todos/619
+Content-Type: application/json
+Accept: application/json
+
+{ "title" : "Update the stage 2 app - changed" }
+
+###
+
+Put {{TodosApi_HostAddress}}/api/todos/619/mark-complete
+Accept: application/json
+
+###
+
+Put {{TodosApi_HostAddress}}/api/todos/619/mark-incomplete
+Accept: application/json
+
+###
+
+Delete {{TodosApi_HostAddress}}/api/todos/619
 Accept: application/json
 
 ###


### PR DESCRIPTION
Should fix current Platform benchmarks breaks. Verified with remote run using this branch. Fortunes perf improvements as a bonus 🚀 

Partially addresses #1851

| load                   | platform_fortunes_razor_slices_0.4 | platform_fortunes_RazorSlices_0.6.1 |         |
| ---------------------- | ---------------------------------- | ----------------------------------- | ------- |
| CPU Usage (%)          |                                 39 |                                  41 |  +5.13% |
| Cores usage (%)        |                              1,079 |                               1,151 |  +6.67% |
| Working Set (MB)       |                                 48 |                                  48 |   0.00% |
| Private Memory (MB)    |                                363 |                                 363 |   0.00% |
| Start Time (ms)        |                                  0 |                                   0 |         |
| First Request (ms)     |                                114 |                                 108 |  -5.26% |
| Requests/sec           |                            457,471 |                             498,120 |  +8.89% |
| Requests               |                          6,907,390 |                           7,521,265 |  +8.89% |
| Mean latency (ms)      |                               1.18 |                                1.08 |  -8.47% |
| Max latency (ms)       |                              23.69 |                               19.69 | -16.88% |
| Bad responses          |                                  0 |                                   0 |         |
| Socket errors          |                                  0 |                                   0 |         |
| Read throughput (MB/s) |                             601.63 |                              653.66 |  +8.65% |
| Latency 50th (ms)      |                               1.05 |                                0.96 |  -8.57% |
| Latency 75th (ms)      |                               1.30 |                                1.17 | -10.00% |
| Latency 90th (ms)      |                               1.63 |                                1.47 |  -9.82% |
| Latency 99th (ms)      |                               4.38 |                                4.23 |  -3.42% |