### PR TITLE
Fix TechEmpower PlatformBenchmarks in AOT

### DIFF
--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -32,7 +32,8 @@ parameters:
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
   - displayName: AOT
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    # workaround https://github.com/dotnet/runtime/issues/86654 by disabling ConfigurationBindingGenerator
+    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" /p:EnableConfigurationBindingGenerator=false
 
 steps:
 - ${{ each s in parameters.scenarios }}:

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.Fortunes.cs
@@ -10,6 +10,7 @@ namespace PlatformBenchmarks
 {
     public partial class BenchmarkApplication
     {
+#if DATABASE
         private async Task FortunesRaw(PipeWriter pipeWriter)
         {
             await OutputFortunes(
@@ -75,5 +76,6 @@ namespace PlatformBenchmarks
             ReturnChunkedWriter(chunkedWriter);
             template.Dispose();
         }
+#endif
     }
 }

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.cs
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/BenchmarkApplication.cs
@@ -56,9 +56,11 @@ namespace PlatformBenchmarks
             }
         }
 
+#if DATABASE
         private readonly static SliceFactory<List<FortuneUtf8>> FortunesTemplateFactory = RazorSlice.ResolveSliceFactory<List<FortuneUtf8>>("/Templates/FortunesUtf8.cshtml");
         private readonly static SliceFactory<List<FortuneUtf16>> FortunesDapperTemplateFactory = RazorSlice.ResolveSliceFactory<List<FortuneUtf16>>("/Templates/FortunesUtf16.cshtml");
         private readonly static SliceFactory<List<FortuneEf>> FortunesEfTemplateFactory = RazorSlice.ResolveSliceFactory<List<FortuneEf>>("/Templates/FortunesEf.cshtml");
+#endif
 
         [ThreadStatic]
         private static Utf8JsonWriter t_writer;


### PR DESCRIPTION
Ensure RazorSlices aren't initialized during the static constructor. Disable ConfigurationBinderGenerator since it generates code that doesn't compile.