### PR TITLE
fix: fix path to user cert for TLS scenarios

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -106,7 +106,7 @@ scenarios:
         presetHeaders: connectionclose
         connections: 32
         serverScheme: https
-        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/HttpSys/testCert.pfx
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Certificates/2048/testCert-2048.pfx
         certPwd: testPassword
         sslProtocol: tls12
 
@@ -123,7 +123,7 @@ scenarios:
         presetHeaders: connectionclose
         connections: 32
         serverScheme: https
-        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/HttpSys/testCert.pfx
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Certificates/2048/testCert-2048.pfx
         certPwd: testPassword
         sslProtocol: tls12
 
@@ -156,7 +156,7 @@ scenarios:
         presetHeaders: connectionclose
         connections: 32
         serverScheme: https
-        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Kestrel/testCert.pfx
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Certificates/2048/testCert-2048.pfx
         certPwd: testPassword
         sslProtocol: tls12
 
@@ -174,7 +174,7 @@ scenarios:
         presetHeaders: connectionclose
         connections: 32
         serverScheme: https
-        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Kestrel/testCert.pfx
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Certificates/2048/testCert-2048.pfx
         certPwd: testPassword
         sslProtocol: tls12
 


### PR DESCRIPTION
path was not found due to previous change #2080

Http Client
CerPath: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Kestrel/testCert.pfx
Downloading certificate: https://raw.githubusercontent.com/aspnet/Benchmarks/refs/heads/main/src/BenchmarksApps/TLS/Kestrel/testCert.pfx