### PR TITLE
fix: specify correct openssl version 3.3.x

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -169,7 +169,7 @@ scenarios:
       job: dockerLinuxKestrelServer
       buildArguments: 
         # openssl version to install
-        - OPENSSL_VERSION="3.3.2-r4"
+        - OPENSSL_VERSION="3.3.3-r0"
         # lookup for openssl+branch version here https://pkgs.alpinelinux.org/packages?name=openssl&branch=v3.20&repo=&arch=x86_64
         - ALPINE_BRANCH="v3.21"
     load:


### PR DESCRIPTION
fixing error below
> An unexpected error occurred while building the job: One or more errors occurred. (Command docker build --pull --build-arg OPENSSL_VERSION="3.3.2-r4" --build-arg ALPINE_BRANCH="v3.21"  -t benchmarks_dockerkestrel -f dockerKestrel/src/BenchmarksApps/TLS/Kestrel/Dockerfile /tmp/benchmarks-agent/benchmarks-server-1/1x2pt4nj.w5o/dockerKestrel/src/BenchmarksApps/TLS/Kestrel returned exit code 1)

because the version changed to 3.3.3-r0 https://pkgs.alpinelinux.org/packages?name=openssl&branch=v3.21&repo=&arch=x86_64&origin=yes&flagged=&maintainer=