### PR TITLE
Refactored siryn win names to siryn lin

### DIFF
--- a/build/ci.profile.yml
+++ b/build/ci.profile.yml
@@ -381,24 +381,24 @@ profiles:
           - warmup
           - secondary
 
-  siryn-win-app:
+  siryn-lin-app:
     variables:
       serverAddress: 10.0.0.111
       cores: 128
     agents: 
       application:
         endpoints: 
-          - http://asp-siryn-win:5001
+          - http://asp-siryn-lin:5001
         aliases:
           - main
 
-  siryn-win-load:
+  siryn-lin-load:
     variables:
       secondaryAddress: 10.0.0.111
     agents: 
       load:
         endpoints: 
-          - http://asp-siryn-win:5001
+          - http://asp-siryn-lin:5001
         aliases:
           - warmup
           - secondary

--- a/scenarios/aspnet.profiles.standard.yml
+++ b/scenarios/aspnet.profiles.standard.yml
@@ -580,7 +580,7 @@ profiles:
           - db
           - downstream
 
-  aspnet-siryn-arm-win:
+  aspnet-siryn-arm-lin:
     variables:
       mainAddress: 10.0.0.111
       secondaryAddress: 10.0.0.109
@@ -592,7 +592,7 @@ profiles:
     agents:
       main:
         endpoints: 
-          - http://asp-siryn-win:5001
+          - http://asp-siryn-lin:5001
         aliases:
           - application
       secondary:
@@ -608,7 +608,7 @@ profiles:
           - db
           - downstream
 
-  aspnet-siryn-arm-win-relay:
+  aspnet-siryn-arm-lin-relay:
     variables:
       mainAddress: 10.0.0.111
       secondaryAddress: 10.0.0.109
@@ -620,7 +620,7 @@ profiles:
     agents:
       main:
         endpoints: 
-          - https://aspnetperf.servicebus.windows.net/sirynwin
+          - https://aspnetperf.servicebus.windows.net/sirynlin
         aliases:
           - application
       secondary:

--- a/scenarios/aspnet.profiles.yml
+++ b/scenarios/aspnet.profiles.yml
@@ -572,7 +572,7 @@ profiles:
           - warmup
           - secondary
 
-  aspnet-siryn-arm-win:
+  aspnet-siryn-arm-lin:
     variables:
       serverAddress: 10.0.0.111
       cores: 128
@@ -585,7 +585,7 @@ profiles:
           - extra
       application:
         endpoints: 
-          - http://asp-siryn-win:5001
+          - http://asp-siryn-lin:5001
         variables:
           databaseServer: 10.0.0.106
         aliases:
@@ -597,7 +597,7 @@ profiles:
           - warmup
           - secondary
 
-  aspnet-siryn-arm-win-relay:
+  aspnet-siryn-arm-lin-relay:
     variables:
       serverAddress: 10.0.0.111
       cores: 128
@@ -610,7 +610,7 @@ profiles:
           - extra
       application:
         endpoints: 
-          - https://aspnetperf.servicebus.windows.net/sirynwin
+          - https://aspnetperf.servicebus.windows.net/sirynlin
         variables:
           databaseServer: 10.0.0.106
         aliases:


### PR DESCRIPTION
Update to PR: #1962.
Updates the win names to be lin as the machine is running linux.