### PR TITLE
chore: suppress cred-scan for added test certificates

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -18,6 +18,14 @@
       "_justification": "Legitimate development X.509 Certificate Private Key"
     },
     {
+      "file": "src/BenchmarksApps/TLS/HttpSys/testCert.pfx",
+      "_justification": "Legitimate development X.509 Certificate Private Key"
+    },
+    {
+      "file": "src/BenchmarksApps/TLS/Kestrel/testCert.pfx",
+      "_justification": "Legitimate development X.509 Certificate Private Key"
+    },
+    {
       "file": "src/Downstream/testCert.pfx",
       "_justification": "Legitimate development X.509 Certificate Private Key"
     },


### PR DESCRIPTION
#2037 added 2 test certs (TLS setup), they need to be suppressed for the cred-scan tooling.