### PR TITLE
Lighthouse benchmark follow-ups

### DIFF
--- a/build/blazor-scenarios.yml
+++ b/build/blazor-scenarios.yml
@@ -45,7 +45,7 @@ steps:
         {
           "name": "crank",
           "condition": "(${{ parameters.condition }})",
-          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --command-line-property --table BlazorWasm --sql SQL_CONNECTION_STRING --chart" ]
+          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --application.framework net9.0 --command-line-property --table BlazorWasm --sql SQL_CONNECTION_STRING --chart" ]
         }
 
 - ${{ each s in parameters.lighthouseScenarios }}:
@@ -60,5 +60,5 @@ steps:
         {
           "name": "crank",
           "condition": "(${{ parameters.condition }})",
-          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --command-line-property --table Lighthouse --sql SQL_CONNECTION_STRING --chart" ]
+          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --application.framework net9.0 --command-line-property --table Lighthouse --sql SQL_CONNECTION_STRING --chart" ]
         }

--- a/src/BenchmarksApps/Lighthouse/src/blazor-scenario.js
+++ b/src/BenchmarksApps/Lighthouse/src/blazor-scenario.js
@@ -199,6 +199,7 @@ async function reportStatistics(flowResult, jobUrl) {
   console.log('Collecting Crank statistics...');
 
   const reporter = new LighthouseCrankReporter(flowResult, /* metadataPrefix */ 'lighthouse-blazor');
+  reporter.measureRawJson();
   addNavigationMeasurements(reporter, /* stepId */ 0);
   addNavigationMeasurements(reporter, /* stepId */ 1);
   addInteractionMeasurements(reporter, /* stepId */ 2);

--- a/src/BenchmarksApps/Lighthouse/src/utilities/lighthouse-crank-reporter.js
+++ b/src/BenchmarksApps/Lighthouse/src/utilities/lighthouse-crank-reporter.js
@@ -104,6 +104,34 @@ export class LighthouseCrankReporter {
   }
 
   /**
+   * Measures the flow result's raw JSON and includes it in the statistics report
+   */
+  measureRawJson() {
+    const metadataId = `${this.metadataPrefix}/raw`;
+    if (this.metadataIds.has(metadataId)) {
+      return;
+    }
+
+    this.metadataIds.add(metadataId);
+    this.statistics.metadata.push({
+      name: metadataId,
+      aggregate: 'First',
+      reduce: 'First',
+      format: 'json',
+      shortDescription: 'Raw JSON',
+      longDescription: 'The raw flow result JSON data',
+    });
+
+    const json = JSON.stringify(this.flowResult);
+    const timeStamp = new Date().toISOString();
+    this.statistics.measurements.push({
+      name: metadataId,
+      timeStamp,
+      value: json,
+    });
+  }
+
+  /**
    * @private
    * @param {number} stepId
    * @param {string} auditId

--- a/src/BenchmarksApps/RunTemplate/Program.cs
+++ b/src/BenchmarksApps/RunTemplate/Program.cs
@@ -42,6 +42,9 @@ rootCommand.Handler = CommandHandler.Create(async (InvocationContext context) =>
 
     Console.WriteLine($"dotnet path: {dotnetPath}");
 
+    // Run "dotnet --info" for debugging purposes
+    await RunDotNetCommand(dotnetPath, "--info");
+
     var workingDirectory = Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName());
     Directory.CreateDirectory(workingDirectory);
 


### PR DESCRIPTION
* Adds `--application.framework net9.0` to the Blazor Lighthouse benchmarks when running in CI
* Adds a new `dotnet --info` step to the `runTemplate` job so we can more easily debug the .NET versions used to create and run a template
* Adds a raw JSON metric to the Blazor Lighthouse benchmarks