### PR TITLE
Add QUIC scenarios to CI

### DIFF
--- a/build/sslstream-scenarios.yml
+++ b/build/sslstream-scenarios.yml
@@ -26,13 +26,13 @@ parameters:
   - name: readWriteScenarios
     type: object
     default:
-      - displayName: "read-write"
+      - displayName: "Read-Write"
         arguments: --scenario read-write --property scenario=Read-Write
 
   - name: handshakeScenarios
     type: object
     default:
-      - displayName: "handshake"
+      - displayName: "Handshake"
         arguments: --scenario handshake --property scenario=Handshake
 
   - name: tlsResume
@@ -54,27 +54,27 @@ parameters:
   - name: connections
     type: object
     default:
-      - displayName: "1 connection"
+      - displayName: "1 conn"
         arguments: --variable connections=1 --property connections=1
-      - displayName: "16 connections"
+      - displayName: "16 conn"
         arguments: --variable connections=16 --property connections=16
 
   - name: singleStreamConnections
     type: object
     default:
-      - displayName: "1 connection 1 stream"
+      - displayName: "1 conn x 1 strm"
         arguments: --variable connections=1 --variable streams=1 --property connxstrm=1x1
-      - displayName: "16 connections 1 stream"
+      - displayName: "16 conn x 1 strm"
         arguments: --variable connections=16 --variable streams=1 --property connxstrm=16x1
 
   - name: multiplexedConnections
     type: object
     default:
-      - displayName: "1 connection 1 stream"
+      - displayName: "1 conn x 1 strm"
         arguments: --variable connections=1 --variable streams=1 --property connxstrm=1x1
-      - displayName: "1 connection 16 streams"
+      - displayName: "1 conn x 16 strm"
         arguments: --variable connections=1 --variable streams=16 --property connxstrm=1x16
-      - displayName: "16 connections 1 stream"
+      - displayName: "16 conn x 1 strm"
         arguments: --variable connections=16 --variable streams=1 --property connxstrm=16x1
 
 steps:

--- a/build/sslstream-scenarios.yml
+++ b/build/sslstream-scenarios.yml
@@ -1,4 +1,4 @@
-# SslStream scenarios
+# Secure Transport (SslStream & QUIC) scenarios
 
 parameters:
   - name: arguments
@@ -11,17 +11,29 @@ parameters:
     type: string
     default: "true"
 
+  - name: sslstreamTransport
+    type: object
+    default:
+      - displayName: "SslStream"
+        arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/sslstream.benchmarks.yml?raw=true --property transport=SslStream
+
+  - name: quicTransport
+    type: object
+    default:
+      - displayName: "QUIC"
+        arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/quic.benchmarks.yml?raw=true --property transport=QUIC --property tlsVersion=1.3 --property tlsResume=no-resume
+
   - name: readWriteScenarios
     type: object
     default:
       - displayName: "read-write"
-        arguments: --scenario read-write --property scenario=Read-Write --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/sslstream.benchmarks.yml?raw=true
+        arguments: --scenario read-write --property scenario=Read-Write
 
   - name: handshakeScenarios
     type: object
     default:
       - displayName: "handshake"
-        arguments: --scenario handshake --property scenario=Handshake --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/sslstream.benchmarks.yml?raw=true
+        arguments: --scenario handshake --property scenario=Handshake
 
   - name: tlsResume
     type: object
@@ -43,39 +55,58 @@ parameters:
     type: object
     default:
       - displayName: "1 connection"
-        arguments: --variable connections=1 --property connections=1 --property streams=1
+        arguments: --variable connections=1 --property connections=1
       - displayName: "16 connections"
-        arguments: --variable connections=16 --property connections=16 --property streams=1
+        arguments: --variable connections=16 --property connections=16
+
+  - name: singleStreamConnections
+    type: object
+    default:
+      - displayName: "1 connection 1 stream"
+        arguments: --variable connections=1 --variable streams=1 --property connxstrm=1x1
+      - displayName: "16 connections 1 stream"
+        arguments: --variable connections=16 --variable streams=1 --property connxstrm=16x1
+
+  - name: multiplexedConnections
+    type: object
+    default:
+      - displayName: "1 connection 1 stream"
+        arguments: --variable connections=1 --variable streams=1 --property connxstrm=1x1
+      - displayName: "1 connection 16 streams"
+        arguments: --variable connections=1 --variable streams=16 --property connxstrm=1x16
+      - displayName: "16 connections 1 stream"
+        arguments: --variable connections=16 --variable streams=1 --property connxstrm=16x1
 
 steps:
