### PR TITLE
Update Alpine and Composite Middleware Dockerfiles with the Official .NET 8 Tags

### DIFF
--- a/docker/container-matrix/Middleware-alpine.dockerfile
+++ b/docker/container-matrix/Middleware-alpine.dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN dotnet publish src/Benchmarks/Benchmarks.csproj -c Release -o out -f net8.0 -p:BenchmarksTargetFramework=net8.0 -p:MicrosoftAspNetCoreAppPackageVersion=$ASPNET_VERSION
 
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-preview-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 

--- a/docker/container-matrix/Middleware-composite.dockerfile
+++ b/docker/container-matrix/Middleware-composite.dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN dotnet publish src/Benchmarks/Benchmarks.csproj -c Release -o out -f net8.0 -p:BenchmarksTargetFramework=net8.0 -p:MicrosoftAspNetCoreAppPackageVersion=$ASPNET_VERSION
 
-FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-preview-alpine-composite AS runtime
+FROM mcr.microsoft.com/dotnet/nightly/aspnet:8.0-alpine-composite AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 


### PR DESCRIPTION
Fixes #1867.
Fixes #1904.

Now that we've moved onto RC release stages of .NET 8, the preview ASP.NET images have become outdated. On the other hand, we now have the official .NET 8 tags with the latest versions of the runtime, so this PR updates the Dockerfiles to use those instead.