### PR TITLE
Some fixes & updates to some TechEmpower benchmarks

### DIFF
--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/Database/Db.cs
@@ -20,7 +20,7 @@ public sealed class Db : IAsyncDisposable
     public async Task<List<Fortune>> LoadFortunesRowsDapper()
     {
         await using var connection = _dataSource.CreateConnection();
-        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).ToList();
+        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).AsList();
 
         result.Add(new Fortune { Id = 0, Message = "Additional fortune added at request time." });
         result.Sort(FortuneSortComparison);

--- a/src/BenchmarksApps/TechEmpower/Minimal/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Database/Db.cs
@@ -19,13 +19,13 @@ public class Db
         _connectionString = appSettings.ConnectionString;
     }
 
-    public Task<World> LoadSingleQueryRow()
+    public async Task<World> LoadSingleQueryRow()
     {
-        using var db = _dbProviderFactory.CreateConnection();
+        await using var db = _dbProviderFactory.CreateConnection();
         db!.ConnectionString = _connectionString;
 
         // Note: Don't need to open connection if only doing one thing; let dapper do it
-        return ReadSingleRow(db);
+        return await ReadSingleRow(db);
     }
 
     static Task<World> ReadSingleRow(DbConnection db)
@@ -40,7 +40,7 @@ public class Db
         count = Math.Clamp(count, 1, 500);
 
         var results = new World[count];
-        using var db = _dbProviderFactory.CreateConnection();
+        await using var db = _dbProviderFactory.CreateConnection();
 
         db!.ConnectionString = _connectionString;
         await db.OpenAsync();
@@ -59,7 +59,7 @@ public class Db
 
         var parameters = new Dictionary<string, object>();
 
-        using var db = _dbProviderFactory.CreateConnection();
+        await using var db = _dbProviderFactory.CreateConnection();
 
         db!.ConnectionString = _connectionString;
         await db.OpenAsync();
@@ -87,7 +87,7 @@ public class Db
     {
         List<Fortune> result;
 
-        using var db = _dbProviderFactory.CreateConnection();
+        await using var db = _dbProviderFactory.CreateConnection();
 
         db!.ConnectionString = _connectionString;
 

--- a/src/BenchmarksApps/TechEmpower/Minimal/Program.cs
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Program.cs
@@ -27,12 +27,19 @@ var app = builder.Build();
 
 app.MapGet("/plaintext", () => "Hello, World!");
 
+app.MapGet("/plaintext/result", () => Results.Text("Hello, World!"));
+
 app.MapGet("/json", () => new { message = "Hello, World!" });
+
+app.MapGet("/json/result", () => Results.Json(new { message = "Hello, World!" }));
 
 app.MapGet("/db", async (Db db) => await db.LoadSingleQueryRow());
 
+app.MapGet("/db/result", async (Db db) => Results.Json(await db.LoadSingleQueryRow()));
+
 var createFortunesTemplate = RazorSlice.ResolveSliceFactory<List<Fortune>>("/Templates/Fortunes.cshtml");
 var htmlEncoder = CreateHtmlEncoder();
+
 app.MapGet("/fortunes", async (HttpContext context, Db db) => {
     var fortunes = await db.LoadFortunesRows();
     var template = (RazorSliceHttpResult<List<Fortune>>)createFortunesTemplate(fortunes);
@@ -42,7 +49,11 @@ app.MapGet("/fortunes", async (HttpContext context, Db db) => {
 
 app.MapGet("/queries/{count}", async (Db db, int count) => await db.LoadMultipleQueriesRows(count));
 
+app.MapGet("/queries/{count}/result", async (Db db, int count) => Results.Json(await db.LoadMultipleQueriesRows(count)));
+
 app.MapGet("/updates/{count}", async (Db db, int count) => await db.LoadMultipleUpdatesRows(count));
+
+app.MapGet("/updates/{count}/result", async (Db db, int count) => Results.Json(await db.LoadMultipleUpdatesRows(count)));
 
 app.Lifetime.ApplicationStarted.Register(() => Console.WriteLine("Application started. Press Ctrl+C to shut down."));
 app.Lifetime.ApplicationStopping.Register(() => Console.WriteLine("Application is shutting down..."));

--- a/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml
@@ -40,6 +40,16 @@ scenarios:
         path: /plaintext
         pipeline: 16
 
+  plaintext_result:
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: plaintext
+        path: /plaintext/result
+        pipeline: 16
+
   json:
     application:
       job: minimal
@@ -48,7 +58,16 @@ scenarios:
       variables:
         presetHeaders: json
         path: /json
-  
+
+  json_result:
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /json/result
+
   fortunes:
     db:
       job: postgresql
@@ -59,7 +78,18 @@ scenarios:
       variables:
         presetHeaders: html
         path: /fortunes
-  
+
+  fortunes_result:
+    db:
+      job: postgresql
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: html
+        path: /fortunes/result
+
   single_query:
     db:
       job: postgresql
@@ -70,6 +100,18 @@ scenarios:
       variables:
         presetHeaders: json
         path: /db
+        connections: 512
+
+  single_query_result:
+    db:
+      job: postgresql
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /db/result
         connections: 512
 
   multiple_queries:
@@ -84,6 +126,18 @@ scenarios:
         path: /queries/20
         connections: 512
 
+  multiple_queries_result:
+    db:
+      job: postgresql
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /queries/20/result
+        connections: 512
+
   updates:
     db:
       job: postgresql
@@ -94,6 +148,18 @@ scenarios:
       variables:
         presetHeaders: json
         path: /updates/20
+        connections: 512
+
+  updates_result:
+    db:
+      job: postgresql
+    application:
+      job: minimal
+    load:
+      job: wrk
+      variables:
+        presetHeaders: json
+        path: /updates/20/result
         connections: 512
 
 profiles:

--- a/src/BenchmarksApps/TechEmpower/Mvc/Database/DbDapper.cs
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Database/DbDapper.cs
@@ -24,7 +24,7 @@ public sealed class DbDapper
     public async Task<List<Fortune>> LoadFortunesRowsDapper()
     {
         await using var connection = _dataSource.CreateConnection();
-        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).ToList();
+        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).AsList();
 
         result.Add(new Fortune { Id = 0, Message = "Additional fortune added at request time." });
         result.Sort(FortuneSortComparison);

--- a/src/BenchmarksApps/TechEmpower/RazorPages/Database/Db.cs
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/Database/Db.cs
@@ -14,13 +14,17 @@ public sealed class Db : IAsyncDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(appSettings.ConnectionString);
 
+#if NET8_0_OR_GREATER
         _dataSource = new NpgsqlSlimDataSourceBuilder(appSettings.ConnectionString).Build();
+#else
+        _dataSource = new NpgsqlDataSourceBuilder(appSettings.ConnectionString).Build();
+#endif
     }
 
     public async Task<List<Fortune>> LoadFortunesRowsDapper()
     {
         await using var connection = _dataSource.CreateConnection();
-        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).ToList();
+        var result = (await connection.QueryAsync<Fortune>($"SELECT id, message FROM fortune")).AsList();
 
         result.Add(new Fortune { Id = 0, Message = "Additional fortune added at request time." });
         result.Sort(FortuneSortComparison);

--- a/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
- Adds versions of the minimal endpoints that return IResult instead of relying on implicit response writing
- Fixes a connection lifetime issue in the /db endpoint
- Fixes RazorPages project compilation error when targeting net7.0
- Replace uses of ToList() on Dapper results with AsList() to avoid the extra List<T> allocation