### PR TITLE
fix(antiforgery): change /noop endpoint to HTTP GET

### DIFF
--- a/src/BenchmarksApps/Antiforgery/Program.cs
+++ b/src/BenchmarksApps/Antiforgery/Program.cs
@@ -8,7 +8,7 @@ var app = builder.Build();
 app.UseAntiforgery();
 
 app.MapGet("/", () => Results.Ok("hello world!"));
-app.MapPost("/noOp", (HttpContext ctx, IAntiforgery antiforgery) => Results.Ok());
+app.MapGet("/noOp", (HttpContext ctx, IAntiforgery antiforgery) => Results.Ok());
 
 // GET https://localhost:55471/auth
 app.MapGet("/auth", (HttpContext ctx, IAntiforgery antiforgery) =>


### PR DESCRIPTION
Fixing the wrk targeting `/noop` endpoint [mentioned here](https://github.com/aspnet/Benchmarks/pull/2033#discussion_r1848982176)

