### PR TITLE
Update Blazor SSR fortunes benchmark to use MapRazorComponents<App>

### DIFF
--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/App.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/App.razor
@@ -1,6 +1,4 @@
-﻿@implements IRazorComponentApplication<App>
-
-<Router AppAssembly="@typeof(App).Assembly">
+﻿<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" />
     </Found>

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/App.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/App.razor
@@ -1,0 +1,10 @@
+﻿@implements IRazorComponentApplication<App>
+
+<Router AppAssembly="@typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        not found
+    </NotFound>
+</Router>

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/Fortunes.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/Fortunes.razor
@@ -1,4 +1,5 @@
-﻿@inject Db Db
+﻿@page "/fortunes"
+@inject Db Db
 <!DOCTYPE html>
 <html>
 <head>

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/FortunesEf.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Components/FortunesEf.razor
@@ -1,4 +1,5 @@
-﻿@using Microsoft.EntityFrameworkCore;
+﻿@page "/fortunes-ef"
+@using Microsoft.EntityFrameworkCore;
 @inject Db Db
 @inject AppDbContext DbContext
 <!DOCTYPE html>

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddSingleton(new Db(appSettings));
 builder.Services.AddRazorComponents();
 builder.Services.AddSingleton(serviceProvider =>
 {
+    // TODO: This custom configured HtmlEncoder won't actually be used until Blazor supports it: https://github.com/dotnet/aspnetcore/issues/47477
     var settings = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Katakana, UnicodeRanges.Hiragana);
     settings.AllowCharacter('\u2014'); // allow EM DASH through
     return HtmlEncoder.Create(settings);
@@ -32,18 +33,9 @@ builder.Services.AddSingleton(serviceProvider =>
 
 var app = builder.Build();
 
-app.MapGet("/fortunes", () => new RazorComponentResult<Fortunes>());
-app.MapGet("/fortunes-ef", () => new RazorComponentResult<FortunesEf>());
+app.MapRazorComponents<App>();
 
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
 app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));
 
 app.Run();
-
-// TODO: Use this custom configured HtmlEncoder when Blazor supports it: https://github.com/dotnet/aspnetcore/issues/47477
-//static HtmlEncoder CreateHtmlEncoder()
-//{
-//    var settings = new TextEncoderSettings(UnicodeRanges.BasicLatin, UnicodeRanges.Katakana, UnicodeRanges.Hiragana);
-//    settings.AllowCharacter('\u2014'); // allow EM DASH through
-//    return HtmlEncoder.Create(settings);
-//}

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Program.cs
@@ -35,6 +35,9 @@ var app = builder.Build();
 
 app.MapRazorComponents<App>();
 
+app.MapGet("/direct/fortunes", () => new RazorComponentResult<Fortunes>());
+app.MapGet("/direct/fortunes-ef", () => new RazorComponentResult<FortunesEf>());
+
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
 app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));
 

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Properties/launchSettings.json
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Properties/launchSettings.json
@@ -4,6 +4,7 @@
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "fortunes",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/_Imports.razor
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/_Imports.razor
@@ -1,2 +1,10 @@
-﻿@using BlazorSSR.Database
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using BlazorSSR
+@using BlazorSSR.Database
 @using BlazorSSR.Models


### PR DESCRIPTION
This is the idiomatic approach for Blazor SSR apps. Kept the direct-rendering approach via `RazorComponentResult<T>` at different endpoint URLs to allow for comparisons.