-  # handshake scenarios
+  # handshake scenarios -- SslStream
   - ${{ each s in parameters.handshakeScenarios }}:
-      - ${{ each version in parameters.tlsVersion }}:
-          - ${{ each c in parameters.connections }}:
-              - ${{ each res in parameters.tlsResume }}:
-                  - task: PublishToAzureServiceBus@1
-                    condition: succeededOrFailed()
-                    timeoutInMinutes: 10
-                    displayName: ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} ${{ res.displayName }}
-                    inputs:
-                      connectedServiceName: ${{ parameters.connection }}
-                      waitForCompletion: true
-                      useDataContractSerializer: "false"
-                      messageBody: |
-                        {
-                          "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
-                          "name": "crank",
-                          "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} ${{ res.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ s.arguments }} ${{ version.arguments }} ${{ res.arguments }} ${{ c.arguments }}" ]
-                        }
+      - ${{ each t in parameters.sslstreamTransport }}:
+          - ${{ each version in parameters.tlsVersion }}:
+              - ${{ each c in parameters.connections }}:
+                  - ${{ each res in parameters.tlsResume }}:
+                      - task: PublishToAzureServiceBus@1
+                        condition: succeededOrFailed()
+                        timeoutInMinutes: 10
+                        displayName: ${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} ${{ res.displayName }}
+                        inputs:
+                          connectedServiceName: ${{ parameters.connection }}
+                          waitForCompletion: true
+                          useDataContractSerializer: "false"
+                          messageBody: |
+                            {
+                              "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
+                              "name": "crank",
+                              "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} ${{ res.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ version.arguments }} ${{ res.arguments }} ${{ c.arguments }}" ]
+                            }
 
-  # read-write scenarios
-  - ${{ each s in parameters.readWriteScenarios }}:
-      - ${{ each version in parameters.tlsVersion }}:
+  # handshake scenarios -- QUIC
+  - ${{ each s in parameters.handshakeScenarios }}:
+      - ${{ each t in parameters.quicTransport }}:
           - ${{ each c in parameters.connections }}:
               - task: PublishToAzureServiceBus@1
                 condition: succeededOrFailed()
                 timeoutInMinutes: 10
-                displayName: ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }}
+                displayName: ${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }}
                 inputs:
                   connectedServiceName: ${{ parameters.connection }}
                   waitForCompletion: true
@@ -84,5 +115,44 @@ steps:
                     {
                       "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
                       "name": "crank",
-                      "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ s.arguments }} ${{ version.arguments }} ${{ c.arguments }}" ]
+                      "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ c.arguments }}" ]
+                    }
+
+  # read-write scenarios -- SslStream
+  - ${{ each s in parameters.readWriteScenarios }}:
+      - ${{ each t in parameters.sslstreamTransport }}:
+          - ${{ each version in parameters.tlsVersion }}:
+              - ${{ each c in parameters.singleStreamConnections }}:
+                  - task: PublishToAzureServiceBus@1
+                    condition: succeededOrFailed()
+                    timeoutInMinutes: 10
+                    displayName:  ${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }}
+                    inputs:
+                      connectedServiceName: ${{ parameters.connection }}
+                      waitForCompletion: true
+                      useDataContractSerializer: "false"
+                      messageBody: |
+                        {
+                          "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
+                          "name": "crank",
+                          "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ version.arguments }} ${{ c.arguments }}" ]
+                        }
+
+  # read-write scenarios -- QUIC
+  - ${{ each s in parameters.readWriteScenarios }}:
+      - ${{ each t in parameters.quicTransport }}:
+          - ${{ each c in parameters.multiplexedConnections }}:
+              - task: PublishToAzureServiceBus@1
+                condition: succeededOrFailed()
+                timeoutInMinutes: 10
+                displayName:  ${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }}
+                inputs:
+                  connectedServiceName: ${{ parameters.connection }}
+                  waitForCompletion: true
+                  useDataContractSerializer: "false"
+                  messageBody: |
+                    {
+                      "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
+                      "name": "crank",
+                      "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ c.arguments }}" ]
                     }

