### PR TITLE
feat: disable tls-resumption for tls jobs

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -65,11 +65,12 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v MaximumCacheSize /t REG_DWORD /d 0 /f
-      afterScript: |
-        Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore
-        Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore
-        Restart-Service -Name Http -Force
+      beforeScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
+      # afterScript: /
+      #   Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore
+      #   Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore
+      #   Restart-Service -Name Http -Force
+      #   echo "Rollbacked HTTP.SYS Registry to default"
     load:
       job: httpclient
       variables:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -65,6 +65,16 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
+      beforeScript: /
+        powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0";
+        powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0";
+        powershell -Command "Restart-Service -Name Http -Force";
+        echo "Disabled HTTP.SYS TLS Resumption"
+      afterScript: /
+        Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore
+        Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore
+        Restart-Service -Name Http -Force
+        echo "Rollbacked HTTP.SYS Registry to default"
     load:
       job: httpclient
       variables:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -9,7 +9,7 @@ variables:
 
   # these scripts allow to disable (or rollback changes) to the SChannel registry
   # this allows to disable TLS resumption on windows level
-  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force;"
+  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0 -ErrorAction Ignore; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0 -ErrorAction Ignore; Restart-Service -Name Http -Force;"
   rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force;"
 
 jobs:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -66,9 +66,10 @@ scenarios:
     application:
       job: httpSysServer
       beforeScript: /
-        pwsh -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0";
-        pwsh -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0";
-        pwsh -Command "Restart-Service -Name Http -Force";
+        reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v MaximumCacheSize /t REG_DWORD /d 0 /f
+        reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v ServerCacheTime /t REG_DWORD /d 0 /f
+        net stop http
+        net start http
         echo "Disabled HTTP.SYS TLS Resumption"
       afterScript: /
         Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -66,9 +66,9 @@ scenarios:
     application:
       job: httpSysServer
       beforeScript: /
-        powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0";
-        powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0";
-        powershell -Command "Restart-Service -Name Http -Force";
+        pwsh -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0";
+        pwsh -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0";
+        pwsh -Command "Restart-Service -Name Http -Force";
         echo "Disabled HTTP.SYS TLS Resumption"
       afterScript: /
         Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -10,7 +10,7 @@ variables:
   # these scripts allow to disable (or rollback changes) to the SChannel registry
   # this allows to disable TLS resumption on windows level
   disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0 -ErrorAction Ignore; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0 -ErrorAction Ignore; Restart-Service -Name Http -Force;"
-  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force;"
+  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force;"
 
 jobs:
   httpSysServer:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -10,7 +10,7 @@ variables:
   # these scripts allow to disable (or rollback changes) to the SChannel registry
   # this allows to disable TLS resumption on windows level
   disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0 -ErrorAction Ignore; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0 -ErrorAction Ignore; Restart-Service -Name Http -Force;"
-  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force;"
+  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name MaximumCacheSize -ErrorAction Ignore; Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name ServerCacheTime -ErrorAction Ignore; Restart-Service -Name Http -Force;"
 
 jobs:
   httpSysServer:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -65,17 +65,11 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: /
-        reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v MaximumCacheSize /t REG_DWORD /d 0 /f
-        reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v ServerCacheTime /t REG_DWORD /d 0 /f
-        net stop http
-        net start http
-        echo "Disabled HTTP.SYS TLS Resumption"
-      afterScript: /
+      beforeScript: reg add "HKLM\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" /v MaximumCacheSize /t REG_DWORD /d 0 /f
+      afterScript: |
         Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore
         Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore
         Restart-Service -Name Http -Force
-        echo "Rollbacked HTTP.SYS Registry to default"
     load:
       job: httpclient
       variables:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -6,6 +6,8 @@
 
 variables:
   serverPort: 5000
+  httpSysBeforeScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
+  httpSysAfterScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force; Write-Host 'Rollbacked HTTP.SYS'"
 
 jobs:
   httpSysServer:
@@ -65,12 +67,8 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
-      # afterScript: /
-      #   Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore
-      #   Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore
-      #   Restart-Service -Name Http -Force
-      #   echo "Rollbacked HTTP.SYS Registry to default"
+      beforeScript: "{{httpSysBeforeScript}}"
+      afterScript: "{{httpSysAfterScript}}"
     load:
       job: httpclient
       variables:

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -6,8 +6,11 @@
 
 variables:
   serverPort: 5000
