### PR TITLE
fix: use http.sys api to control tls resumption and mutual tls configuration

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -7,11 +7,6 @@
 variables:
   serverPort: 5000
 
-  # these scripts allow to disable (or rollback changes) to the SChannel registry
-  # this allows to disable TLS resumption on windows level
-  disableTlsResumptionScript: powershell -Command "New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name MaximumCacheSize -PropertyType DWord -Value 0 -ErrorAction Ignore; New-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\' -Name ServerCacheTime -PropertyType DWord -Value 0 -ErrorAction Ignore; Restart-Service -Name Http -Force;"
-  rollbackTlsResumptionScript: powershell -Command "Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name MaximumCacheSize -ErrorAction Ignore; Remove-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL' -Name ServerCacheTime -ErrorAction Ignore; Restart-Service -Name Http -Force;"
-
 jobs:
   httpSysServer:
     source:
@@ -70,8 +65,6 @@ scenarios:
   tls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: "{{disableTlsResumptionScript}}"
-      afterScript: "{{rollbackTlsResumptionScript}}"
     load:
       job: httpclient
       variables:
@@ -84,8 +77,6 @@ scenarios:
   mTls-handshakes-httpsys:
     application:
       job: httpSysServer
-      beforeScript: "{{disableTlsResumptionScript}}"
-      afterScript: "{{rollbackTlsResumptionScript}}"
       variables:
         mTLS: true # enables settings on http.sys to negotiate client cert on connections
         tlsRenegotiation: true # enables client cert validation
@@ -106,8 +97,6 @@ scenarios:
   tls-renegotiation-httpsys:
     application:
       job: httpSysServer
-      beforeScript: "{{disableTlsResumptionScript}}"
-      afterScript: "{{rollbackTlsResumptionScript}}"
       variables:
         mTLS: false
         tlsRenegotiation: true

--- a/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
+++ b/src/BenchmarksApps/TLS/HttpSys/NetSh/SslCertBinding.cs
@@ -24,11 +24,12 @@
         """;
     }
 
+    [Flags]
     public enum NetShFlag
     {
-        NotSet = 0,
+        NotSet      = 0,
 
-        Disabled = 1,
-        Enable = 2
+        Disabled    = 1,
+        Enable      = 2,
     }
 }


### PR DESCRIPTION
controlling tls resumption via registry was a bad idea: it is unstable and app shutdown is sometimes stuck waiting for http.sys restart synchronization.

changing to use http.sys api