### PR TITLE
fix: dont use relay config for ci idna jobs

### DIFF
--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -51,6 +51,31 @@ profiles:
           - warmup
           - secondary
 
+  idna-intel-lin:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.0.4.12
+      cores: 4
+    jobs: 
+      db:
+        endpoints: 
+          - http://10.0.4.6:5001
+        aliases:
+          - extra
+      application:
+        endpoints: 
+          - http://10.0.4.12:5001
+        variables:
+          databaseServer: 10.0.4.6
+        aliases:
+          - main
+      load:
+        endpoints: 
+          - http://10.0.4.13:5001 # idna-amd-lin
+        aliases:
+          - warmup
+          - secondary
+
   idna-intel-lin-relay:
     variables:
       serverPort: 5000
@@ -72,6 +97,31 @@ profiles:
       load:
         endpoints: 
           - https://aspnetperf.servicebus.windows.net/idnaamdlin
+        aliases:
+          - warmup
+          - secondary
+
+  idna-amd-lin:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.0.4.13
+      cores: 4
+    jobs: 
+      db:
+        endpoints: 
+          - http://10.0.4.6:5001
+        aliases:
+          - extra
+      application:
+        endpoints: 
+          - http://10.0.4.13:5001
+        variables:
+          databaseServer: 10.0.4.6
+        aliases:
+          - main
+      load:
+        endpoints: 
+          - http://10.0.4.12:5001 # idna-intel-lin
         aliases:
           - warmup
           - secondary
@@ -101,6 +151,31 @@ profiles:
           - warmup
           - secondary
 
+  idna-intel-win:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.0.4.14
+      cores: 4
+    jobs: 
+      db:
+        endpoints: 
+          - http://10.0.4.6:5001
+        aliases:
+          - extra
+      application:
+        endpoints: 
+          - http://10.0.4.14:5001
+        variables:
+          databaseServer: 10.0.4.6
+        aliases:
+          - main
+      load:
+        endpoints: 
+          - http://10.0.4.13:5001 # idna-amd-lin
+        aliases:
+          - warmup
+          - secondary
+
   idna-intel-win-relay:
     variables:
       serverPort: 5000
@@ -122,6 +197,31 @@ profiles:
       load:
         endpoints: 
           - https://aspnetperf.servicebus.windows.net/idnaamdlin
+        aliases:
+          - warmup
+          - secondary
+
+  idna-amd-win:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.0.4.15
+      cores: 4
+    jobs: 
+      db:
+        endpoints: 
+          - http://10.0.4.6:5001
+        aliases:
+          - extra
+      application:
+        endpoints: 
+          - http://10.0.4.15:5001
+        variables:
+          databaseServer: 10.0.4.6
+        aliases:
+          - main
+      load:
+        endpoints: 
+          - http://10.0.4.12:5001 # idna-intel-lin
         aliases:
           - warmup
           - secondary

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -193,7 +193,7 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-amd-lin-relay "
+      arguments: "$(ciProfile) --profile idna-amd-lin "
       
 # GROUP 7
 
@@ -209,7 +209,7 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-intel-lin-relay "
+      arguments: "$(ciProfile) --profile idna-intel-lin "
       
 # GROUP 8
 
@@ -225,7 +225,7 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-amd-win-relay "
+      arguments: "$(ciProfile) --profile idna-amd-win "
       
 - job: IDNA_Azure_Intel_Windows
   displayName: 8- IDNA Azure Intel Windows
@@ -239,6 +239,6 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-intel-win-relay "
+      arguments: "$(ciProfile) --profile idna-intel-win "
       
 

--- a/build/benchmarks.matrix.azure.yml
+++ b/build/benchmarks.matrix.azure.yml
@@ -74,23 +74,23 @@ groups:
       - name: IDNA Azure Amd Linux
         template: trend-scenarios.yml
         profiles:
-        - idna-amd-lin-relay
+        - idna-amd-lin
 
   - jobs:
 
       - name: IDNA Azure Intel Linux
         template: trend-scenarios.yml
         profiles:
-        - idna-intel-lin-relay
+        - idna-intel-lin
 
   - jobs:
       
       - name: IDNA Azure Amd Windows
         template: trend-scenarios.yml
         profiles:
-        - idna-amd-win-relay
+        - idna-amd-win
 
       - name: IDNA Azure Intel Windows
         template: trend-scenarios.yml
         profiles:
-        - idna-intel-win-relay
+        - idna-intel-win


### PR DESCRIPTION
fixing `Response status code does not indicate success: 401 (MissingToken: Relay security token is required)`