### PR TITLE
fix fortunes not finding connection string

### DIFF
--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/appsettings.json
@@ -5,6 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionString": "This should be set in user secrets or environment config"
+  "AllowedHosts": "*"
 }

--- a/src/BenchmarksApps/TechEmpower/Minimal/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/Minimal/appsettings.json
@@ -5,6 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionString": "This should be set in user secrets or environment config"
+  "AllowedHosts": "*"
 }

--- a/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/appsettings.json
@@ -1,4 +1,3 @@
 {
-  "ConnectionString": "This should be set in user secrets or environment config",
   "Database": "PostgreSql"
 }

--- a/src/BenchmarksApps/TechEmpower/RazorPages/appsettings.json
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/appsettings.json
@@ -5,6 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "ConnectionString": "This should be set in user secrets or environment config"
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Unblocking issues with resolving a connection string to database for BlazorSSR
![image](https://github.com/user-attachments/assets/9dbb14fe-c483-4145-a2be-e14b151177de)

> Job failed at runtime with exit code 134:
[STDERR] Unhandled exception. System.ArgumentException: Format of the initialization string does not conform to specification starting at index 0.
[STDERR]    at System.Data.Common.DbConnectionOptions.GetKeyValuePair(String connectionString, Int32 currentPosition, StringBuilder buffer, Boolean useOdbcRules, String& keyname, String& keyvalue)
[STDERR]    at System.Data.Common.DbConnectionOptions.ParseInternal(Dictionary`2 parsetable, String connectionString, Boolean buildChain, Dictionary`2 synonyms, Boolean firstKey)
[STDERR]    at System.Data.Common.DbConnectionOptions..ctor(String connectionString, Dictionary`2 synonyms, Boolean useOdbcRules)
[STDERR]    at System.Data.Common.DbConnectionStringBuilder.set_ConnectionString(String value)
[STDERR]    at Npgsql.NpgsqlConnectionStringBuilder..ctor(String connectionString)
[STDERR]    at Npgsql.NpgsqlSlimDataSourceBuilder..ctor(String connectionString)
[STDERR]    at BlazorSSR.Database.Db..ctor(AppSettings appSettings) in /tmp/benchmarks-agent/benchmarks-server-1/ti3hiq4s.gqg/src/BenchmarksApps/TechEmpower/BlazorSSR/Database/Db.cs:line 17
[STDERR]    at Program.<Main>$(String[] args) in /tmp/benchmarks-agent/benchmarks-server-1/ti3hiq4s.gqg/src/BenchmarksApps/TechEmpower/BlazorSSR/Program.cs:line 24
