### PR TITLE
Add Cobalt Azure Linux 3 CI runs

### DIFF
--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -305,7 +305,7 @@ profiles:
     variables:
       serverPort: 5000
       serverAddress: 10.2.2.15
-      cores: 4
+      cores: 16
     jobs:
       db:
         endpoints:
@@ -330,7 +330,7 @@ profiles:
     variables:
       serverPort: 5000
       serverAddress: 10.2.2.15
-      cores: 4
+      cores: 16
     jobs:
       db:
         endpoints:
@@ -340,6 +340,56 @@ profiles:
       application:
         endpoints:
           - https://aspnetperf.servicebus.windows.net/cobaltcloudlinserver
+        variables:
+          databaseServer: 10.2.2.14
+        aliases:
+          - main
+      load:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlinclient
+        aliases:
+          - warmup
+          - secondary
+
+  cobalt-cloud-lin-al3:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.2.2.16
+      cores: 16
+    jobs:
+      db:
+        endpoints:
+          - http://10.2.2.14:5001
+        aliases:
+          - extra
+      application:
+        endpoints:
+          - http://10.2.2.15:5001
+        variables:
+          databaseServer: 10.2.2.14
+        aliases:
+          - main
+      load:
+        endpoints:
+          - http://10.2.2.13:5001
+        aliases:
+          - warmup
+          - secondary
+
+  cobalt-cloud-lin-al3-relay:
+    variables:
+      serverPort: 5000
+      serverAddress: 10.2.2.16
+      cores: 16
+    jobs:
+      db:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlindb
+        aliases:
+          - extra
+      application:
+        endpoints:
+          - https://aspnetperf.servicebus.windows.net/cobaltcloudlinserver_azurelinux3
         variables:
           databaseServer: 10.2.2.14
         aliases:

--- a/build/benchmarks-ci-azure-eastus2.yml
+++ b/build/benchmarks-ci-azure-eastus2.yml
@@ -1,0 +1,192 @@
+# Do not change this file, it is generated using these steps:
+# - The file benchmarks.matrix.yml defines how each job is run in parallel
+# - Convert its content to json using https://jsonformatter.org/yaml-to-json
+# - Use the template in benchmarks.template.liquid and the converted json using https://liquidjs.com/playground.html
+# - Update this file with the result of the template generation
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 9/12 * * *"
+  always: true # always run the pipeline even if there have not been source code changes since the last successful scheduled run.
+  branches:
+    include:
+    - main
+
+variables:
+  - template: job-variables.yml
+  - name: session
+    value: $(Build.BuildNumber)
+  - name: buildId
+    value: $(Build.BuildId)
+  - name: buildNumber
+    value: $(Build.BuildNumber)
+  - name: am
+    value: $[lt(format('{0:HH}', pipeline.startTime), 12)]
+  - name: pm
+    value: $[ge(format('{0:HH}', pipeline.startTime), 12)]
+
+jobs:
+
+# GROUP 1
+
+- job: Trends_Database_Cobalt_Cloud_Linux
+  displayName: 1- Trends Database Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: []
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
+# GROUP 2
+
+- job: Trends_Cobalt_Cloud_Linux
+  displayName: 2- Trends Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Database_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
+# GROUP 3
+
+- job: Baselines_Database_Cobalt_Cloud_Linux
+  displayName: 3- Baselines Database Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
+# GROUP 4
+
+- job: Baselines_Cobalt_Cloud_Linux
+  displayName: 4- Baselines Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Database_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
+# GROUP 5
+
+- job: Containers_Cobalt_Cloud_Linux
+  displayName: 5- Containers Cobalt Cloud Linux
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: containers-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      
+# GROUP 6
+
+- job: Trends_Database_Cobalt_Cloud_Linux_AL3
+  displayName: 6- Trends Database Cobalt Cloud Linux AL3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Containers_Cobalt_Cloud_Linux]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      
+# GROUP 7
+
+- job: Trends_Cobalt_Cloud_Linux_AL3
+  displayName: 7- Trends Cobalt Cloud Linux AL3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Database_Cobalt_Cloud_Linux_AL3]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      
+# GROUP 8
+
+- job: Baselines_Database_Cobalt_Cloud_Linux_AL3
+  displayName: 8- Baselines Database Cobalt Cloud Linux AL3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Cobalt_Cloud_Linux_AL3]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      
+# GROUP 9
+
+- job: Baselines_Cobalt_Cloud_Linux_AL3
+  displayName: 9- Baselines Cobalt Cloud Linux AL3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Database_Cobalt_Cloud_Linux_AL3]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      
+# GROUP 10
+
+- job: Containers_Cobalt_Cloud_Linux_AL3
+  displayName: 10- Containers Cobalt Cloud Linux AL3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Cobalt_Cloud_Linux_AL3]
+  condition: succeededOrFailed()
+  steps:
+  - template: containers-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      
+

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -59,27 +59,13 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
-- job: Trends_Database_Cobalt_Cloud_Linux
-  displayName: 1- Trends Database Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: []
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-database-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
 # GROUP 2
 
 - job: Trends_Azure_Linux
   displayName: 2- Trends Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