-  httpSysBeforeScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
-  httpSysAfterScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force; Write-Host 'Rollbacked HTTP.SYS'"
+
+  # these scripts allow to disable (or rollback changes) to the SChannel registry
+  # this allows to disable TLS resumption on windows level
+  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
+  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force; Write-Host 'Rollbacked HTTP.SYS'"
 
 jobs:
   httpSysServer:
@@ -67,8 +70,8 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: "{{httpSysBeforeScript}}"
-      afterScript: "{{httpSysAfterScript}}"
+      beforeScript: "{{disableTlsResumptionScript}}"
+      afterScript: "{{rollbackTlsResumptionScript}}"
     load:
       job: httpclient
       variables:
@@ -81,6 +84,8 @@ scenarios:
   mTls-handshakes-httpsys:
     application:
       job: httpSysServer
+      beforeScript: "{{disableTlsResumptionScript}}"
+      afterScript: "{{rollbackTlsResumptionScript}}"
       variables:
         mTLS: true # enables settings on http.sys to negotiate client cert on connections
         tlsRenegotiation: true # enables client cert validation
@@ -101,6 +106,8 @@ scenarios:
   tls-renegotiation-httpsys:
     application:
       job: httpSysServer
+      beforeScript: "{{disableTlsResumptionScript}}"
+      afterScript: "{{rollbackTlsResumptionScript}}"
       variables:
         mTLS: false
         tlsRenegotiation: true

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -9,8 +9,8 @@ variables:
 
   # these scripts allow to disable (or rollback changes) to the SChannel registry
   # this allows to disable TLS resumption on windows level
-  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force; Write-Host 'Disabled TLS Resumption'"
-  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force; Write-Host 'Rollbacked HTTP.SYS'"
+  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0; Restart-Service -Name Http -Force;"
+  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name ServerCacheTime -ErrorAction Ignore; Remove-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -Name EnableSessionTicket -ErrorAction Ignore; Restart-Service -Name Http -Force;"
 
 jobs:
   httpSysServer:

--- a/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
@@ -13,5 +13,15 @@
 
         public bool SessionIdTlsResumptionEnabled { get; set; }
         public bool SessionTicketTlsResumptionEnabled { get; set; }
+
+        public override string ToString() => $"""
+            Parsed NetSh Ssl Certificate Binding Info:
+                Certificate thumbprint: {CertificateThumbprint}
+                Application ID: {ApplicationId}
+                Negotiate client certificate: {NegotiateClientCertificate}
+                Session ID TLS resumption enabled: {SessionIdTlsResumptionEnabled}
+                Session Ticket TLS resumption enabled: {SessionTicketTlsResumptionEnabled}
+            -----
+        """;
     }
 }

--- a/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
@@ -1,0 +1,17 @@
+﻿namespace HttpSys.NetSh
+{
+    public class SslCertBinding
+    {
+        public string CertificateThumbprint { get; set; }
+
+        public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// if mutual TLS is enabled
+        /// </summary>
+        public bool NegotiateClientCertificate { get; set; }
+
+        public bool SessionIdTlsResumptionEnabled { get; set; }
+        public bool SessionTicketTlsResumptionEnabled { get; set; }
+    }
+}

--- a/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
@@ -15,12 +15,11 @@
         public bool SessionTicketTlsResumptionEnabled { get; set; }
 
         public override string ToString() => $"""
-            Parsed NetSh Ssl Certificate Binding Info:
-                Certificate thumbprint: {CertificateThumbprint}
-                Application ID: {ApplicationId}
-                Negotiate client certificate: {NegotiateClientCertificate}
-                Session ID TLS resumption enabled: {SessionIdTlsResumptionEnabled}
-                Session Ticket TLS resumption enabled: {SessionTicketTlsResumptionEnabled}
+            Certificate thumbprint: {CertificateThumbprint}
+            Application ID: {ApplicationId}
+            Negotiate client certificate: {NegotiateClientCertificate}
+            Session ID TLS resumption enabled: {SessionIdTlsResumptionEnabled}
+            Session Ticket TLS resumption enabled: {SessionTicketTlsResumptionEnabled}
             -----
         """;
     }

