### PR TITLE
chore: move tls-scenarios to a separate ci config

### DIFF
--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -188,7 +188,7 @@ jobs:
   dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: tls-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
@@ -204,7 +204,7 @@ jobs:
   dependsOn: [IDNA_Azure_Amd_Linux]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: tls-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
@@ -220,7 +220,7 @@ jobs:
   dependsOn: [IDNA_Azure_Intel_Linux]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: tls-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
@@ -234,7 +234,7 @@ jobs:
   dependsOn: [IDNA_Azure_Intel_Linux]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: tls-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64

--- a/build/benchmarks.matrix.azure.yml
+++ b/build/benchmarks.matrix.azure.yml
@@ -72,25 +72,25 @@ groups:
   - jobs:
       
       - name: IDNA Azure Amd Linux
-        template: trend-scenarios.yml
+        template: tls-scenarios.yml
         profiles:
         - idna-amd-lin
 
   - jobs:
 
       - name: IDNA Azure Intel Linux
-        template: trend-scenarios.yml
+        template: tls-scenarios.yml
         profiles:
         - idna-intel-lin
 
   - jobs:
       
       - name: IDNA Azure Amd Windows
-        template: trend-scenarios.yml
+        template: tls-scenarios.yml
         profiles:
         - idna-amd-win
 
       - name: IDNA Azure Intel Windows
-        template: trend-scenarios.yml
+        template: tls-scenarios.yml
         profiles:
         - idna-intel-win

--- a/build/tls-scenarios.yml
+++ b/build/tls-scenarios.yml
@@ -65,7 +65,7 @@ steps:
   - task: PublishToAzureServiceBus@2
     displayName: "${{ s.displayName }}"
     condition: succeededOrFailed()
-    timeoutInMinutes: 10
+    timeoutInMinutes: 15
     inputs:
       connectedServiceName: ${{ parameters.connection }}
       serviceBusQueueName: ${{ parameters.serviceBusQueueName }}

--- a/build/tls-scenarios.yml
+++ b/build/tls-scenarios.yml
@@ -1,0 +1,81 @@
+parameters:
+- name: arguments
+  type: string
+  default: ''
+- name: connection
+  type: string
+  default: ''
+- name: serviceBusQueueName
+  type: string
+  default: ''
+- name: serviceBusNamespace
+  type: string
+  default: ''
+- name: condition
+  type: string
+  default: 'true'
+
+# Scenarios
+- name: scenarios
+  type: object
+  default:
+
+# TLS
+
+  - displayName: "HttpSys Windows: TLS Handshakes"
+    arguments: --scenario tls-handshakes-httpsys $(tlsJobs) --property scenario=HttpSysTLSHandshakes --application.options.requiredOperatingSystem windows
+
+  - displayName: "HttpSys Windows: mTLS Handshakes"
+    arguments: --scenario mTls-handshakes-httpsys $(tlsJobs) --property scenario=HttpSysMutualTLSHandshakes --application.options.requiredOperatingSystem windows
+
+  - displayName: "HttpSys Windows: TLS Renegotiation"
+    arguments: --scenario tls-renegotiation-httpsys $(tlsJobs) --property scenario=HttpSysTLSRenegotiation --application.options.requiredOperatingSystem windows
+
+  - displayName: "Kestrel Linux: TLS Handshakes"
+    arguments: --scenario tls-handshakes-kestrel $(tlsJobs) --property scenario=KestrelTLSHandshakes --application.options.requiredOperatingSystem linux
+    
+  - displayName: "Kestrel Linux: mTLS Handshakes"
+    arguments: --scenario mTls-handshakes-kestrel $(tlsJobs) --property scenario=KestrelMutualTLSHandshakes --application.options.requiredOperatingSystem linux
+
+  - displayName: "Kestrel Linux: TLS Renegotiation"
+    arguments: --scenario tls-renegotiation-kestrel $(tlsJobs) --property scenario=KestrelTLSRenegotiation --application.options.requiredOperatingSystem linux
+
+# Rejection
+
+  - displayName: "HttpSys Windows: Encoded URL symbols"
+    arguments: --scenario httpsys-encoded-url $(rejectionJobs) --property scenario=RejectionEncodedUrlHttpSys --application.options.requiredOperatingSystem windows
+
+  - displayName: "HttpSys Windows: Invalid Header"
+    arguments: --scenario httpsys-header-symbols $(rejectionJobs) --property scenario=RejectionInvalidHeaderHttpSys --application.options.requiredOperatingSystem windows
+
+  - displayName: "HttpSys Windows: Host Header Mismatch"
+    arguments: --scenario httpsys-hostheader-mismatch $(rejectionJobs) --property scenario=RejectionHostHeaderMismatchHttpSys --application.options.requiredOperatingSystem windows
+
+  - displayName: "Kestrel Linux: Encoded URL symbols"
+    arguments: --scenario kestrel-encoded-url $(rejectionJobs) --property scenario=RejectionEncodedUrlKestrel --application.options.requiredOperatingSystem linux
+
+  - displayName: "Kestrel Linux: Invalid Header"
+    arguments: --scenario kestrel-header-symbols $(rejectionJobs) --property scenario=RejectionInvalidHeaderKestrel --application.options.requiredOperatingSystem linux
+
+  - displayName: "Kestrel Linux: Host Header Mismatch"
+    arguments: --scenario kestrel-hostheader-mismatch $(rejectionJobs) --property scenario=RejectionHostHeaderMismatchKestrel --application.options.requiredOperatingSystem linux
+
+steps:
+- ${{ each s in parameters.scenarios }}:
+  - task: PublishToAzureServiceBus@2
+    displayName: "${{ s.displayName }}"
+    condition: succeededOrFailed()
+    timeoutInMinutes: 10
+    inputs:
+      connectedServiceName: ${{ parameters.connection }}
+      serviceBusQueueName: ${{ parameters.serviceBusQueueName }}
+      serviceBusNamespace: ${{ parameters.serviceBusNamespace }}
+      waitForCompletion: true
+      useDataContractSerializer: "false"
+      messageBody: |
+        {
+          "name": "crank",
+          "condition": "(${{ parameters.condition }})",
+          "retries": 1,
+          "args": [ "${{ s.arguments }} $(azureProfile) --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/steadystate.profile.yml --application.framework net10.0 --application.collectDependencies true ${{ parameters.arguments }} --application.options.collectCounters true --no-metadata --no-measurements --load.options.reuseBuild true --session $(session) --description \"${{ s.displayName }} $(System.JobDisplayName)\" --property buildId=\"$(buildId)\" --property buildNumber=\"$(buildNumber)\" --command-line-property --table TrendBenchmarks --sql SQL_CONNECTION_STRING --cert-tenant-id SQL_SERVER_TENANTID --cert-client-id SQL_SERVER_CLIENTID --cert-path SQL_SERVER_CERT_PATH --cert-sni --chart" ]
+        }


### PR DESCRIPTION
idna machines are slower, and timeout happen for too many jobs running at a time. it also blocks from testing while ci runs (cant use machines heavily)