### PR TITLE
feat: tls-benchmark running azurelinux3.0

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -217,3 +217,19 @@ scenarios:
         connections: 32
         serverScheme: https
         sslProtocol: tls12
+
+  tls-handshakes-docker-azurelinux:
+    application:
+      job: dockerLinuxKestrelServer
+      variables:
+        # openssl version is already pre-installed with base image
+        dockerFile: dockerKestrel/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
+    load:
+      job: httpclient
+      variables:
+        path: /hello-world
+        serverPort: 8080
+        presetHeaders: connectionclose
+        connections: 32
+        serverScheme: https
+        sslProtocol: tls12

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -221,9 +221,8 @@ scenarios:
   tls-handshakes-docker-azurelinux:
     application:
       job: dockerLinuxKestrelServer
-      variables:
-        # openssl version is already pre-installed with base image
-        dockerFile: dockerKestrel/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
+      # openssl version is already pre-installed with base image (latest)
+      dockerFile: dockerKestrel/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
     load:
       job: httpclient
       variables:

--- a/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
+++ b/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+USER root
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+# This stage is used to build the service project
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["Kestrel.csproj", "."]
+RUN dotnet restore "./Kestrel.csproj"
+COPY . .
+WORKDIR "/src/."
+RUN dotnet build "./Kestrel.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+# This stage is used to publish the service project to be copied to the final stage
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./Kestrel.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+# This stage is used in production or when running from VS in regular mode
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+ENTRYPOINT [ "dotnet", "Kestrel.dll" ]

--- a/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
+++ b/src/BenchmarksApps/TLS/Kestrel/Dockerfile.azurelinux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-azurelinux3.0 AS base
 USER root
 WORKDIR /app
 EXPOSE 8080


### PR DESCRIPTION
test against the [official image](https://github.com/dotnet/dotnet-docker/tree/main/src/aspnet/9.0) provided to run on azure services

example:
> crank --config https://raw.githubusercontent.com/DeagleGross/Benchmarks/refs/heads/dmkorolev/idna/azurelinux-img/scenarios/tls.benchmarks.yml --scenario tls-handshakes-docker-azurelinux --profile aspnet-gold-lin --application.sources.dockerKestrel.repository "https://github.com/deaglegross/benchmarks.git" --application.sources.dockerKestrel.branchOrCommit "dmkorolev/idna/azurelinux-img"

![image](https://github.com/user-attachments/assets/701e13c6-aa78-4a7f-b28d-9749173c9c80)