--- a/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
@@ -9,18 +9,26 @@
         /// <summary>
         /// if mutual TLS is enabled
         /// </summary>
-        public bool NegotiateClientCertificate { get; set; }
+        public NetShFlag NegotiateClientCertificate { get; set; }
 
-        public bool SessionIdTlsResumptionEnabled { get; set; }
-        public bool SessionTicketTlsResumptionEnabled { get; set; }
+        public NetShFlag DisableSessionIdTlsResumption { get; set; }
+        public NetShFlag EnableSessionTicketTlsResumption { get; set; }
 
         public override string ToString() => $"""
             Certificate thumbprint: {CertificateThumbprint}
             Application ID: {ApplicationId}
             Negotiate client certificate: {NegotiateClientCertificate}
-            Session ID TLS resumption enabled: {SessionIdTlsResumptionEnabled}
-            Session Ticket TLS resumption enabled: {SessionTicketTlsResumptionEnabled}
+            Disable Session ID TLS Resumption: {DisableSessionIdTlsResumption}
+            Enable Session Ticket TLS Resumption: {EnableSessionTicketTlsResumption}
             -----
         """;
+    }
+
+    public enum NetShFlag
+    {
+        NotSet = 0,
+
+        Disabled = 1,
+        Enable = 2
     }
 }

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -118,7 +118,7 @@ namespace HttpSys
             {
                 "Not Set" => NetShFlag.NotSet,
                 "Disable" or "Disabled" => NetShFlag.Disabled,
-                "Enable" or "Set" => NetShFlag.Enable,
+                "Enable" or "Enabled" or "Set" => NetShFlag.Enable,
                 _ => throw new ArgumentOutOfRangeException(nameof(prop), $"unexpected netsh flag '{prop}' for ssl cert binding"),
             };
         }

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -221,14 +221,20 @@ namespace HttpSys
             {
                 command += $" clientcertnegotiation={clientcertnegotiationFlag}";
             }
+
+            // below options are supported only in later versions of HTTP.SYS
+            // you can identify if it is available by running `netsh http add sslcert help`
+            // ---
+            // workaround is to control SChannel settings via registry
+
             //if (disablesessionidFlag != null)
             //{
             //    command += $" disablesessionid={disablesessionidFlag}";
             //}
-            if (enablesessionticketFlag != null)
-            {
-                command += $" enablesessionticket={enablesessionticketFlag}";
-            }
+            //if (enablesessionticketFlag != null)
+            //{
+            //    command += $" enablesessionticket={enablesessionticketFlag}";
+            //}
 
             ExecuteNetShCommand(command, alwaysLogOutput: true);
             Console.WriteLine($"Performed cert binding for {ipPort}");

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using HttpSys.NetSh;
 
 namespace HttpSys
 {
@@ -28,12 +29,49 @@ namespace HttpSys
             Console.WriteLine("Disabled http.sys settings for mTLS");
         }
 
