### PR TITLE
Add special case for GetDocument.Insider invocation

### DIFF
--- a/src/BenchmarksApps/TodosApi/HostEnvironmentExtensions.cs
+++ b/src/BenchmarksApps/TodosApi/HostEnvironmentExtensions.cs
@@ -1,6 +1,14 @@
-﻿namespace Microsoft.Extensions.Hosting;
+﻿using System.Reflection;
+
+namespace Microsoft.Extensions.Hosting;
 
 internal static class HostEnvironmentExtensions
 {
-    public static bool IsBuild(this IHostEnvironment hostEnvironment) => hostEnvironment.IsEnvironment("Build");
+    public static bool IsBuild(this IHostEnvironment hostEnvironment)
+    {
+        // Check if the environment is "Build" or the entry assembly is "GetDocument.Insider"
+        // to account for scenarios where app is launching via OpenAPI build-time generation
+        // via the GetDocument.Insider tool.
+        return hostEnvironment.IsEnvironment("Build") || Assembly.GetEntryAssembly()?.GetName().Name == "GetDocument.Insider";
+    }
 }


### PR DESCRIPTION
Follow-up fix to resolve build errors in CI when building OpenAPI document.

Verified locally and via:

```
crank --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/goldilocks.benchmarks.yml --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/ci.profile.yml --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/steadystate.profile.yml --scenario todosapipublishaot --profile intel-lin-app --profile intel-load-load --profile intel-db-db --application.packageReferences Microsoft.DotNet.ILCompiler=9.0.0-rc.1.24403.1 --application.environmentVariables DOTNET_gcServer=1 --application.environmentVariables DOTNET_GCDynamicAdaptationMode=0 --application.framework net9.0 --application.options.collectCounters true --load.options.reuseBuild true --application.aspNetCoreVersion 9.0.0-rc.1.24402.3 --application.runtimeVersion 9.0.0-rc.1.24403.1 --application.sdkVersion 9.0.100-rc.1.24405.3 --application.source.branchOrCommit fix-aot-build
```

Output from build:

```

Command:
dotnet publish TodosApi.csproj -c Release -o /tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/published /p:MicrosoftNETCoreAppPackageVersion=9.0.0-rc.1.24403.1 /p:MicrosoftAspNetCoreAppPackageVersion=9.0.0-rc.1.24402.3 /p:GenerateErrorForMissingTargetingPacks=false /p:RestoreNoCache=true /p:MicrosoftNETPlatformLibrary=Microsoft.NETCore.App /p:PublishAot=true /p:StripSymbols=true --framework net9.0 --self-contained -r linux-x64 
  Determining projects to restore...
  Restored /tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/TodosApi.csproj (in 307 ms).
/tmp/benchmarks-agent/benchmarks-server-1/ol5sc3pi.gpl/sdk/9.0.100-rc.1.24405.3/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.RuntimeIdentifierInference.targets(326,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy [/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/TodosApi.csproj]
  TodosApi -> /tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/bin/Release/net9.0/linux-x64/TodosApi.dll
  
  GenerateOpenApiDocuments:
    dotnet "/root/.nuget/packages/microsoft.extensions.apidescription.server/9.0.0-rc.1.24402.3/build/../tools/dotnet-getdocument.dll" --assembly "/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/bin/Release/net9.0/linux-x64/TodosApi.dll" --file-list "obj/TodosApi.OpenApiFiles.cache" --framework ".NETCoreApp,Version=v9.0" --output "/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/" --project "TodosApi" --assets-file "/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/obj/project.assets.json" --platform "x64" --runtime "linux-x64 --self-contained" 
  Application started. Press Ctrl+C to shut down.
  Generating document named 'v1'.
  Using discovered `GenerateAsync` overload with version parameter.
  Writing document named 'v1' to '/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/TodosApi.json'.
/root/.nuget/packages/microsoft.dotnet.ilcompiler/9.0.0-rc.1.24403.1/build/Microsoft.DotNet.ILCompiler.SingleEntry.targets(57,5): warning : Delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file to avoid versioning problems. [/tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/TodosApi.csproj]
  Generating native code
  TodosApi -> /tmp/benchmarks-agent/benchmarks-server-1/dewnko3t.dcd/src/BenchmarksApps/TodosApi/published/
Exit code: 0
```