+  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -93,7 +79,7 @@ jobs:
   displayName: 2- Trends Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
+  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -103,27 +89,13 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
-- job: Trends_Cobalt_Cloud_Linux
-  displayName: 2- Trends Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux, Trends_Database_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
 # GROUP 3
 
 - job: Baselines_Database_Azure_Linux
   displayName: 3- Baselines Database Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
+  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-database-scenarios.yml
@@ -137,7 +109,7 @@ jobs:
   displayName: 3- Baselines Database Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
+  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-database-scenarios.yml
@@ -147,27 +119,13 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
-- job: Baselines_Database_Cobalt_Cloud_Linux
-  displayName: 3- Baselines Database Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux, Trends_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-database-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
 # GROUP 4
 
 - job: Baselines_Azure_Linux
   displayName: 4- Baselines Azure Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
+  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-scenarios.yml
@@ -181,7 +139,7 @@ jobs:
   displayName: 4- Baselines Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
+  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: baselines-scenarios.yml
@@ -191,27 +149,13 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
-- job: Baselines_Cobalt_Cloud_Linux
-  displayName: 4- Baselines Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux, Baselines_Database_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
 # GROUP 5
 
 - job: Containers_Azure_Intel_Linux
   displayName: 5- Containers Azure Intel Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
+  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: containers-scenarios.yml
@@ -225,7 +169,7 @@ jobs:
   displayName: 5- Containers Azure Arm64 Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
+  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: containers-scenarios.yml
@@ -235,27 +179,13 @@ jobs:
       serviceBusNamespace: aspnetbenchmarks
       arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
       
-- job: Containers_Cobalt_Cloud_Linux
-  displayName: 5- Containers Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux, Baselines_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: containers-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
 # GROUP 6
 
 - job: IDNA_Azure_Amd_Linux
   displayName: 6- IDNA Azure Amd Linux
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux, Containers_Cobalt_Cloud_Linux]
+  dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml

--- a/build/benchmarks.matrix.azure.eastus2.yml
+++ b/build/benchmarks.matrix.azure.eastus2.yml
@@ -1,0 +1,68 @@
+# This file describes all the scenarios which are run continuously on AzDo.
+# It generates the file benchmarks.yml. See this file for instructions.
+
+queues:
+  - cobaltcloud
+
+schedule: "0 9/12 * * *"
+
+groups:
+  - jobs:
+    - name: Trends Database Cobalt Cloud Linux
+      template: trend-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+
+  - jobs:
+    - name: Trends Cobalt Cloud Linux
+      template: trend-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+
+  - jobs:
+    - name: Baselines Database Cobalt Cloud Linux
+      template: baselines-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+
+  - jobs:
+    - name: Baselines Cobalt Cloud Linux
+      template: baselines-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin
+  
+  - jobs:
+      - name: Containers Cobalt Cloud Linux
+        template: containers-scenarios.yml
+        profiles:
+        - cobalt-cloud-lin
+
+  - jobs:
+    - name: Trends Database Cobalt Cloud Linux AL3
+      template: trend-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin-al3
+
+  - jobs:
+    - name: Trends Cobalt Cloud Linux AL3
+      template: trend-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin-al3
+
+  - jobs:
+    - name: Baselines Database Cobalt Cloud Linux AL3
+      template: baselines-database-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin-al3
+
+  - jobs:
+    - name: Baselines Cobalt Cloud Linux AL3
+      template: baselines-scenarios.yml
+      profiles:
+      - cobalt-cloud-lin-al3
+  
+  - jobs:
+      - name: Containers Cobalt Cloud Linux AL3
+        template: containers-scenarios.yml
+        profiles:
+        - cobalt-cloud-lin-al3

