### PR TITLE
Update the application ip address 10.2.2.15->10.2.2.16.

### DIFF
--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -364,7 +364,7 @@ profiles:
           - extra
       application:
         endpoints:
-          - http://10.2.2.15:5001
+          - http://10.2.2.16:5001
         variables:
           databaseServer: 10.2.2.14
         aliases:


### PR DESCRIPTION
Update the application ip address 10.2.2.15->10.2.2.16. This was improperly set when setting up the profile.

Tested on the machines with an updated profile with only this change, and one of the previously failing scenarios succeeded.