### PR TITLE
Fix Blazor WebAssembly Hosted and Blazor Server build perf benchmarks

### DIFF
--- a/build/build-perf-scenarios.yml
+++ b/build/build-perf-scenarios.yml
@@ -15,11 +15,10 @@ parameters:
 
   - displayName: "Build - BlazorWasm"
     arguments: --scenario blazorwasm $(buildJobs) --property scenario=BlazorWasm 
-  # Skip https://github.com/dotnet/aspnetcore/issues/49760
-  # - displayName: "Build - BlazorWasm (Hosted)"
-  #   arguments: --scenario blazorwasm-hosted $(buildJobs) --property scenario=BlazorWasmHosted
-  # - displayName: "Build - BlazorServer"
-  #   arguments: --scenario blazorserver $(buildJobs) --property scenario=BlazorServer
+  - displayName: "Build - BlazorWasm (Hosted)"
+    arguments: --scenario blazorwasm-hosted $(buildJobs) --property scenario=BlazorWasmHosted
+  - displayName: "Build - BlazorServer"
+    arguments: --scenario blazorserver $(buildJobs) --property scenario=BlazorServer
   - displayName: "Build - MVC"
     arguments: --scenario mvc $(buildJobs) --property scenario=MVC
   - displayName: "Build - API"

--- a/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
+++ b/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
@@ -68,7 +68,7 @@ namespace Build
 
         async Task ChangeToRazorMarkup()
         {
-            var indexRazorFile = Path.Combine(_workingDirectory, "Components", "Pages", "Index.razor");
+            var indexRazorFile = Path.Combine(_workingDirectory, "Components", "Pages", "Home.razor");
             File.AppendAllText(indexRazorFile, Environment.NewLine + "<h3>New content</h3>");
 
             var buildDuration = await _dotnet.ExecuteAsync("build --no-restore");

--- a/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
+++ b/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
@@ -35,9 +35,6 @@ namespace Build
             // No-Op build
             await NoOpBuild();
 
-            // Changes to a .cshtml file
-            await ModifyCshtmlFile();
-
             // Rebuild
             await Rebuild();
         }
@@ -116,21 +113,6 @@ namespace Build
                 "blazorserver/razor-add-parameter",
                 buildDuration.TotalMilliseconds,
                 "Add a parameter to .razor");
-        }
-
-        async Task ModifyCshtmlFile()
-        {
-            var file = Path.Combine(_workingDirectory, "App.razor");
-            var originalContent = File.ReadAllText(file);
-
-            File.WriteAllText(file, originalContent.Replace("<body>", "<body><h2>Some text</h2>"));
-
-            var buildDuration = await _dotnet.ExecuteAsync("build --no-restore");
-
-            MeasureAndRegister(
-                "blazorserver/razor-change-cshtml",
-                buildDuration.TotalMilliseconds,
-                "Change .cshtml file markup");
         }
     }
 }

--- a/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
+++ b/src/BenchmarksApps/BuildPerformance/BlazorServerScenario.cs
@@ -19,7 +19,7 @@ namespace Build
 
         public async Task RunAsync()
         {
-            await _dotnet.ExecuteAsync($"new blazor --use-server");
+            await _dotnet.ExecuteAsync($"new blazor -int Server");
 
             await Build();
 

--- a/src/BenchmarksApps/BuildPerformance/BlazorWasmHosted.cs
+++ b/src/BenchmarksApps/BuildPerformance/BlazorWasmHosted.cs
@@ -26,7 +26,7 @@ namespace Build
 
         public async Task RunAsync()
         {
-            await _dotnet.ExecuteAsync($"new blazor -n {ProjectName} -int WebAssembly");
+            await _dotnet.ExecuteAsync($"new blazor -n {ProjectName} -o . -int WebAssembly");
 
             await Build();
 

--- a/src/BenchmarksApps/BuildPerformance/BlazorWasmHosted.cs
+++ b/src/BenchmarksApps/BuildPerformance/BlazorWasmHosted.cs
@@ -24,11 +24,11 @@ namespace Build
 
         public async Task RunAsync()
         {
-            await _dotnet.ExecuteAsync($"new blazor --use-wasm");
+            await _dotnet.ExecuteAsync($"new blazor -int WebAssembly");
 
             await Build();
 
-            // Change 
+            // Change
             await ChangeShared();
 
             // Changes to .razor file markup


### PR DESCRIPTION
## Fix Blazor WebAssembly Hosted and Blazor Server build perf benchmarks

Updates these two benchmarks to account for changes to the project templates in .NET 8.

It should be noted that the "Blazor WebAssembly Hosted" and "Blazor Server" templates don't actually exist anymore - they're now just variants of the "Blazor Web App" template. That said, I haven't changed any test names, etc. in this PR in case that breaks continuity in the dashboards. I will probably perform the rename as part of https://github.com/dotnet/aspnetcore/issues/51971.

Fixes https://github.com/dotnet/aspnetcore/issues/49760