### PR TITLE
Add Cobalt Cloud machine Azure CI profile and runs.

### DIFF
--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -6,21 +6,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.4
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.6:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.4:5001
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.5:5001
         aliases:
           - warmup
@@ -31,21 +31,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.4
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azuredb
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azureserver
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azureclient
         aliases:
           - warmup
@@ -56,21 +56,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.12
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.6:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.12:5001
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.13:5001 # idna-amd-lin
         aliases:
           - warmup
@@ -81,21 +81,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.12
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azuredb
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaintellin
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaamdlin
         aliases:
           - warmup
@@ -106,21 +106,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.13
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.6:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.13:5001
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.12:5001 # idna-intel-lin
         aliases:
           - warmup
@@ -131,21 +131,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.13
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azuredb
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaamdlin
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaintellin
         aliases:
           - warmup
@@ -156,21 +156,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.14
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.6:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.14:5001
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.13:5001 # idna-amd-lin
         aliases:
           - warmup
@@ -181,21 +181,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.14
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azuredb
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaintelwin
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaamdlin
         aliases:
           - warmup
@@ -206,21 +206,21 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.15
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.6:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.15:5001
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.12:5001 # idna-intel-lin
         aliases:
           - warmup
@@ -231,46 +231,46 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.15
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azuredb
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaamdwin
         variables:
           databaseServer: 10.0.4.6
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/idnaintellin
         aliases:
           - warmup
           - secondary
-  
+
   aspnet-azurearm64-lin:
     variables:
       serverPort: 5000
       serverAddress: 10.0.4.7
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - http://10.0.4.9:5001
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - http://10.0.4.7:5001
         variables:
           databaseServer: 10.0.4.9
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - http://10.0.4.8:5001
         aliases:
           - warmup
@@ -281,22 +281,72 @@ profiles:
       serverPort: 5000
       serverAddress: 10.0.4.7
       cores: 4
-    jobs: 
+    jobs:
       db:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azurearm64db
         aliases:
           - extra
       application:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azurearm64server
         variables:
           databaseServer: 10.0.4.9
         aliases:
           - main
       load:
-        endpoints: 
+        endpoints:
           - https://aspnetperf.servicebus.windows.net/azurearm64client
+        aliases:
+          - warmup
+          - secondary
+
+  cobalt-cloud-lin:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.2.2.15
+      cores: 4
+    jobs:
+      db:
+        endpoints:
+          - http://10.2.2.14:5001
+        aliases:
+          - extra
+      application:
+        endpoints:
+          - http://10.2.2.15:5001
+        variables:
+          databaseServer: 10.2.2.14
+        aliases:
+          - main
+      load:
+        endpoints:
+          - http://10.2.2.13:5001
+        aliases:
+          - warmup
+          - secondary
+
+  cobalt-cloud-lin-relay:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.2.2.15
+      cores: 4
+    jobs:
+      db:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlindb
+        aliases:
+          - extra
+      application:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlinserver
+        variables:
+          databaseServer: 10.2.2.14
+        aliases:
+          - main
+      load:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlinclient
         aliases:
           - warmup
           - secondary

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -69,7 +69,7 @@ jobs:
   - template: trend-database-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: 
+      serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile cobalt-cloud-lin "
       
@@ -113,7 +113,7 @@ jobs:
   - template: trend-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: 
+      serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile cobalt-cloud-lin "
       
@@ -157,7 +157,7 @@ jobs:
   - template: baselines-database-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: 
+      serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile cobalt-cloud-lin "
       
@@ -201,7 +201,7 @@ jobs:
   - template: baselines-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: 
+      serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile cobalt-cloud-lin "
       
@@ -245,7 +245,7 @@ jobs:
   - template: containers-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: 
+      serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile cobalt-cloud-lin "
       

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -59,13 +59,27 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
+- job: Trends_Database_Cobalt_Cloud_Linux
+  displayName: 1- Trends Database Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: []
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: 
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
 # GROUP 2
 
 - job: Trends_Azure_Linux
   displayName: 2- Trends Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