--- a/build/benchmarks.matrix.azure.yml
+++ b/build/benchmarks.matrix.azure.yml
@@ -4,14 +4,11 @@
 queues:
   - azure
   - azurearm64
-  - cobaltcloud
 
 schedule: "0 9/12 * * *"
 
 groups:
-
   - jobs:
-
     - name: Trends Database Azure Linux
       template: trend-database-scenarios.yml
       profiles:
@@ -22,13 +19,7 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
-    - name: Trends Database Cobalt Cloud Linux
-      template: trend-database-scenarios.yml
-      profiles:
-      - cobalt-cloud-lin
-
   - jobs:
-
     - name: Trends Azure Linux
       template: trend-scenarios.yml
       profiles:
@@ -39,13 +30,7 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
-    - name: Trends Cobalt Cloud Linux
-      template: trend-scenarios.yml
-      profiles:
-      - cobalt-cloud-lin
-
   - jobs:
-
     - name: Baselines Database Azure Linux
       template: baselines-database-scenarios.yml
       profiles:
@@ -56,13 +41,7 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
-    - name: Baselines Database Cobalt Cloud Linux
-      template: baselines-database-scenarios.yml
-      profiles:
-      - cobalt-cloud-lin
-
   - jobs:
-
     - name: Baselines Azure Linux
       template: baselines-scenarios.yml
       profiles:
@@ -73,13 +52,7 @@ groups:
       profiles:
       - aspnet-azurearm64-lin
 
-    - name: Baselines Cobalt Cloud Linux
-      template: baselines-scenarios.yml
-      profiles:
-      - cobalt-cloud-lin
-  
-  - jobs:
-      
+  - jobs:      
       - name: Containers Azure Intel Linux
         template: containers-scenarios.yml
         profiles:
@@ -90,27 +63,19 @@ groups:
         profiles:
         - aspnet-azurearm64-lin
 
-      - name: Containers Cobalt Cloud Linux
-        template: containers-scenarios.yml
-        profiles:
-        - cobalt-cloud-lin
-
-  - jobs:
-      
+  - jobs:      
       - name: IDNA Azure Amd Linux
         template: trend-scenarios.yml
         profiles:
         - idna-amd-lin
 
   - jobs:
-
       - name: IDNA Azure Intel Linux
         template: trend-scenarios.yml
         profiles:
         - idna-intel-lin
 
-  - jobs:
-      
+  - jobs:      
       - name: IDNA Azure Amd Windows
         template: trend-scenarios.yml
         profiles:


### PR DESCRIPTION
Added Cobalt Azure Linux 3 CI runs. This includes adding the cobalt-cloud-lin-al3 azure profile for running the jobs, creating a new yml for a new pipeline for the cobalt network job queue, and moving the previously added cobalt jobs to the new pipeline. Also made a minor update to the core counts for the profiles to match the actual available cores on the cobalt VMs. 

The reason for the addition of a new Azure CI pipeline is that the Cobalt machines were made in Azure East US 2 while the other azure machines were in a different region and VNet. As such, the service bus queue management machines are not able to send jobs between the two networks. The two options to work around this I came up with were to either have a new pipeline for each network we need to send runs to (which I don't think we will have many of) o,r update the liquid templates queue selection setup to include different queue lists per network and specifying the network on a per job level. I think adding the pipeline is the cleaner of these two options, at least at this moment, and keeps wider updates from being necessary.