### PR TITLE
Fix NativeAOT ServerGC benchmarks

### DIFF
--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -37,7 +37,7 @@ parameters:
 
   - displayName: Goldilocks Stage 1 (NativeAOT - Server GC)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    arguments: --scenario basicminimalapipublishaot $(goldilocksJobs) --property scenario=Stage1AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    arguments: --scenario basicminimalapipublishaot $(goldilocksJobs) --property scenario=Stage1AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_GCDynamicAdaptationMode=0
     condition: 'true'
 
   - displayName: Goldilocks Stage 1 (NativeAOT - Workstation GC)
@@ -73,7 +73,7 @@ parameters:
 
   - displayName: Goldilocks Stage 2 (NativeAOT - Server GC)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    arguments: --scenario todosapipublishaot $(goldilocksJobs) --property scenario=Stage2AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    arguments: --scenario todosapipublishaot $(goldilocksJobs) --property scenario=Stage2AotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_GCDynamicAdaptationMode=0
     condition: 'true'
 
   - displayName: Goldilocks Stage 2 (NativeAOT - Workstation GC)
@@ -109,7 +109,7 @@ parameters:
 
   - displayName: Goldilocks gRPC Stage 1 (NativeAOT - Server GC)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    arguments: --scenario basicgrpcpublishaot $(goldilocksJobs) --property scenario=Stage1GrpcAotServerGC --property publish=nativeaot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\" --application.environmentVariables DOTNET_GCDynamicAdaptationMode=0
     condition: 'true'
 
   - displayName: Goldilocks gRPC Stage 1 (NativeAOT - Workstation GC)


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/33309 enables GarbageCollectionAdaptationMode=1 by default for ASP.NET Native AOT apps that use ServerGarbageCollection. Our Server GC benchmarks want to use the "normal" Server GC, so explicitly set the environment variable so they aren't using the adaptive mode.