### PR TITLE
 Add OpenTelemetry to TodosApi

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -33,5 +33,6 @@
     <RazorSlicesVersion>0.7.0</RazorSlicesVersion>
     <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
     <MicrosoftCrankEventSourcesVersion>0.2.0-alpha.24114.2</MicrosoftCrankEventSourcesVersion>
+    <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>
   </PropertyGroup>
 </Project>

--- a/src/BenchmarksApps/TodosApi/AppSettings.cs
+++ b/src/BenchmarksApps/TodosApi/AppSettings.cs
@@ -11,7 +11,8 @@ internal class AppSettings
     public bool SuppressDbInitialization { get; set; }
 }
 
-// Change to using ValidateDataAnnotations once https://github.com/dotnet/runtime/issues/77412 is complete
+// Changing this to use the Options Validation source generator increases the app size significantly.
+// See https://github.com/dotnet/runtime/issues/106366
 internal class AppSettingsValidator : IValidateOptions<AppSettings>
 {
     public ValidateOptionsResult Validate(string? name, AppSettings options)
@@ -41,12 +42,6 @@ internal static class AppSettingsExtensions
             services.AddSingleton<IValidateOptions<AppSettings>, AppSettingsValidator>();
             optionsBuilder.ValidateOnStart();
         }
-
-        // Change to using ValidateDataAnnotations once https://github.com/dotnet/runtime/issues/77412 is complete
-        //services.AddOptions<AppSettings>()
-        //    .BindConfiguration(nameof(AppSettings))
-        //    .ValidateDataAnnotations()
-        //    .ValidateOnStart();
 
         return services;
     }

--- a/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseHealthCheck.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Nanorm;
 using Npgsql;
 
 namespace TodosApi;

--- a/src/BenchmarksApps/TodosApi/DatabaseInitializer.cs
+++ b/src/BenchmarksApps/TodosApi/DatabaseInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using Nanorm;
 using Npgsql;
 
 namespace TodosApi;

--- a/src/BenchmarksApps/TodosApi/Extensions.cs
+++ b/src/BenchmarksApps/TodosApi/Extensions.cs
@@ -1,0 +1,88 @@
+﻿using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using TodosApi;
+
+namespace Microsoft.Extensions.Hosting;
+
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+
+        builder.AddDefaultHealthChecks();
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        builder.AddOpenTelemetryExporters();
+
+        return builder;
+    }
+
+    private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+    {
+        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+        if (useOtlpExporter)
+        {
+            builder.Services.AddOpenTelemetry().UseOtlpExporter();
+        }
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            // Add a default liveness check to ensure app is responsive
+            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"])
+            .AddCheck<DatabaseHealthCheck>("Database", timeout: TimeSpan.FromSeconds(2))
+            .AddCheck<JwtHealthCheck>("JwtAuthentication");
+
+        return builder;
+    }
+
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        // Adding health checks endpoints to applications in non-development environments has security implications.
+        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+        if (app.Environment.IsDevelopment())
+        {
+            // All health checks must pass for app to be considered ready to accept traffic after starting
+            app.MapHealthChecks("/health");
+
+            // Only health checks tagged with the "live" tag must pass for app to be considered alive
+            app.MapHealthChecks("/alive", new HealthCheckOptions
+            {
+                Predicate = r => r.Tags.Contains("live")
+            });
+        }
+
+        return app;
+    }
+}

--- a/src/BenchmarksApps/TodosApi/Program.cs
+++ b/src/BenchmarksApps/TodosApi/Program.cs
@@ -6,6 +6,9 @@ var builder = WebApplication.CreateSlimBuilder(args);
 builder.Logging.ClearProviders();
 #endif
 
+// Add service defaults
+builder.AddServiceDefaults();
+
 // Bind app settings from configuration & validate
 builder.Services.ConfigureAppSettings(builder.Configuration, builder.Environment);
 
@@ -24,9 +27,6 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 
 // Configure health checks
-builder.Services.AddHealthChecks()
-    .AddCheck<DatabaseHealthCheck>("Database", timeout: TimeSpan.FromSeconds(2))
-    .AddCheck<JwtHealthCheck>("JwtAuthentication");
 
 // Problem details
 builder.Services.AddProblemDetails();
@@ -50,7 +50,7 @@ if (!app.Environment.IsDevelopment())
 
 app.MapShortCircuit(StatusCodes.Status404NotFound, "/favicon.ico");
 
-app.MapHealthChecks("/health");
+app.MapDefaultEndpoints();
 
 // Enables testing request exception handling behavior
 app.MapGet("/throw", void () => throw new InvalidOperationException("You hit the throw endpoint"));

--- a/src/BenchmarksApps/TodosApi/Todo.cs
+++ b/src/BenchmarksApps/TodosApi/Todo.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel.DataAnnotations;
-using Nanorm.Npgsql;
-using Npgsql;
+using Nanorm;
 
 namespace TodosApi;
 
-internal sealed class Todo : IDataReaderMapper<Todo>, IValidatable
+[DataRecordMapper]
+internal sealed partial class Todo : IValidatable
 {
     public int Id { get; set; }
 
@@ -13,16 +13,6 @@ internal sealed class Todo : IDataReaderMapper<Todo>, IValidatable
     public DateOnly? DueBy { get; set; }
 
     public bool IsComplete { get; set; }
-
-    public static Todo Map(NpgsqlDataReader dataReader)
-    {
-        return !dataReader.HasRows ? new() : new()
-        {
-            Id = dataReader.GetInt32(dataReader.GetOrdinal(nameof(Id))),
-            Title = dataReader.GetString(dataReader.GetOrdinal(nameof(Title))),
-            IsComplete = dataReader.GetBoolean(dataReader.GetOrdinal(nameof(IsComplete)))
-        };
-    }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/BenchmarksApps/TodosApi/TodoApi.cs
+++ b/src/BenchmarksApps/TodosApi/TodoApi.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Nanorm;
 using Npgsql;
 using TodosApi;
 

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <LangVersion>preview</LangVersion>
     <UserSecretsId>b8ffb8d3-b768-460b-ac1f-ef267c954c85</UserSecretsId>
     <PublishAot>true</PublishAot>
     <OpenApiDocumentsDirectory>.\</OpenApiDocumentsDirectory>
@@ -16,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Npgsql" Version="$(NpgsqlVersion80)" />
-    <PackageReference Include="Nanorm.Npgsql" Version="0.0.5" />
+    <PackageReference Include="Nanorm.Npgsql" Version="0.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="$(MicrosoftAspNetCoreAppPackageVersion)">
       <PrivateAssets>all</PrivateAssets>

--- a/src/BenchmarksApps/TodosApi/TodosApi.csproj
+++ b/src/BenchmarksApps/TodosApi/TodosApi.csproj
@@ -21,6 +21,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds the default OpenTelemetry configuration used by .NET Aspire ServiceDefaults - enable instrumentation for:
* AspNetCore
* HttpClient
* Runtime

and OTLP exporter.

Also update to the latest Nanorm version.

Note that this increases the size of the published app from `18.1 MB` => `22.2 MB` on `win-x64`. I plan on opening investigation issues in OpenTelemetry to reduce this size. If I remove the OTLP exporter, the size drops to `20.0 MB`. I've opened https://github.com/open-telemetry/opentelemetry-dotnet/issues/5785 to discuss if there is anything we can do to decrease the amount of app size OTel adds to the app.