--- a/build/sslstream-scenarios.yml
+++ b/build/sslstream-scenarios.yml
@@ -28,6 +28,8 @@ parameters:
     default:
       - displayName: "Read-Write"
         arguments: --scenario read-write --property scenario=Read-Write
+      - displayName: "RPS"
+        arguments: --scenario rps --property scenario=RPS
 
   - name: handshakeScenarios
     type: object
@@ -77,10 +79,26 @@ parameters:
       - displayName: "16 conn x 1 strm"
         arguments: --variable connections=16 --variable streams=1 --property connxstrm=16x1
 
+  - name: sendBuffers
+    type: object
+    default:
+      - displayName: "128 b send"
+        arguments: --variable sendBufferSize=128 --property sendBufferSize=128b
+      - displayName: "32 Kb send"
+        arguments: --variable sendBufferSize=32768 --property sendBufferSize=32Kb
+
+  - name: receiveBuffers
+    type: object
+    default:
+      - displayName: "128 b recv"
+        arguments: --variable receiveBufferSize=128 --property receiveBufferSize=128b
+      - displayName: "32 Kb recv"
+        arguments: --variable receiveBufferSize=32768 --property receiveBufferSize=32Kb
+
 steps:
   # handshake scenarios -- SslStream
-  - ${{ each s in parameters.handshakeScenarios }}:
-      - ${{ each t in parameters.sslstreamTransport }}:
+  - ${{ each t in parameters.sslstreamTransport }}:
+      - ${{ each s in parameters.handshakeScenarios }}:
           - ${{ each version in parameters.tlsVersion }}:
               - ${{ each c in parameters.connections }}:
                   - ${{ each res in parameters.tlsResume }}:
@@ -100,8 +118,8 @@ steps:
                             }
 
   # handshake scenarios -- QUIC
-  - ${{ each s in parameters.handshakeScenarios }}:
-      - ${{ each t in parameters.quicTransport }}:
+  - ${{ each t in parameters.quicTransport }}:
+      - ${{ each s in parameters.handshakeScenarios }}:
           - ${{ each c in parameters.connections }}:
               - task: PublishToAzureServiceBus@1
                 condition: succeededOrFailed()
@@ -119,40 +137,44 @@ steps:
                     }
 
   # read-write scenarios -- SslStream
-  - ${{ each s in parameters.readWriteScenarios }}:
-      - ${{ each t in parameters.sslstreamTransport }}:
-          - ${{ each version in parameters.tlsVersion }}:
-              - ${{ each c in parameters.singleStreamConnections }}:
-                  - task: PublishToAzureServiceBus@1
-                    condition: succeededOrFailed()
-                    timeoutInMinutes: 10
-                    displayName:  ${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }}
-                    inputs:
-                      connectedServiceName: ${{ parameters.connection }}
-                      waitForCompletion: true
-                      useDataContractSerializer: "false"
-                      messageBody: |
-                        {
-                          "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
-                          "name": "crank",
-                          "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ version.arguments }} ${{ c.arguments }}" ]
-                        }
+  - ${{ each t in parameters.sslstreamTransport }}:
+      - ${{ each s in parameters.readWriteScenarios }}:
+          - ${{ each sendbuf in parameters.sendBuffers }}:
+              - ${{ each recvbuf in parameters.receiveBuffers }}:
+                  - ${{ each version in parameters.tlsVersion }}:
+                      - ${{ each c in parameters.singleStreamConnections }}:
+                          - task: PublishToAzureServiceBus@1
+                            condition: succeededOrFailed()
+                            timeoutInMinutes: 10
+                            displayName:  ${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ sendbuf.displayName }} ${{ recvbuf.displayName }} ${{ c.displayName }}
+                            inputs:
+                              connectedServiceName: ${{ parameters.connection }}
+                              waitForCompletion: true
+                              useDataContractSerializer: "false"
+                              messageBody: |
+                                {
+                                  "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
+                                  "name": "crank",
+                                  "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ version.displayName }} ${{ s.displayName }} ${{ sendbuf.displayName }} ${{ recvbuf.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ version.arguments }} ${{ sendbuf.arguments }} ${{ recvbuf.arguments }} ${{ c.arguments }}" ]
+                                }
 
   # read-write scenarios -- QUIC
