### PR TITLE
Razor Slices in Fortunes Middleware

### DIFF
--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <!-- For local dev specify all supported TFMs they can be easily tested -->
   <PropertyGroup Condition="'$(BenchmarksTargetFramework)' == ''">
     <TargetFramework>net9.0</TargetFramework>
@@ -63,6 +63,10 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="$(MicrosoftDataSqlClientVersion90)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftEntityFrameworkCoreSqliteVersion90)" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IntegrationTesting.IIS" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RazorSlices" Version="$(RazorSlicesVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -104,7 +104,7 @@ namespace Benchmarks.Data
                 result = (await db.QueryAsync<Fortune>("SELECT id, message FROM fortune")).AsList();
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time." });
+            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
             result.Sort();
 
             return result;

--- a/src/Benchmarks/Data/DapperDb.cs
+++ b/src/Benchmarks/Data/DapperDb.cs
@@ -20,6 +20,8 @@ namespace Benchmarks.Data
         private readonly DbProviderFactory _dbProviderFactory;
         private readonly string _connectionString;
 
+        private readonly byte[] AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
+
         public DapperDb(IRandom random, DbProviderFactory dbProviderFactory, IOptions<AppSettings> appSettings)
         {
             _random = random;
@@ -104,7 +106,7 @@ namespace Benchmarks.Data
                 result = (await db.QueryAsync<Fortune>("SELECT id, message FROM fortune")).AsList();
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
+            result.Add(new Fortune { Message = AdditionalFortune });
             result.Sort();
 
             return result;

--- a/src/Benchmarks/Data/EfDb.cs
+++ b/src/Benchmarks/Data/EfDb.cs
@@ -83,7 +83,7 @@ namespace Benchmarks.Data
                 result.Add(fortune);
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time." });
+            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
             
             result.Sort();
 

--- a/src/Benchmarks/Data/EfDb.cs
+++ b/src/Benchmarks/Data/EfDb.cs
@@ -18,6 +18,8 @@ namespace Benchmarks.Data
         private readonly IRandom _random;
         private readonly ApplicationDbContext _dbContext;
 
+        private readonly byte[] AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
+
         public EfDb(IRandom random, ApplicationDbContext dbContext, IOptions<AppSettings> appSettings)
         {
             _random = random;
@@ -83,7 +85,7 @@ namespace Benchmarks.Data
                 result.Add(fortune);
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
+            result.Add(new Fortune { Message = AdditionalFortune });
             
             result.Sort();
 

--- a/src/Benchmarks/Data/Fortune.cs
+++ b/src/Benchmarks/Data/Fortune.cs
@@ -19,10 +19,10 @@ namespace Benchmarks.Data
         public int _Id { get; set; }
 
         [Column("message")]
-        [StringLength(2048)]
+        [MaxLength(2048)]
         [IgnoreDataMember]
         [Required]
-        public string Message { get; set; }
+        public byte[] Message { get; set; }
         
         public int CompareTo(object obj)
         {
@@ -31,7 +31,7 @@ namespace Benchmarks.Data
 
         public int CompareTo(Fortune other)
         {
-            return String.CompareOrdinal(Message, other.Message);
+            return Message.AsSpan().SequenceCompareTo(other.Message.AsSpan());
         }
     }
 }

--- a/src/Benchmarks/Data/RawDb.cs
+++ b/src/Benchmarks/Data/RawDb.cs
@@ -19,6 +19,8 @@ namespace Benchmarks.Data
         private readonly DbProviderFactory _dbProviderFactory;
         private readonly string _connectionString;
 
+        private readonly byte[] AdditionalFortune = "Additional fortune added at request time."u8.ToArray();
+
         public RawDb(IRandom random, DbProviderFactory dbProviderFactory, IOptions<AppSettings> appSettings)
         {
             _random = random;
@@ -156,7 +158,7 @@ namespace Benchmarks.Data
                 }
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
+            result.Add(new Fortune { Message = AdditionalFortune });
             result.Sort();
 
             return result;
@@ -190,7 +192,7 @@ namespace Benchmarks.Data
                 }
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
+            result.Add(new Fortune { Message = AdditionalFortune });
             result.Sort();
 
             return result;

--- a/src/Benchmarks/Data/RawDb.cs
+++ b/src/Benchmarks/Data/RawDb.cs
@@ -150,13 +150,13 @@ namespace Benchmarks.Data
                         result.Add(new Fortune
                         {
                             Id = rdr.GetInt32(0),
-                            Message = rdr.GetString(1)
+                            Message = rdr.GetFieldValue<byte[]>(1)
                         });
                     }
                 }
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time." });
+            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
             result.Sort();
 
             return result;
@@ -184,13 +184,13 @@ namespace Benchmarks.Data
                         result.Add(new Fortune
                         {
                             Id = rdr.GetInt32(0),
-                            Message = rdr.GetString(1)
+                            Message = rdr.GetFieldValue<byte[]>(1)
                         });
                     }
                 }
             }
 
-            result.Add(new Fortune { Message = "Additional fortune added at request time." });
+            result.Add(new Fortune { Message = "Additional fortune added at request time."u8.ToArray() });
             result.Sort();
 
             return result;