-        public static bool BindingExists(string ipPort, out string certThumbprint, out string appId)
-        {
-            certThumbprint = string.Empty;
-            appId = string.Empty;
 
-            var bindings = ExecuteNetShCommand("http show sslcert");
+
+        public static bool TryGetSslCertBinding(string ipPort, out SslCertBinding result)
+        {
+            result = new SslCertBinding();
+
+            /*
+             Example of output:
+             -----------------
+                IP:port                      : <ip:port>
+                Certificate Hash             : <hash>
+                Application ID               : {<guid>}
+                Certificate Store Name       : <store-name>
+                Verify Client Certificate Revocation : Enabled
+                Verify Revocation Using Cached Client Certificate Only : Disabled
+                Usage Check                  : Enabled
+                Revocation Freshness Time    : 0
+                URL Retrieval Timeout        : 0
+                Ctl Identifier               : (null)
+                Ctl Store Name               : (null)
+                DS Mapper Usage              : Disabled
+                Negotiate Client Certificate : Disabled
+                Reject Connections           : Disabled
+                Disable HTTP2                : Not Set
+                Disable QUIC                 : Not Set
+                Disable TLS1.2               : Not Set
+                Disable TLS1.3               : Not Set
+                Disable OCSP Stapling        : Not Set
+                Enable Token Binding         : Not Set
+                Log Extended Events          : Not Set
+                Disable Legacy TLS Versions  : Not Set
+                Enable Session Ticket        : Not Set
+                Disable Session ID           : Not Set
+                Enable Caching Client Hello  : Not Set
+             Extended Properties:
+                PropertyId                   : 0
+                Receive Window               : 1048576
+             Extended Properties:
+                PropertyId                   : 1
+                Max Settings Per Frame       : 2796202
+                Max Settings Per Minute      : 4294967295
+             */
+            var bindings = ExecuteNetShCommand($"http show sslcert ipport={ipPort}");
             if (string.IsNullOrEmpty(bindings) || !bindings.Contains(ipPort))
             {
                 return false;
@@ -43,17 +81,45 @@ namespace HttpSys
             var thumbprintMatch = Regex.Match(bindings, @"Certificate Hash\s+:\s+([a-fA-F0-9]+)");
             if (thumbprintMatch.Success)
             {
-                certThumbprint = thumbprintMatch.Groups[1].Value;
+                result.CertificateThumbprint = thumbprintMatch.Groups[1].Value;
             }
 
             // Extract the application ID
             var appIdMatch = Regex.Match(bindings, @"Application ID\s+:\s+{([a-fA-F0-9-]+)}");
             if (appIdMatch.Success)
             {
-                appId = appIdMatch.Groups[1].Value;
+                result.ApplicationId = appIdMatch.Groups[1].Value;
+            }
+
+            var negotiateClientCertEnabledRegex = Regex.Match(bindings, @"Negotiate Client Certificate\s+:\s+([a-zA-Z0-9]+)");
+            if (negotiateClientCertEnabledRegex.Success)
+            {
+                var negotiateClientCertValue = negotiateClientCertEnabledRegex.Groups[1].Value;
+                result.NegotiateClientCertificate = IsEnabled(negotiateClientCertValue);
+            }
+
+            var disableSessionId = Regex.Match(bindings, @"Disable Session ID\s+:\s+([a-zA-Z0-9 ]+)");
+            if (disableSessionId.Success)
+            {
+                var disableSessionIdValue = disableSessionId.Groups[1].Value;
+                result.SessionIdTlsResumptionEnabled = !IsEnabled(disableSessionIdValue);
+            }
+
+            var enableSessionTicket = Regex.Match(bindings, @"Enable Session Ticket\s+:\s+([a-zA-Z0-9 ]+)");
+            if (enableSessionTicket.Success)
+            {
+                var enableSessionTicketValue = enableSessionTicket.Groups[1].Value;
+                result.SessionTicketTlsResumptionEnabled = IsEnabled(enableSessionTicketValue);
             }
 
             return true;
+
+            // http will return "Disabled" or "Not Set" for properties which are disabled
+            bool IsEnabled(string prop)
+            {
+                if (prop is "Disabled" or "Not Set") return false;
+                return true;
+            }
         }
 
         public static void Show()
@@ -76,7 +142,7 @@ namespace HttpSys
             }
 
             string certThumbprint = certificate.Thumbprint;
-            SetCertBinding(ipPort, certThumbprint, enableClientCertNegotiation: enableClientCertNegotiation);
+            AddCertBinding(ipPort, certThumbprint, enableClientCertNegotiation: enableClientCertNegotiation);
 
             Console.WriteLine("Configured binding for testCert for http.sys");
         }
@@ -108,16 +174,42 @@ namespace HttpSys
             }
         }
 