-  - ${{ each s in parameters.readWriteScenarios }}:
-      - ${{ each t in parameters.quicTransport }}:
-          - ${{ each c in parameters.multiplexedConnections }}:
-              - task: PublishToAzureServiceBus@1
-                condition: succeededOrFailed()
-                timeoutInMinutes: 10
-                displayName:  ${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }}
-                inputs:
-                  connectedServiceName: ${{ parameters.connection }}
-                  waitForCompletion: true
-                  useDataContractSerializer: "false"
-                  messageBody: |
-                    {
-                      "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
-                      "name": "crank",
-                      "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ s.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ c.arguments }}" ]
-                    }
+  - ${{ each t in parameters.quicTransport }}:
+      - ${{ each s in parameters.readWriteScenarios }}:
+          - ${{ each sendbuf in parameters.sendBuffers }}:
+              - ${{ each recvbuf in parameters.receiveBuffers }}:
+                  - ${{ each c in parameters.multiplexedConnections }}:
+                      - task: PublishToAzureServiceBus@1
+                        condition: succeededOrFailed()
+                        timeoutInMinutes: 10
+                        displayName:  ${{ t.displayName }} ${{ s.displayName }} ${{ sendbuf.displayName }} ${{ recvbuf.displayName }} ${{ c.displayName }}
+                        inputs:
+                          connectedServiceName: ${{ parameters.connection }}
+                          waitForCompletion: true
+                          useDataContractSerializer: "false"
+                          messageBody: |
+                            {
+                              "condition": "(${{ parameters.condition }}) && (Math.round(Date.now() / 43200000) % 2 == 0 )",  
+                              "name": "crank",
+                              "args": [ "--client.framework net9.0 --server.framework net9.0 --client.options.collectCounters true --command-line-property --table SystemNet_TlsBenchmarks --sql SQL_CONNECTION_STRING --chart --session $(session) --description \"${{ t.displayName }} ${{ s.displayName }} ${{ sendbuf.displayName }} ${{ recvbuf.displayName }} ${{ c.displayName }} $(System.JobDisplayName)\" ${{ parameters.arguments }} --no-metadata --no-measurements ${{ t.arguments }} ${{ s.arguments }} ${{ sendbuf.arguments }} ${{ recvbuf.arguments }} ${{ c.arguments }}" ]
+                            }

--- a/scenarios/quic.benchmarks.yml
+++ b/scenarios/quic.benchmarks.yml
@@ -97,6 +97,17 @@ scenarios:
         scenario: Handshake
         host: "{{secondaryAddress}}"
 
+  rps:
+    server:
+      job: quicServer
+      agent: secondary
+    client:
+      job: quicClient
+      agent: main
+      variables:
+        scenario: Rps
+        host: "{{secondaryAddress}}"
+
 jobs:
   quicServer:
     source:

--- a/scenarios/sslstream.benchmarks.yml
+++ b/scenarios/sslstream.benchmarks.yml
@@ -101,6 +101,17 @@ scenarios:
         scenario: Handshake
         host: "{{secondaryAddress}}"
 
+  rps:
+    server:
+      job: sslServer
+      agent: secondary
+    client:
+      job: sslClient
+      agent: main
+      variables:
+        scenario: Rps
+        host: "{{secondaryAddress}}"
+
 jobs:
   sslServer:
     source:

--- a/src/System/Net/Benchmarks/Common/BenchmarkApp.cs
+++ b/src/System/Net/Benchmarks/Common/BenchmarkApp.cs
@@ -16,10 +16,20 @@ public abstract class BenchmarkApp<TOptions> where TOptions : new()
     protected abstract string MetricPrefix { get; }
 
     protected static void Log(string message) => LogHelper.Log(message);