--- a/src/Benchmarks/Middleware/FortunesDapperMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesDapperMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
@@ -9,6 +10,7 @@ using Benchmarks.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using RazorSlices;
 
 namespace Benchmarks.Middleware
 {
@@ -18,11 +20,13 @@ namespace Benchmarks.Middleware
 
         private readonly RequestDelegate _next;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly SliceFactory<IEnumerable<Fortune>> _fortunesFactory;
 
         public FortunesDapperMiddleware(RequestDelegate next, HtmlEncoder htmlEncoder)
         {
             _next = next;
             _htmlEncoder = htmlEncoder;
+            _fortunesFactory = RazorSlice.ResolveSliceFactory<IEnumerable<Fortune>>("/Templates/Fortunes.cshtml");
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -32,7 +36,7 @@ namespace Benchmarks.Middleware
                 var db = httpContext.RequestServices.GetService<DapperDb>();
                 var rows = await db.LoadFortunesRows();
 
-                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder, _fortunesFactory);
 
                 return;
             }

--- a/src/Benchmarks/Middleware/FortunesEfMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesEfMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
@@ -9,6 +10,7 @@ using Benchmarks.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using RazorSlices;
 
 namespace Benchmarks.Middleware
 {
@@ -18,11 +20,13 @@ namespace Benchmarks.Middleware
 
         private readonly RequestDelegate _next;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly SliceFactory<IEnumerable<Fortune>> _fortunesFactory;
 
         public FortunesEfMiddleware(RequestDelegate next, HtmlEncoder htmlEncoder)
         {
             _next = next;
             _htmlEncoder = htmlEncoder;
+            _fortunesFactory = RazorSlice.ResolveSliceFactory<IEnumerable<Fortune>>("/Templates/Fortunes.cshtml");
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -32,7 +36,7 @@ namespace Benchmarks.Middleware
                 var db = httpContext.RequestServices.GetService<EfDb>();
                 var rows = await db.LoadFortunesRows();
 
-                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder, _fortunesFactory);
 
                 return;
             }

--- a/src/Benchmarks/Middleware/FortunesRawMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesRawMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
@@ -9,6 +10,7 @@ using Benchmarks.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using RazorSlices;
 
 namespace Benchmarks.Middleware
 {
@@ -18,11 +20,13 @@ namespace Benchmarks.Middleware
 
         private readonly RequestDelegate _next;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly SliceFactory<IEnumerable<Fortune>> _fortunesFactory;
 
         public FortunesRawMiddleware(RequestDelegate next, HtmlEncoder htmlEncoder)
         {
             _next = next;
             _htmlEncoder = htmlEncoder;
+            _fortunesFactory = RazorSlice.ResolveSliceFactory<IEnumerable<Fortune>>("/Templates/Fortunes.cshtml");
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -32,7 +36,7 @@ namespace Benchmarks.Middleware
                 var db = httpContext.RequestServices.GetService<RawDb>();
                 var rows = await db.LoadFortunesRows();
 
-                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+                await MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder, _fortunesFactory);
 
                 return;
             }

--- a/src/Benchmarks/Middleware/FortunesRawSyncMiddleware.cs
+++ b/src/Benchmarks/Middleware/FortunesRawSyncMiddleware.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Benchmarks.Configuration;
@@ -9,6 +10,7 @@ using Benchmarks.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using RazorSlices;
 
 namespace Benchmarks.Middleware
 {
@@ -18,11 +20,13 @@ namespace Benchmarks.Middleware
 
         private readonly RequestDelegate _next;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly SliceFactory<IEnumerable<Fortune>> _fortunesFactory;
 
         public FortunesRawSyncMiddleware(RequestDelegate next, HtmlEncoder htmlEncoder)
         {
             _next = next;
             _htmlEncoder = htmlEncoder;
+            _fortunesFactory = RazorSlice.ResolveSliceFactory<IEnumerable<Fortune>>("/Templates/Fortunes.cshtml");
         }
 
         public Task Invoke(HttpContext httpContext)
@@ -32,7 +36,7 @@ namespace Benchmarks.Middleware
                 var db = httpContext.RequestServices.GetService<RawDb>();
                 var rows = db.LoadFortunesRowsSync();
 
-                return MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder);
+                return MiddlewareHelpers.RenderFortunesHtml(rows, httpContext, _htmlEncoder, _fortunesFactory);
             }
 
             return _next(httpContext);

--- a/src/Benchmarks/Templates/Fortunes.cshtml
+++ b/src/Benchmarks/Templates/Fortunes.cshtml
@@ -1,0 +1,2 @@
+﻿@inherits RazorSlice<IEnumerable<Fortune>>
+<!DOCTYPE html><html><head><title>Fortunes</title></head><body><table><tr><th>id</th><th>message</th></tr>@foreach (var item in Model){<tr><td>@WriteNumber(item.Id, default, CultureInfo.InvariantCulture, false)</td><td>@item.Message</td></tr>}</table></body></html>

--- a/src/Benchmarks/Templates/_ViewImports.cshtml
+++ b/src/Benchmarks/Templates/_ViewImports.cshtml
@@ -1,0 +1,10 @@
+﻿@inherits RazorSliceHttpResult
+
+@using System.Globalization;
+@using Microsoft.AspNetCore.Razor;
+@using Microsoft.AspNetCore.Http.HttpResults;
+@using RazorSlices;
+@using Benchmarks.Data;
+
+@tagHelperPrefix __disable_tagHelpers__:
+@removeTagHelper *, Microsoft.AspNetCore.Mvc.Razor


### PR DESCRIPTION
Massively reduces allocations in the Fortunes middleware by using `byte[]` instead of `string` for the `Message` property in the `Fortune` class and writing directly to the `PipeWriter` instead of to a `StringBuilder`. ~2.2GB/sec -> ~1.3GB/sec

Additionally, we've added templating which I believe makes it follow the guidelines for a proper Fortunes benchmark according to Techempower.