### PR TITLE
Add an Alpine Flavor for TE Performance Tests

### DIFF
--- a/build/containers-scenarios.yml
+++ b/build/containers-scenarios.yml
@@ -50,31 +50,31 @@ parameters:
 
   - displayName: Json ASP.NET
     arguments: --scenario json_aspnet --property scenario=JsonAspNet
-    condition: Math.round(Date.now() / 43200000) % 3 == 0 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 0 # once every 4 half-days
   - displayName: Fortunes ASP.NET
     arguments: --scenario fortunes_aspnet --property scenario=FortunesAspNet
-    condition: Math.round(Date.now() / 43200000) % 3 == 0 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 0 # once every 4 half-days
 
   - displayName: Json ASP.NET Alpine
     arguments: --scenario json_aspnet_alpine --property scenario=JsonAspNetAlpine
-    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 1 # once every 4 half-days
   - displayName: Fortunes ASP.NET Alpine
     arguments: --scenario fortunes_aspnet_alpine --property scenario=FortunesAspNetAlpine
-    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 1 # once every 4 half-days
 
   - displayName: Json ASP.NET Composite
     arguments: --scenario json_aspnet_composite --property scenario=JsonAspNetComposite
-    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 2 # once every 3 half-days
   - displayName: Fortunes ASP.NET Composite
     arguments: --scenario fortunes_aspnet_composite --property scenario=FortunesAspNetComposite
-    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 2 # once every 4 half-days
 
   - displayName: Json ASP.NET 7.0
     arguments: --scenario json_aspnet_net7 --property scenario=JsonAspNet70
-    condition: Math.round(Date.now() / 43200000) % 3 == 2 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 3 # once every 4 half-days
   - displayName: Fortunes ASP.NET 7.0
     arguments: --scenario fortunes_aspnet_net7 --property scenario=FortunesAspNet70
-    condition: Math.round(Date.now() / 43200000) % 3 == 2 # once every 3 half-days
+    condition: Math.round(Date.now() / 43200000) % 4 == 3 # once every 4 half-days
 
   - displayName: Json Actix
     arguments: --scenario json_actix --property scenario=JsonActix

--- a/build/containers-scenarios.yml
+++ b/build/containers-scenarios.yml
@@ -55,6 +55,13 @@ parameters:
     arguments: --scenario fortunes_aspnet --property scenario=FortunesAspNet
     condition: Math.round(Date.now() / 43200000) % 3 == 0 # once every 3 half-days
 
+  - displayName: Json ASP.NET Alpine
+    arguments: --scenario json_aspnet_alpine --property scenario=JsonAspNetAlpine
+    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+  - displayName: Fortunes ASP.NET Alpine
+    arguments: --scenario fortunes_aspnet_alpine --property scenario=FortunesAspNetAlpine
+    condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days
+
   - displayName: Json ASP.NET Composite
     arguments: --scenario json_aspnet_composite --property scenario=JsonAspNetComposite
     condition: Math.round(Date.now() / 43200000) % 3 == 1 # once every 3 half-days

--- a/docker/container-matrix/Middleware-alpine.dockerfile
+++ b/docker/container-matrix/Middleware-alpine.dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/nightly/sdk:latest AS build
+WORKDIR /app
+COPY . .
+RUN dotnet publish src/Benchmarks/Benchmarks.csproj -c Release -o out -f net8.0 -p:BenchmarksTargetFramework=net8.0 -p:MicrosoftAspNetCoreAppPackageVersion=$ASPNET_VERSION
+
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-preview-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+
+ENTRYPOINT ["dotnet", "Benchmarks.dll" ]
+

--- a/scenarios/containers.benchmarks.yml
+++ b/scenarios/containers.benchmarks.yml
@@ -36,6 +36,20 @@ scenarios:
         path: /json
         serverPort: 8080
 
+  json_aspnet_alpine:
+    application:
+      job: aspnet
+      source:
+        dockerFile: docker/container-matrix/Middleware-alpine.dockerfile
+      variables:
+        scenario: json
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /json
+        serverPort: 8080
+
   json_aspnet_composite:
     application:
       job: aspnet
@@ -55,6 +69,22 @@ scenarios:
       job: postgresql
     application:
       job: aspnet
+      variables:
+        scenario: dbfortunesraw
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes/raw
+        serverPort: 8080
+
+  fortunes_aspnet_alpine:
+    db:
+      job: postgresql
+    application:
+      job: aspnet
+      source:
+        dockerFile: docker/container-matrix/Middleware-alpine.dockerfile
       variables:
         scenario: dbfortunesraw
     load:


### PR DESCRIPTION
This PR follows up on PR #1854. Now that the composite images are up and running, it is ideal to be able to compare them to non-composites on equal grounds. So, this PR enables tests using the non-composite Alpine image so that we can compare and analyze against the composites, which are also built on Alpine.