### PR TITLE
Bump TechEmpower Npgsql dependencies to 8.0.0-rc.2

### DIFF
--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/BlazorSSR.csproj
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/BlazorSSR.csproj
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/BlazorSSR.csproj
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/BlazorSSR.csproj
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
+    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="RazorSlices" Version="0.6.2" />
   </ItemGroup>

--- a/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
+++ b/src/BenchmarksApps/TechEmpower/Minimal/Minimal.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="RazorSlices" Version="0.6.2" />
   </ItemGroup>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -12,11 +12,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion70)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion70)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
+++ b/src/BenchmarksApps/TechEmpower/Mvc/Mvc.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.4" />
+    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -28,8 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 
 </Project>

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -23,11 +23,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) != 'net8.0'">
-    <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion70)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion70)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/PlatformBenchmarks.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.4" />
+    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
   </ItemGroup>
 
 </Project>

--- a/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-preview.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.4" />
+    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="Npgsql" Version="8.0.0-rc.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 </Project>

--- a/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/RazorPages.csproj
@@ -13,11 +13,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion70)" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion70)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLVersion80)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Should we just start using the properties defined in build/dependencies.props? These were updated recently (I think by @eerhardt) but we don't use them in the TE benchmarks for some reason.