### PR TITLE
Enable configuration binding generator in TodosApi app

### DIFF
--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -32,8 +32,7 @@ parameters:
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
   - displayName: AOT
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.Dotnet.ILCompiler version
-    # workaround https://github.com/dotnet/runtime/issues/86654 by disabling ConfigurationBindingGenerator
-    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true /p:EnableConfigurationBindingGenerator=false\" --property mode=Aot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot --application.packageReferences \"Microsoft.Dotnet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
 
 steps:
 - ${{ each s in parameters.scenarios }}:

--- a/src/BenchmarksApps/TodosApi/AppSettings.cs
+++ b/src/BenchmarksApps/TodosApi/AppSettings.cs
@@ -33,22 +33,10 @@ internal static class AppSettingsExtensions
 {
     public static IServiceCollection ConfigureAppSettings(this IServiceCollection services, IConfigurationRoot configurationRoot, IHostEnvironment hostEnvironment)
     {
-        // Can't use the configuration binding source generator due to bug where it emits non-compiling code right now
-        // https://github.com/dotnet/runtime/issues/83600
-        var optionsBuilder = services.Configure<AppSettings>(configurationRoot.GetSection(nameof(AppSettings)))
-            .AddOptions<AppSettings>();
-
-        if (!hostEnvironment.IsBuild())
-        {
-            services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>();
-            optionsBuilder.ValidateOnStart();
-        }
-
-        // Change to using BindConfiguration once https://github.com/dotnet/runtime/issues/83600 is complete
-        //services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>()
-        //    .AddOptions<AppSettings>()
-        //    .BindConfiguration(nameof(AppSettings))
-        //    .ValidateOnStart();
+        services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>()
+            .AddOptions<AppSettings>()
+            .BindConfiguration(nameof(AppSettings))
+            .ValidateOnStart();
 
         // Change to using ValidateDataAnnotations once https://github.com/dotnet/runtime/issues/77412 is complete
         //services.AddOptions<AppSettings>()

--- a/src/BenchmarksApps/TodosApi/AppSettings.cs
+++ b/src/BenchmarksApps/TodosApi/AppSettings.cs
@@ -33,10 +33,14 @@ internal static class AppSettingsExtensions
 {
     public static IServiceCollection ConfigureAppSettings(this IServiceCollection services, IConfigurationRoot configurationRoot, IHostEnvironment hostEnvironment)
     {
-        services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>()
-            .AddOptions<AppSettings>()
-            .BindConfiguration(nameof(AppSettings))
-            .ValidateOnStart();
+        var optionsBuilder = services.AddOptions<AppSettings>()
+            .BindConfiguration(nameof(AppSettings));
+
+        if (!hostEnvironment.IsBuild())
+        {
+            services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>();
+            optionsBuilder.ValidateOnStart();
+        }
 
         // Change to using ValidateDataAnnotations once https://github.com/dotnet/runtime/issues/77412 is complete
         //services.AddOptions<AppSettings>()

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -10,8 +10,6 @@
     <PublishAot>true</PublishAot>
     <OpenApiDocumentsDirectory>.\</OpenApiDocumentsDirectory>
     <!--<OpenApiEnabled>false</OpenApiEnabled>-->
-    <!-- Don't use configuration binding generator until bug is fixed: https://github.com/dotnet/runtime/issues/83600 -->
-    <EnableConfigurationBindingGenerator>false</EnableConfigurationBindingGenerator>
     <EnableLogging Condition=" '$(EnableLogging)' == '' and $(Configuration.StartsWith('Debug')) ">true</EnableLogging>
     <DefineConstants Condition=" '$(EnableLogging)' == 'true' ">$(DefineConstants);ENABLE_LOGGING</DefineConstants>
   </PropertyGroup>
@@ -19,7 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore.OpenApi\AspNetCore.OpenApi.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.5.23302.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-preview.5.23280.8" />
     <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
     <PackageReference Include="Nanorm.Npgsql" Version="0.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
<details>
<summary>Generated code (click to view)</summary>

```cs
// <auto-generated/>
#nullable enable

/// <summary>Generated helper providing an AOT and linking compatible implementation for configuration binding.</summary>
internal static class GeneratedOptionsBuilderBinder
{
    /// <summary>Registers the dependency injection container to bind <typeparamref name="TOptions"/> against the <see cref="global::Microsoft.Extensions.Configuration.IConfiguration"/> obtained from the DI service provider.</summary>
    public static global::Microsoft.Extensions.Options.OptionsBuilder<TOptions> BindConfiguration<TOptions>(this global::Microsoft.Extensions.Options.OptionsBuilder<TOptions> optionsBuilder, string configSectionPath, global::System.Action<global::Microsoft.Extensions.Configuration.BinderOptions>? configureOptions = null) where TOptions : class
    {
        if (optionsBuilder is null)
        {
            throw new global::System.ArgumentNullException(nameof(optionsBuilder));
        }

        if (configSectionPath is null)
        {
            throw new global::System.ArgumentNullException(nameof(configSectionPath));
        }

        optionsBuilder.Configure<global::Microsoft.Extensions.Configuration.IConfiguration>((obj, configuration) =>
        {
            global::Microsoft.Extensions.Configuration.IConfiguration section = string.Equals(string.Empty, configSectionPath, global::System.StringComparison.OrdinalIgnoreCase) ? configuration : configuration.GetSection(configSectionPath);
            global::Microsoft.Extensions.Configuration.Binder.SourceGeneration.CoreBindingHelper.BindCoreUntyped(section, obj, typeof(TOptions), configureOptions);
        });

        global::Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<global::Microsoft.Extensions.Options.IOptionsChangeTokenSource<TOptions>, global::Microsoft.Extensions.Options.ConfigurationChangeTokenSource<TOptions>>(optionsBuilder.Services);
        return optionsBuilder;
    }
}

namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
{
    using Microsoft.Extensions.Configuration;
    using Microsoft.Extensions.DependencyInjection;
    using System;
    using System.Collections.Generic;
    using System.Globalization;
    using TodosApi;

    /// <summary>Provide core binding logic.</summary>
    internal static class CoreBindingHelper
    {
        public static void BindCoreUntyped(this IConfiguration configuration, object obj, Type type, Action<BinderOptions>? configureOptions)
        {
            if (configuration is null)
            {
                throw new ArgumentNullException(nameof(configuration));
            }

            BinderOptions? binderOptions = GetBinderOptions(configureOptions);

            if (!HasValueOrChildren(configuration))
            {
                return;
            }

            if (type == typeof(AppSettings))
            {
                var temp = (AppSettings)obj;
                BindCore(configuration, ref temp, binderOptions);
                return;
            }

            throw new global::System.NotSupportedException($"Unable to bind to type '{type}': generator did not detect the type as input.");
        }

        public static void BindCore(IConfiguration configuration, ref AppSettings obj, BinderOptions? binderOptions)
        {
            if (obj is null)
            {
                throw new ArgumentNullException(nameof(obj));
            }

            List<string>? temp = null;
            foreach (IConfigurationSection section in configuration.GetChildren())
            {
                switch (section.Key)
                {
                    case "ConnectionString":
                        {
                            obj.ConnectionString = configuration["ConnectionString"]!;
                        }
                        break;
                    case "JwtSigningKey":
                        {
                            obj.JwtSigningKey = configuration["JwtSigningKey"]!;
                        }
                        break;
                    case "SuppressDbInitialization":
                        {
                            if (configuration["SuppressDbInitialization"] is string stringValue3)
                            {
                                obj.SuppressDbInitialization = ParseBool(stringValue3, () => section.Path)!;
                            }
                        }
                        break;
                    default:
                        {
                            if (binderOptions?.ErrorOnUnknownConfiguration == true)
                            {
                                (temp ??= new List<string>()).Add($"'{section.Key}'");
                            }
                        }
                        break;
                }
            }

            if (temp is not null)
            {
                throw new InvalidOperationException($"'ErrorOnUnknownConfiguration' was set on the provided BinderOptions, but the following properties were not found on the instance of {typeof(AppSettings)}: {string.Join(", ", temp)}");
            }
        }

        public static bool HasValueOrChildren(IConfiguration configuration)
        {
            if ((configuration as IConfigurationSection)?.Value is not null)
            {
                return true;
            }
            return HasChildren(configuration);
        }

        public static bool HasChildren(IConfiguration configuration)
        {
            foreach (IConfigurationSection section in configuration.GetChildren())
            {
                return true;
            }
            return false;
        }

        public static BinderOptions? GetBinderOptions(Action<BinderOptions>? configureOptions)
        {
            if (configureOptions is null)
            {
                return null;
            }
            BinderOptions binderOptions = new();
            configureOptions(binderOptions);
            if (binderOptions.BindNonPublicProperties)
            {
                throw new global::System.NotSupportedException($"The configuration binding source generator does not support 'BinderOptions.BindNonPublicProperties'.");
            }
            return binderOptions;
        }

        public static bool ParseBool(string stringValue, Func<string?> getPath)
        {
            try
            {
                return bool.Parse(stringValue);
            }
            catch (Exception exception)
            {
                throw new InvalidOperationException($"Failed to convert configuration value at '{getPath()}' to type '{typeof(bool)}'.", exception);
            }
        }
    }
}
```
</details>

The [binding extension classes](https://github.com/dotnet/runtime/tree/4bb41a7b85e29686a3882e777f0320a504cdd8bd/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/src) in `Microsoft.Extensions.Options.ConfigurationExtensions` are now trimmed out from the app.

When https://github.com/dotnet/runtime/pull/87935 flows through, `ConfigurationBinder` itself will be trimmed out.