-    protected void LogMetric(string name, double value) => LogHelper.LogMetric(MetricPrefix + name, value);
-    protected void LogPercentileMetric(string name, List<double> values) => LogHelper.LogPercentileMetric(MetricPrefix + name, values);
-    protected void RegisterMetric(string name, string description, string format = "n2") => LogHelper.RegisterSimpleMetric(MetricPrefix + name, description, format);
-    protected void RegisterPercentileMetric(string name, string description, string format = "n3") => LogHelper.RegisterPercentileMetric(MetricPrefix + name, description, description, format);
+
+    protected void LogMetric(string name, string description, double value, string format = "n2")
+    {
+        var metricName = MetricPrefix + name;
+        LogHelper.RegisterSimpleMetric(metricName, description, format);
+        LogHelper.LogMetric(metricName, value);
+    }
+
+    protected void LogMetricPercentiles(string name, string description, List<double> values, string format = "n3")
+    {
+        var metricName = MetricPrefix + name;
+        LogHelper.RegisterPercentileMetric(metricName, description, description, format);
+        LogHelper.LogPercentileMetric(metricName, values);
+    }
 
     protected virtual void ValidateOptions(TOptions options) { }
     protected abstract Task RunBenchmarkAsync(TOptions options, CancellationToken cancellationToken);
@@ -49,15 +59,22 @@ public abstract class BenchmarkApp<TOptions> where TOptions : new()
 
         ValidateOptions(options);
 
-        LogHelper.RegisterSimpleMetric("env/processorcount", "Processor Count", "n0");
-        LogHelper.LogMetric("env/processorcount", Environment.ProcessorCount);
-
         Console.CancelKeyPress += static (s, e) =>
         {
             Log("Keyboard interrupt...");
             e.Cancel = true;
             GlobalCts.Cancel();
         };
+
+        // NOTE:
+        // It is better for metrics to be registered with some delay to ensure the metadata is collected.
+        // Event listener is started (shortly) after the benchmark app starts, so it might miss the registration event.
+        _ = Task.Run(static async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1), GlobalCts.Token).ConfigureAwait(false);
+            LogHelper.RegisterSimpleMetric("env/processorcount", "Processor Count", "n0");
+            LogHelper.LogMetric("env/processorcount", Environment.ProcessorCount);
+        });
 
         try
         {

--- a/src/System/Net/Benchmarks/Common/BenchmarkClient.cs
+++ b/src/System/Net/Benchmarks/Common/BenchmarkClient.cs
@@ -45,8 +45,6 @@ internal abstract class BenchmarkClient<TOptions> : BenchmarkApp<TOptions>
 
         await scenarioTask.ConfigureAwait(false);
         Log("Done");
-
-        await Task.Delay(100).ConfigureAwait(false); // sometimes the measure events seem to be lost? wait a bit to ensure they are collected
     }
 
     private static async Task WaitForWarmupCompletion(CancellationToken cancellationToken)

--- a/src/System/Net/Benchmarks/Common/BenchmarkServer.cs
+++ b/src/System/Net/Benchmarks/Common/BenchmarkServer.cs
@@ -26,8 +26,6 @@ internal abstract class BenchmarkServer<TListener, TAcceptResult, TOptions> : Be
 
     protected override async Task RunBenchmarkAsync(TOptions options, CancellationToken ct)
     {
-        RegisterMetric(MetricName.Errors, "Errors", "n0");
-
         await using var listener = await ListenAsync(options, ct);
         Log(GetReadyStateText(listener));
 
@@ -44,7 +42,7 @@ internal abstract class BenchmarkServer<TListener, TAcceptResult, TOptions> : Be
         {
             if (s_errors > 0)
             {
-                LogMetric(MetricName.Errors, s_errors);
+                LogMetric(MetricName.Errors, "Errors", s_errors, "n0");
             }
         }
         Log("Exiting...");

--- a/src/System/Net/Benchmarks/Common/LogHelper.cs
+++ b/src/System/Net/Benchmarks/Common/LogHelper.cs
@@ -36,6 +36,10 @@ public static class LogHelper
             throw new InvalidOperationException($"Metric '{name}' is already registered.");
         }
         s_metrics[name] = (longDescription, format, IsLogged: false);
+
+        // NOTE:
+        // It is better for metrics to be registered with some delay to ensure the metadata is collected.
+        // Event listener is started (shortly) after the benchmark app starts, so it might miss the registration event.
         BenchmarksEventSource.Register(name, Operations.First, Operations.First, shortDescription, longDescription, format);
     }
 


### PR DESCRIPTION
Also:
- Fix missing (on fast agents 😁) metric metadata
- Add rps scenario to ymls
- Add buffer sizes to test matrix

/cc @rzikm @sebastienros 

/cc @liveans -- after this PR, registering and logging a metric will happen together inside `LogMetric` function