-        public static void SetCertBinding(string ipPort, string certThumbprint, string appId = null, bool enableClientCertNegotiation = false)
+        public static void AddCertBinding(
+            string ipPort, string certThumbprint,
+            string? appId = null,
+            bool enableClientCertNegotiation = false,
+            bool disablesessionid = true,
+            bool enablesessionticket = false)
+        => CertBindingCore("add", ipPort, certThumbprint, appId, enableClientCertNegotiation, disablesessionid, enablesessionticket);
+
+        public static void UpdateCertBinding(string ipPort, SslCertBinding binding)
+            => UpdateCertBinding(ipPort, binding.CertificateThumbprint, binding.ApplicationId, binding.NegotiateClientCertificate, !binding.SessionIdTlsResumptionEnabled, binding.SessionTicketTlsResumptionEnabled);
+
+        public static void UpdateCertBinding(
+            string ipPort, string certThumbprint,
+            string? appId = null,
+            bool enableClientCertNegotiation = false,
+            bool disablesessionid = true,
+            bool enablesessionticket = false)
+        => CertBindingCore("update", ipPort, certThumbprint, appId, enableClientCertNegotiation, disablesessionid, enablesessionticket);
+
+        private static void CertBindingCore(
+            string httpOperation,
+            string ipPort, string certThumbprint,
+            string? appId = null,
+            bool enableClientCertNegotiation = false,
+            bool disablesessionid = true,
+            bool enablesessionticket = false)
         {
-            var negotiateClientCert = enableClientCertNegotiation ? "enable" : "disable";
             if (string.IsNullOrEmpty(appId))
             {
                 appId = "00000000-0000-0000-0000-000000000000";
             }
-            string command = $"http add sslcert ipport={ipPort} certstorename=MY certhash={certThumbprint} appid={{{appId}}} clientcertnegotiation={negotiateClientCert}";
+            string command = $"http {httpOperation} sslcert ipport={ipPort} certstorename=MY certhash={certThumbprint} appid={{{appId}}} clientcertnegotiation={GetFlagValue(enableClientCertNegotiation)} disablesessionid={GetFlagValue(disablesessionid)} enablesessionticket={GetFlagValue(enablesessionticket)}";
             ExecuteNetShCommand(command);
-            Console.WriteLine($"Performed cert bindign for {ipPort}");
+            Console.WriteLine($"Performed cert binding for {ipPort}");
+
+            string GetFlagValue(bool flag) => flag ? "enable" : "disable";
         }
 
         private static string ExecutePowershellCommand(string command, bool alwaysLogOutput = false)

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -230,7 +230,7 @@ namespace HttpSys
                 command += $" enablesessionticket={enablesessionticketFlag}";
             }
 
-            ExecuteNetShCommand(command);
+            ExecuteNetShCommand(command, alwaysLogOutput: true);
             Console.WriteLine($"Performed cert binding for {ipPort}");
 
             string? GetFlagValue(NetShFlag flag) => flag switch
@@ -248,7 +248,7 @@ namespace HttpSys
         private static string ExecuteNetShCommand(string command, bool alwaysLogOutput = false)
             => ExecuteCommand("netsh", command, alwaysLogOutput);
 
-        private static string ExecuteCommand(string fileName, string command, bool alwaysLogOutput = false)
+        private static string ExecuteCommand(string fileName, string command, bool logOutput = false)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(fileName, command)
             {
@@ -263,7 +263,7 @@ namespace HttpSys
             string output = process.StandardOutput.ReadToEnd();
             process.WaitForExit();
 
-            if (alwaysLogOutput)
+            if (logOutput)
             {
                 Console.WriteLine(output);
             }

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -102,7 +102,6 @@ namespace HttpSys
             if (disableSessionId.Success)
             {
                 var disableSessionIdValue = disableSessionId.Groups[1].Value;
-                Console.WriteLine("Debug: Disable Session ID = " + disableSessionIdValue);
                 result.SessionIdTlsResumptionEnabled = !IsEnabled(disableSessionIdValue);
             }
 
@@ -110,7 +109,6 @@ namespace HttpSys
             if (enableSessionTicket.Success)
             {
                 var enableSessionTicketValue = enableSessionTicket.Groups[1].Value;
-                Console.WriteLine("Debug: Enable Session Ticket = " + enableSessionTicketValue);
                 result.SessionTicketTlsResumptionEnabled = IsEnabled(enableSessionTicketValue);
             }
 
@@ -124,9 +122,9 @@ namespace HttpSys
             }
         }
 
-        public static void Show()
+        public static void LogSslCertBinding(string ipPort)
         {
-            ExecuteNetShCommand("http show sslcert", alwaysLogOutput: true);
+            ExecuteNetShCommand($"http show sslcert ipport={ipPort}", alwaysLogOutput: true);
         }
 
         public static void SetTestCertBinding(string ipPort, bool enableClientCertNegotiation)

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -102,6 +102,7 @@ namespace HttpSys
             if (disableSessionId.Success)
             {
                 var disableSessionIdValue = disableSessionId.Groups[1].Value;
+                Console.WriteLine("Debug: Disable Session ID = " + disableSessionIdValue);
                 result.SessionIdTlsResumptionEnabled = !IsEnabled(disableSessionIdValue);
             }
 
