### PR TITLE
Update TodosApi to latest JwtBearer version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -25,15 +25,4 @@
     <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.7.23375.4</MicrosoftEntityFrameworkCoreSqliteVersion80>
 
   </PropertyGroup>
-
-  <!-- ASP.NET versions used by default when no specific one is defined for a benchmark -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <MicrosoftAspNetCoreAppPackageVersion>6.0.21</MicrosoftAspNetCoreAppPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <MicrosoftAspNetCoreAppPackageVersion>7.0.10</MicrosoftAspNetCoreAppPackageVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <MicrosoftAspNetCoreAppPackageVersion>8.0.0-rc.2.23421.27</MicrosoftAspNetCoreAppPackageVersion>
-  </PropertyGroup>
 </Project>

--- a/build/dependencies.targets
+++ b/build/dependencies.targets
@@ -1,0 +1,16 @@
+<Project>
+  <!--
+  ASP.NET versions used by default when no specific one is defined for a benchmark.
+  Note these need to be defined in a .targets file because they depend on the TargetFramework,
+  which isn't set until the .csproj is evaluated.
+  -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>6.0.*</MicrosoftAspNetCoreAppPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>7.0.*</MicrosoftAspNetCoreAppPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <MicrosoftAspNetCoreAppPackageVersion>8.0.*-*</MicrosoftAspNetCoreAppPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/src/BenchmarksApps/DistributedCache/DistributedCache.csproj
+++ b/src/BenchmarksApps/DistributedCache/DistributedCache.csproj
@@ -4,16 +4,9 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-
-    <!-- Set package versions to float to latest based on TFM if not defined -->
-    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Use the latest version based on the requested TFM -->
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftNETCoreAppPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/Mvc/Mvc.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
-    <!-- Set package versions to float to latest based on TFM if not defined -->
-    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/SignalR/BenchmarkServer.csproj
+++ b/src/BenchmarksApps/SignalR/BenchmarkServer.csproj
@@ -2,10 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    
-    <!-- Set package versions to float to latest based on TFM if not defined -->
-    <MicrosoftNETCoreAppPackageVersion Condition="'$(MicrosoftNETCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftNETCoreAppPackageVersion>
-    <MicrosoftAspNetCoreAppPackageVersion Condition="'$(MicrosoftAspNetCoreAppPackageVersion)' == '' and '$(TargetFramework)' != ''">$(TargetFramework.Substring(3,3)).*</MicrosoftAspNetCoreAppPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -16,11 +16,11 @@
   
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore.OpenApi\AspNetCore.OpenApi.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-preview.5.23302.2" />
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
     <PackageReference Include="Nanorm.Npgsql" Version="0.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.0-preview.5.23302.2">
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="$(MicrosoftAspNetCoreAppPackageVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="..\build\dependencies.targets" />
+
+</Project>


### PR DESCRIPTION
- Also refactor how OOB package versions are brought into the benchmark apps. The versions all come from the build\dependencies.props|targets files when they aren't supplied by crank.