### PR TITLE
Upgrade Npgsql to 8.0.0-rc.2

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,7 +10,7 @@
 
     <NpgsqlEntityFrameworkCorePostgreSQLVersion60>6.0.8</NpgsqlEntityFrameworkCorePostgreSQLVersion60>
     <NpgsqlEntityFrameworkCorePostgreSQLVersion70>7.0.4</NpgsqlEntityFrameworkCorePostgreSQLVersion70>
-    <NpgsqlEntityFrameworkCorePostgreSQLVersion80>8.0.0-preview.7</NpgsqlEntityFrameworkCorePostgreSQLVersion80>
+    <NpgsqlEntityFrameworkCorePostgreSQLVersion80>8.0.0-rc.2</NpgsqlEntityFrameworkCorePostgreSQLVersion80>
 
     <PomeloEntityFrameworkCoreMySqlVersion60>6.0.2</PomeloEntityFrameworkCoreMySqlVersion60>
     <PomeloEntityFrameworkCoreMySqlVersion70>7.0.0</PomeloEntityFrameworkCoreMySqlVersion70>
@@ -18,11 +18,11 @@
 
     <MicrosoftEntityFrameworkCoreSqlServerVersion60>6.0.21</MicrosoftEntityFrameworkCoreSqlServerVersion60>
     <MicrosoftEntityFrameworkCoreSqlServerVersion70>7.0.10</MicrosoftEntityFrameworkCoreSqlServerVersion70>
-    <MicrosoftEntityFrameworkCoreSqlServerVersion80>8.0.0-preview.7.23375.4</MicrosoftEntityFrameworkCoreSqlServerVersion80>
+    <MicrosoftEntityFrameworkCoreSqlServerVersion80>8.0.0-rc.2.23480.1</MicrosoftEntityFrameworkCoreSqlServerVersion80>
 
     <MicrosoftEntityFrameworkCoreSqliteVersion60>6.0.21</MicrosoftEntityFrameworkCoreSqliteVersion60>
     <MicrosoftEntityFrameworkCoreSqliteVersion70>7.0.10</MicrosoftEntityFrameworkCoreSqliteVersion70>
-    <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-preview.7.23375.4</MicrosoftEntityFrameworkCoreSqliteVersion80>
+    <MicrosoftEntityFrameworkCoreSqliteVersion80>8.0.0-rc.2.23480.1</MicrosoftEntityFrameworkCoreSqliteVersion80>
 
   </PropertyGroup>
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="Package Versions">
     <NpgsqlVersion60>6.0.0</NpgsqlVersion60>
     <NpgsqlVersion70>7.0.4</NpgsqlVersion70>
-    <NpgsqlVersion80>8.0.0-preview.4</NpgsqlVersion80>
+    <NpgsqlVersion80>8.0.0-rc.2</NpgsqlVersion80>
 
     <MicrosoftDataSqlClientVersion60>4.1.1</MicrosoftDataSqlClientVersion60>
     <MicrosoftDataSqlClientVersion70>5.1.1</MicrosoftDataSqlClientVersion70>


### PR DESCRIPTION
With the release of Npgsql 8.0-rc2 build, the TodoApi / Stage 2 app is officially warning free.

App sizes measured locally:

for Linux-x64 we went:
22.4 MB => 21.4 MB
 
for Windows we went:
19.4 MB => 18.6 MB