### PR TITLE
fix: re-set the netsh sslcert bindings after reconfiguration

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -20,10 +20,9 @@ jobs:
       tlsRenegotiation: false # enables client cert validation
       # debug settings
       certValidationConsoleEnabled: false
-      httpSysLogs: false
       statsEnabled: false
       logRequestDetails: false
-    arguments: "--urls https://{{serverAddress}}:{{serverPort}} --mTLS {{mTLS}} --certValidationConsoleEnabled {{certValidationConsoleEnabled}} --statsEnabled {{statsEnabled}} --tlsRenegotiation {{tlsRenegotiation}} --httpSysLogs {{httpSysLogs}} --logRequestDetails {{logRequestDetails}}"
+    arguments: "--urls https://{{serverAddress}}:{{serverPort}} --mTLS {{mTLS}} --certValidationConsoleEnabled {{certValidationConsoleEnabled}} --statsEnabled {{statsEnabled}} --tlsRenegotiation {{tlsRenegotiation}} --logRequestDetails {{logRequestDetails}}"
 
   kestrelServer:
     source:
@@ -81,7 +80,6 @@ scenarios:
       variables:
         mTLS: true # enables settings on http.sys to negotiate client cert on connections
         tlsRenegotiation: true # enables client cert validation
-        httpSysLogs: false # only for debug purposes
         certValidationConsoleEnabled: false # only for debug purposes
         serverPort: 8080 # IMPORTANT: not to intersect with other tests in case http.sys configuration impacts other benchmarks
     load:
@@ -102,7 +100,6 @@ scenarios:
       variables:
         mTLS: false
         tlsRenegotiation: true
-        httpSysLogs: false # only for debug purposes
         certValidationConsoleEnabled: false # only for debug purposes
     load:
       job: httpclient

--- a/src/BenchmarksApps/TLS/HttpSys/Program.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/Program.cs
@@ -20,8 +20,12 @@ var logRequestDetails = bool.TryParse(builder.Configuration["logRequestDetails"]
 // existing netsh bindings to restore after the benchmark run
 if (!NetShWrapper.BindingExists(httpsIpPort, out var originalCertThumbprint, out var originalAppId))
 {
-    Console.WriteLine("WARNING: no binding existed...");
-    throw new ApplicationException($"SslCert binding should exist for '{httpsIpPort}' before. Infrastructure error.");
+    Console.WriteLine($"No binding existed. Need to self-sign it and bind to '{httpsIpPort}'");
+    if (!NetShWrapper.TrySelfSignCertificate(httpsIpPort, out originalCertThumbprint))
+    {
+        throw new ApplicationException($"Failed to setup ssl binding for '{httpsIpPort}'. Please unblock the VM.");
+    }
+    NetShWrapper.SetCertBinding(httpsIpPort, originalCertThumbprint);
 }
 
 #pragma warning disable CA1416 // Can be launched only on Windows (HttpSys)

--- a/src/BenchmarksApps/TLS/HttpSys/Program.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/Program.cs
@@ -20,7 +20,7 @@ var logRequestDetails = bool.TryParse(builder.Configuration["logRequestDetails"]
 // existing netsh bindings to restore after the benchmark run
 if (!NetShWrapper.BindingExists(httpsIpPort, out var originalCertThumbprint, out var originalAppId))
 {
-    Console.WriteLine("WARNING: no binding existed, performing a new self-signed certificate generation and binding...");
+    Console.WriteLine("WARNING: no binding existed...");
     throw new ApplicationException($"SslCert binding should exist for '{httpsIpPort}' before. Infrastructure error.");
 }
 
@@ -89,6 +89,7 @@ if (mTlsEnabled)
         {
             NetShWrapper.DeleteBinding(ipPort: httpsIpPort);
             NetShWrapper.SetCertBinding(ipPort: httpsIpPort, certThumbprint: originalCertThumbprint, appId: originalAppId);
+            NetShWrapper.Show();
         }
         catch
         {

--- a/src/BenchmarksApps/TLS/HttpSys/Properties/launchSettings.json
+++ b/src/BenchmarksApps/TLS/HttpSys/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "hello-world",
-      "applicationUrl": "https://localhost:5000;http://localhost:5001",
+      "applicationUrl": "https://127.0.0.1:5000;http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
After mTLS tests run, machine is left in a broken state (no ssl cert binding existing there). We need to reset the binding correctly after test finishes