+  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -79,7 +93,7 @@ jobs:
   displayName: 2- Trends Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
+  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -89,13 +103,27 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
+- job: Trends_Cobalt_Cloud_Linux
+  displayName: 2- Trends Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: 
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
 # GROUP 3
 
 - job: Baselines_Database_Azure_Linux
   displayName: 3- Baselines Database Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
+  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-database-scenarios.yml
@@ -109,7 +137,7 @@ jobs:
   displayName: 3- Baselines Database Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
+  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-database-scenarios.yml
@@ -119,13 +147,27 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
+- job: Baselines_Database_Cobalt_Cloud_Linux
+  displayName: 3- Baselines Database Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: 
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
 # GROUP 4
 
 - job: Baselines_Azure_Linux
   displayName: 4- Baselines Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-scenarios.yml
@@ -139,7 +181,7 @@ jobs:
   displayName: 4- Baselines Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-scenarios.yml
@@ -149,13 +191,27 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
+- job: Baselines_Cobalt_Cloud_Linux
+  displayName: 4- Baselines Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: 
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
 # GROUP 5
 
 - job: Containers_Azure_Intel_Linux
   displayName: 5- Containers Azure Intel Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: containers-scenarios.yml
@@ -169,7 +225,7 @@ jobs:
   displayName: 5- Containers Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: containers-scenarios.yml
@@ -179,13 +235,27 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
+- job: Containers_Cobalt_Cloud_Linux
+  displayName: 5- Containers Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: containers-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: 
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
 # GROUP 6
 
 - job: IDNA_Azure_Amd_Linux
   displayName: 6- IDNA Azure Amd Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux]
+  dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux, Containers_Cobalt_Cloud_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml

--- a/build/benchmarks.matrix.azure.yml
+++ b/build/benchmarks.matrix.azure.yml
@@ -4,6 +4,7 @@
 queues:
   - azure
   - azurearm64
+  - cobaltcloud
 
 schedule: "0 9/12 * * *"
 

--- a/build/benchmarks.matrix.azure.yml
+++ b/build/benchmarks.matrix.azure.yml
@@ -21,6 +21,11 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
+    - name: Trends Database Cobalt Cloud Linux
+      template: trend-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+
   - jobs:
 
     - name: Trends Azure Linux
@@ -32,6 +37,11 @@ groups:
       template: trend-scenarios.yml
       profiles:
       - aspnet-azurearm64-lin
+
+    - name: Trends Cobalt Cloud Linux
+      template: trend-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
 
   - jobs:
 
@@ -45,6 +55,11 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
+    - name: Baselines Database Cobalt Cloud Linux
+      template: baselines-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+
   - jobs:
 
     - name: Baselines Azure Linux
@@ -56,6 +71,11 @@ groups:
       template: baselines-scenarios.yml
       profiles:
       - aspnet-azurearm64-lin
+
+    - name: Baselines Cobalt Cloud Linux
+      template: baselines-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
   
   - jobs:
       
@@ -68,6 +88,11 @@ groups:
         template: containers-scenarios.yml
         profiles:
         - aspnet-azurearm64-lin
+
+      - name: Containers Cobalt Cloud Linux
+        template: containers-scenarios.yml
+        profiles:
+        - cobalt-cloud-lin
 
   - jobs:
       


### PR DESCRIPTION
Add Cobalt Cloud machine Azure CI profile and runs. We have 3 added Linux Cobalt machines, so I decided to add them to each of the run types. 

One thing that I am unsure about it that these machines are under a different virtual network as the cobalt machines were not available in the same data center as the other machines. I am not super familiar with the connection between the pipelines and the machines so please let me know if there is known work that will have to be done there.

Additional steps necessary to set this up:
- [x] Added cobaltcloud to the aspnetbenchmarks service bus (I am assuming service bus can be accessed across datacenters).
- [x] Added necessary environment variables to the cobalt-db-lin machine to act as the entry point for that network.
- [x] Setup the service bus cronjob and start the connection.
- [x] Did not need to add hosts file as the other VMs are pingable via their VM name.