### PR TITLE
fix: properly pass headers to client for rejection scenarios

### DIFF
--- a/scenarios/rejection.benchmarks.yml
+++ b/scenarios/rejection.benchmarks.yml
@@ -106,7 +106,7 @@ scenarios:
         connections: 32
         serverScheme: https
         customHeaders:
-        - X-Custom: "Québec"
+        - "X-Custom: Québec"
     
   kestrel-hostheader-mismatch:
     application:
@@ -118,4 +118,4 @@ scenarios:
         connections: 32
         serverScheme: https
         customHeaders:
-        - Host: "google.com"
+        - "Host: google.com"

--- a/scenarios/rejection.benchmarks.yml
+++ b/scenarios/rejection.benchmarks.yml
@@ -69,7 +69,7 @@ scenarios:
         connections: 32
         serverScheme: https
         customHeaders:
-        - X-Custom: "Québec"
+        - "X-Custom: Québec"
 
   httpsys-hostheader-mismatch:
     application:
@@ -81,7 +81,7 @@ scenarios:
         connections: 32
         serverScheme: https
         customHeaders:
-        - Host: "google.com"
+        - "Host: google.com"
 
 # Kestrel
   


### PR DESCRIPTION
it was passing the args incorrectly: 
![image](https://github.com/user-attachments/assets/8e272a99-6319-4ae6-9fe4-99bd4001f1e7)
