### PR TITLE
Update BasicGrpc to use gRPC 2.57.0

### DIFF
--- a/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
+++ b/src/BenchmarksApps/Grpc/BasicGrpc/BasicGrpc.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Theoretically, the Google.Protobuf version referenced should remove regex dependency and reduce AOT deployment size.