### PR TITLE
Change Duration and Warmup representation to reflect they're timestamps

### DIFF
--- a/src/TcpClient/Program.cs
+++ b/src/TcpClient/Program.cs
@@ -13,8 +13,8 @@ namespace TcpClient
         private static string Ip;
         private static int Port = 5201;
         private static int Size = 1;
-        private static int WarmupSeconds;
-        private static int DurationSeconds;
+        private static TimeSpan WarmupSeconds = default(TimeSpan);
+        private static TimeSpan DurationSeconds = default(TimeSpan);
         private static int Connections;
         private static Stopwatch _stopwatch = Stopwatch.StartNew();
 
@@ -65,11 +65,9 @@ namespace TcpClient
                     Size = int.Parse(optionSize.Value());
                 }
 
-                WarmupSeconds = optionWarmup.HasValue()
-                    ? int.Parse(optionWarmup.Value())
-                    : 0;
-
-                DurationSeconds = int.Parse(optionDuration.Value());
+                WarmupSeconds = TimeSpan.FromSeconds(optionWarmup.HasValue() ? int.Parse(optionWarmup.Value()) : 0);
+		
+		DurationSeconds = TimeSpan.FromSeconds(int.Parse(optionDuration.Value()));
 
                 Connections = int.Parse(optionConnections.Value());
 

--- a/src/TcpClient/Program.cs
+++ b/src/TcpClient/Program.cs
@@ -13,8 +13,8 @@ namespace TcpClient
         private static string Ip;
         private static int Port = 5201;
         private static int Size = 1;
-        private static TimeSpan WarmupSeconds = default(TimeSpan);
-        private static TimeSpan DurationSeconds = default(TimeSpan);
+        private static TimeSpan Warmup = default(TimeSpan);
+        private static TimeSpan Duration = default(TimeSpan);
         private static int Connections;
         private static Stopwatch _stopwatch = Stopwatch.StartNew();
 
@@ -65,9 +65,9 @@ namespace TcpClient
                     Size = int.Parse(optionSize.Value());
                 }
 
-                WarmupSeconds = TimeSpan.FromSeconds(optionWarmup.HasValue() ? int.Parse(optionWarmup.Value()) : 0);
+                Warmup = TimeSpan.FromSeconds(optionWarmup.HasValue() ? int.Parse(optionWarmup.Value()) : 0);
 		
-		DurationSeconds = TimeSpan.FromSeconds(int.Parse(optionDuration.Value()));
+		        Duration = TimeSpan.FromSeconds(int.Parse(optionDuration.Value()));
 
                 Connections = int.Parse(optionConnections.Value());
 
@@ -88,13 +88,13 @@ namespace TcpClient
 
         private static async Task ScheduleAsync()
         {
-            await Task.Delay(WarmupSeconds);
+            await Task.Delay(Warmup);
 
             Interlocked.Exchange(ref _requests, 0);
 
             _measure = true;
 
-            await Task.Delay(DurationSeconds);
+            await Task.Delay(Duration);
 
             _stopped = true;
         }


### PR DESCRIPTION
Begins addressing #2016 , following @sebastienros guidance (mostly, variable names still have "Seconds" suffix).  Also, not sure it follows style.  But as far as I can tell it works (I tested using .net 8).

Also: compiler (.net 8) complains about missing `await`, but I didn't make those changes since they don't seem related to the specific problem.