@@ -109,12 +110,13 @@ namespace HttpSys
             if (enableSessionTicket.Success)
             {
                 var enableSessionTicketValue = enableSessionTicket.Groups[1].Value;
+                Console.WriteLine("Debug: Enable Session Ticket = " + enableSessionTicketValue);
                 result.SessionTicketTlsResumptionEnabled = IsEnabled(enableSessionTicketValue);
             }
 
             return true;
 
-            // http will return "Disabled" or "Not Set" for properties which are disabled
+            // http will return "Disabled" or "Not Set" for properties which are not explicitly turned on
             bool IsEnabled(string prop)
             {
                 if (prop is "Disabled" or "Not Set") return false;

--- a/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetShWrapper.cs
@@ -221,10 +221,10 @@ namespace HttpSys
             {
                 command += $" clientcertnegotiation={clientcertnegotiationFlag}";
             }
-            if (disablesessionidFlag != null)
-            {
-                command += $" disablesessionid={disablesessionidFlag}";
-            }
+            //if (disablesessionidFlag != null)
+            //{
+            //    command += $" disablesessionid={disablesessionidFlag}";
+            //}
             if (enablesessionticketFlag != null)
             {
                 command += $" enablesessionticket={enablesessionticketFlag}";

--- a/src/BenchmarksApps/TLS/HttpSys/Program.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/Program.cs
@@ -119,7 +119,7 @@ if (tlsRenegotiationEnabled)
 
 await app.StartAsync();
 
-NetShWrapper.Show();
+NetShWrapper.LogSslCertBinding(httpsIpPort);
 
 Console.WriteLine("Application Info:");
 if (mTlsEnabled)

--- a/src/BenchmarksApps/TLS/HttpSys/Program.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/Program.cs
@@ -26,7 +26,9 @@ if (!NetShWrapper.TryGetSslCertBinding(httpsIpPort, out var sslCertBinding))
     }
     NetShWrapper.AddCertBinding(httpsIpPort, originalCertThumbprint, disablesessionid: true, enablesessionticket: false, enableClientCertNegotiation: mTlsEnabled);
 }
-else if (sslCertBinding.SessionIdTlsResumptionEnabled || sslCertBinding.SessionTicketTlsResumptionEnabled)
+
+Console.WriteLine("Current netsh ssl certificate binding: " + sslCertBinding);
+if (sslCertBinding.SessionIdTlsResumptionEnabled || sslCertBinding.SessionTicketTlsResumptionEnabled)
 {
     Console.WriteLine($"SslCert bind to '{httpsIpPort}' has TLS resumption enabled. Need to turn it off for pure TLS benchmarks.");
     NetShWrapper.UpdateCertBinding(httpsIpPort, sslCertBinding.CertificateThumbprint, appId: sslCertBinding.ApplicationId, disablesessionid: true, enablesessionticket: false, enableClientCertNegotiation: mTlsEnabled);

--- a/src/BenchmarksApps/TLS/HttpSys/Program.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/Program.cs
@@ -28,7 +28,7 @@ if (!NetShWrapper.TryGetSslCertBinding(httpsIpPort, out var sslCertBinding))
 }
 else if (sslCertBinding.SessionIdTlsResumptionEnabled || sslCertBinding.SessionTicketTlsResumptionEnabled)
 {
-    Console.WriteLine($"SslCert bind to '{httpsIpPort}' has TLS resumption enabled. Need to turn it off.");
+    Console.WriteLine($"SslCert bind to '{httpsIpPort}' has TLS resumption enabled. Need to turn it off for pure TLS benchmarks.");
     NetShWrapper.UpdateCertBinding(httpsIpPort, sslCertBinding.CertificateThumbprint, appId: sslCertBinding.ApplicationId, disablesessionid: true, enablesessionticket: false, enableClientCertNegotiation: mTlsEnabled);
 }
 

--- a/src/BenchmarksApps/TLS/Kestrel/Program.cs
+++ b/src/BenchmarksApps/TLS/Kestrel/Program.cs
@@ -60,7 +60,7 @@ builder.WebHost.UseKestrel(options =>
                 // forcefully disable TLS resumption
                 options.OnAuthenticate = (connectionContext, sslServerAuthOptions) =>
                 {
-                    // sslServerAuthOptions.AllowTlsResume = false;
+                    sslServerAuthOptions.AllowTlsResume = false;
                 };
 
                 if (mTlsEnabled)

--- a/src/BenchmarksApps/TLS/Kestrel/Program.cs
+++ b/src/BenchmarksApps/TLS/Kestrel/Program.cs
@@ -60,6 +60,7 @@ builder.WebHost.UseKestrel(options =>
                 // forcefully disable TLS resumption
                 options.OnAuthenticate = (connectionContext, sslServerAuthOptions) =>
                 {
+                    Console.WriteLine("Dis-allowed TLS resumption");
                     sslServerAuthOptions.AllowTlsResume = false;
                 };
 

--- a/src/BenchmarksApps/TLS/Kestrel/Program.cs
+++ b/src/BenchmarksApps/TLS/Kestrel/Program.cs
@@ -60,7 +60,6 @@ builder.WebHost.UseKestrel(options =>
                 // forcefully disable TLS resumption
                 options.OnAuthenticate = (connectionContext, sslServerAuthOptions) =>
                 {
-                    Console.WriteLine("Dis-allowed TLS resumption");
                     sslServerAuthOptions.AllowTlsResume = false;
                 };
 

--- a/src/BenchmarksApps/TLS/Kestrel/Program.cs
+++ b/src/BenchmarksApps/TLS/Kestrel/Program.cs
@@ -57,6 +57,12 @@ builder.WebHost.UseKestrel(options =>
                     options.SslProtocols = supportedTlsVersions.Value;
                 }
 
+                // forcefully disable TLS resumption
+                options.OnAuthenticate = (connectionContext, sslServerAuthOptions) =>
+                {
+                    sslServerAuthOptions.AllowTlsResume = false;
+                };
+
                 if (mTlsEnabled)
                 {
                     options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;

--- a/src/BenchmarksApps/TLS/Kestrel/Program.cs
+++ b/src/BenchmarksApps/TLS/Kestrel/Program.cs
@@ -60,7 +60,7 @@ builder.WebHost.UseKestrel(options =>
                 // forcefully disable TLS resumption
                 options.OnAuthenticate = (connectionContext, sslServerAuthOptions) =>
                 {
-                    sslServerAuthOptions.AllowTlsResume = false;
+                    // sslServerAuthOptions.AllowTlsResume = false;
                 };
 
                 if (mTlsEnabled)


### PR DESCRIPTION
For Kestrel disable is done via [SslServerAuthenticationOptions.AllowTlsResume](https://learn.microsoft.com/en-gb/dotnet/api/system.net.security.sslserverauthenticationoptions.allowtlsresume?view=net-9.0).

For http.sys I have added code to control it as netsh parameters:
```
> netsh http add sslcert help
        enablesessionticket: When set, TLS session ticket resumption is enabled.
        disablesessionid: When set, TLS session id resumption is disabled.
```

but due to underlying OS dependency, not all agents support it, so I am controlling resumption via registry settings of SChannel.
```bash
New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0 
New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0
Restart-Service -Name Http -Force
```

Validation of TLS Resumption being turned off was done via openssl traces. In example
> openssl s_client -connect 10.0.4.15:5000 -sess_out session13.pem -tls1_3
...
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
SSL-Session: // returned session-id and session-ticket
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_256_GCM_SHA384
    Session-ID: BA80...80B
    Session-ID-ctx:
    TLS session ticket:
    0000 - 84 4a 00 00 ...
    
And for next request we can see still `new` tls handshake and another session-id and session-ticket:
> openssl s_client -connect 10.0.4.15:5000 -sess_in session13.pem -tls1_3
...
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
SSL-Session:
    Protocol  : TLSv1.3
    Cipher    : TLS_AES_256_GCM_SHA384
    Session-ID: 487C...633
    TLS session ticket:
    0000 - f1 43 00 00 ...

That confirms that even trying to reuse the same session from client side, we end up establishing new tls handshake.