### PR TITLE
Switch to auto-scheduled setup for azure and azure_eastus2 ci runs

### DIFF
--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -400,3 +400,498 @@ profiles:
         aliases:
           - warmup
           - secondary
+
+  # Add individual machine profiles for azure-arm64-db similar to ci.profile.yml
+  azure-arm64-db-app:
+    variables:
+      serverAddress: 10.0.4.9
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.9:5001
+        aliases:
+          - main
+
+  azure-arm64-db-db:
+    variables:
+      databaseServer: 10.0.4.9
+      downstreamAddress: 10.0.4.9
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.9:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-arm64-db-load:
+    variables:
+      secondaryAddress: 10.0.4.9
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.9:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for azure-arm64-client
+  azure-arm64-client-app:
+    variables:
+      serverAddress: 10.0.4.8
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.8:5001
+        aliases:
+          - main
+
+  azure-arm64-client-db:
+    variables:
+      databaseServer: 10.0.4.8
+      downstreamAddress: 10.0.4.8
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.8:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-arm64-client-load:
+    variables:
+      secondaryAddress: 10.0.4.8
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.8:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for azure-arm64-server
+  azure-arm64-server-app:
+    variables:
+      serverAddress: 10.0.4.7
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.7:5001
+        aliases:
+          - main
+
+  azure-arm64-server-db:
+    variables:
+      databaseServer: 10.0.4.7
+      downstreamAddress: 10.0.4.7
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.7:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-arm64-server-load:
+    variables:
+      secondaryAddress: 10.0.4.7
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.7:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for azure-client
+  azure-client-app:
+    variables:
+      serverAddress: 10.0.4.5
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.5:5001
+        aliases:
+          - main
+
+  azure-client-db:
+    variables:
+      databaseServer: 10.0.4.5
+      downstreamAddress: 10.0.4.5
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.5:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-client-load:
+    variables:
+      secondaryAddress: 10.0.4.5
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.5:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for azure-db
+  azure-db-app:
+    variables:
+      serverAddress: 10.0.4.6
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.6:5001
+        aliases:
+          - main
+
+  azure-db-db:
+    variables:
+      databaseServer: 10.0.4.6
+      downstreamAddress: 10.0.4.6
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.6:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-db-load:
+    variables:
+      secondaryAddress: 10.0.4.6
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.6:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for azure-server
+  azure-server-app:
+    variables:
+      serverAddress: 10.0.4.4
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.4:5001
+        aliases:
+          - main
+
+  azure-server-db:
+    variables:
+      databaseServer: 10.0.4.4
+      downstreamAddress: 10.0.4.4
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.4:5001
+        aliases:
+          - downstream
+          - extra
+
+  azure-server-load:
+    variables:
+      secondaryAddress: 10.0.4.4
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.4:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for idna-amd-lin
+  idna-amd-lin-app:
+    variables:
+      serverAddress: 10.0.4.13
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.13:5001
+        aliases:
+          - main
+
+  idna-amd-lin-db:
+    variables:
+      databaseServer: 10.0.4.13
+      downstreamAddress: 10.0.4.13
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.13:5001
+        aliases:
+          - downstream
+          - extra
+
+  idna-amd-lin-load:
+    variables:
+      secondaryAddress: 10.0.4.13
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.13:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for idna-amd-win
+  idna-amd-win-app:
+    variables:
+      serverAddress: 10.0.4.15
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.15:5001
+        aliases:
+          - main
+
+  idna-amd-win-db:
+    variables:
+      databaseServer: 10.0.4.15
+      downstreamAddress: 10.0.4.15
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.15:5001
+        aliases:
+          - downstream
+          - extra
+
+  idna-amd-win-load:
+    variables:
+      secondaryAddress: 10.0.4.15
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.15:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for idna-intel-lin
+  idna-intel-lin-app:
+    variables:
+      serverAddress: 10.0.4.12
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.12:5001
+        aliases:
+          - main
+
+  idna-intel-lin-db:
+    variables:
+      databaseServer: 10.0.4.12
+      downstreamAddress: 10.0.4.12
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.12:5001
+        aliases:
+          - downstream
+          - extra
+
+  idna-intel-lin-load:
+    variables:
+      secondaryAddress: 10.0.4.12
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.12:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for idna-intel-win
+  idna-intel-win-app:
+    variables:
+      serverAddress: 10.0.4.14
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.0.4.14:5001
+        aliases:
+          - main
+
+  idna-intel-win-db:
+    variables:
+      databaseServer: 10.0.4.14
+      downstreamAddress: 10.0.4.14
+    agents:
+      db:
+        endpoints:
+          - http://10.0.4.14:5001
+        aliases:
+          - downstream
+          - extra
+
+  idna-intel-win-load:
+    variables:
+      secondaryAddress: 10.0.4.14
+    agents:
+      load:
+        endpoints:
+          - http://10.0.4.14:5001
+        aliases:
+          - warmup
+            - secondary
+
+  #############################################
+  #                                           #
+  #         EAST US 2 MACHINES                #
+  #                                           #
+  #############################################
+  # Individual machine profiles for cobalt-cloud-lin-client
+  cobalt-cloud-lin-client-app:
+    variables:
+      serverAddress: 10.2.2.13
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.2.2.13:5001
+        aliases:
+          - main
+
+  cobalt-cloud-lin-client-db:
+    variables:
+      databaseServer: 10.2.2.13
+      downstreamAddress: 10.2.2.13
+    agents:
+      db:
+        endpoints:
+          - http://10.2.2.13:5001
+        aliases:
+          - downstream
+          - extra
+
+  cobalt-cloud-lin-client-load:
+    variables:
+      secondaryAddress: 10.2.2.13
+    agents:
+      load:
+        endpoints:
+          - http://10.2.2.13:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for cobalt-cloud-lin-db
+  cobalt-cloud-lin-db-app:
+    variables:
+      serverAddress: 10.2.2.14
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.2.2.14:5001
+        aliases:
+          - main
+
+  cobalt-cloud-lin-db-db:
+    variables:
+      databaseServer: 10.2.2.14
+      downstreamAddress: 10.2.2.14
+    agents:
+      db:
+        endpoints:
+          - http://10.2.2.14:5001
+        aliases:
+          - downstream
+          - extra
+
+  cobalt-cloud-lin-db-load:
+    variables:
+      secondaryAddress: 10.2.2.14
+    agents:
+      load:
+        endpoints:
+          - http://10.2.2.14:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for cobalt-cloud-lin-server
+  cobalt-cloud-lin-server-app:
+    variables:
+      serverAddress: 10.2.2.15
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.2.2.15:5001
+        aliases:
+          - main
+
+  cobalt-cloud-lin-server-db:
+    variables:
+      databaseServer: 10.2.2.15
+      downstreamAddress: 10.2.2.15
+    agents:
+      db:
+        endpoints:
+          - http://10.2.2.15:5001
+        aliases:
+          - downstream
+          - extra
+
+  cobalt-cloud-lin-server-load:
+    variables:
+      secondaryAddress: 10.2.2.15
+    agents:
+      load:
+        endpoints:
+          - http://10.2.2.15:5001
+        aliases:
+          - warmup
+          - secondary
+
+  # Individual machine profiles for cobalt-cloud-lin-server-azure-linux3
+  cobalt-cloud-lin-server-azure-linux3-app:
+    variables:
+      serverAddress: 10.2.2.16
+      cores: TODO
+    agents:
+      application:
+        endpoints:
+          - http://10.2.2.16:5001
+        aliases:
+          - main
+
+  cobalt-cloud-lin-server-azure-linux3-db:
+    variables:
+      databaseServer: 10.2.2.16
+      downstreamAddress: 10.2.2.16
+    agents:
+      db:
+        endpoints:
+          - http://10.2.2.16:5001
+        aliases:
+          - downstream
+          - extra
+
+  cobalt-cloud-lin-server-azure-linux3-load:
+    variables:
+      secondaryAddress: 10.2.2.16
+    agents:
+      load:
+        endpoints:
+          - http://10.2.2.16:5001
+        aliases:
+          - warmup
+          - secondary

--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -404,6 +404,7 @@ profiles:
   # Add individual machine profiles for azure-db similar to ci.profile.yml
   azure-db-app: # azurearm64db
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.9
       cores: 4
     agents:
@@ -439,6 +440,7 @@ profiles:
   # Individual machine profiles for azure-client
   azure-client-app: # azurearm64client
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.8
       cores: 4
     agents:
@@ -474,6 +476,7 @@ profiles:
   # Individual machine profiles for azure-server-arm64
   azure-server-arm64-app: # azurearm64server
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.7
       cores: 4
     agents:
@@ -509,6 +512,7 @@ profiles:
   # Individual machine profiles for azure2-client
   azure2-client-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.5
       cores: 2
     agents:
@@ -544,6 +548,7 @@ profiles:
   # Individual machine profiles for azure2-db
   azure2-db-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.6
       cores: 2
     agents:
@@ -579,6 +584,7 @@ profiles:
   # Individual machine profiles for azure2-server-amd64
   azure2-server-amd64-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.4
       cores: 4
     agents:
@@ -614,6 +620,7 @@ profiles:
   # Individual machine profiles for idna-amd-lin
   idna-amd-lin-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.13
       cores: 4
     agents:
@@ -649,6 +656,7 @@ profiles:
   # Individual machine profiles for idna-amd-win
   idna-amd-win-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.15
       cores: 4
     agents:
@@ -684,6 +692,7 @@ profiles:
   # Individual machine profiles for idna-intel-lin
   idna-intel-lin-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.12
       cores: 4
     agents:
@@ -719,6 +728,7 @@ profiles:
   # Individual machine profiles for idna-intel-win
   idna-intel-win-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.0.4.14
       cores: 4
     agents:
@@ -759,6 +769,7 @@ profiles:
   # Individual machine profiles for cobalt-cloud-lin-client
   cobalt-cloud-lin-client-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.2.2.13
       cores: 16
     agents:
@@ -794,6 +805,7 @@ profiles:
   # Individual machine profiles for cobalt-cloud-lin-db
   cobalt-cloud-lin-db-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.2.2.14
       cores: 16
     agents:
@@ -829,6 +841,7 @@ profiles:
   # Individual machine profiles for cobalt-cloud-lin-server
   cobalt-cloud-lin-server-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.2.2.15
       cores: 16
     agents:
@@ -864,6 +877,7 @@ profiles:
   # Individual machine profiles for cobalt-cloud-lin-server-azure-linux3
   cobalt-cloud-lin-server-azure-linux3-app:
     variables:
+      serverPort: 5000
       serverAddress: 10.2.2.16
       cores: 16
     agents:

--- a/build/azure.profile.yml
+++ b/build/azure.profile.yml
@@ -401,11 +401,11 @@ profiles:
           - warmup
           - secondary
 
-  # Add individual machine profiles for azure-arm64-db similar to ci.profile.yml
-  azure-arm64-db-app:
+  # Add individual machine profiles for azure-db similar to ci.profile.yml
+  azure-db-app: # azurearm64db
     variables:
       serverAddress: 10.0.4.9
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -413,7 +413,7 @@ profiles:
         aliases:
           - main
 
-  azure-arm64-db-db:
+  azure-db-db:
     variables:
       databaseServer: 10.0.4.9
       downstreamAddress: 10.0.4.9
@@ -425,7 +425,7 @@ profiles:
           - downstream
           - extra
 
-  azure-arm64-db-load:
+  azure-db-load:
     variables:
       secondaryAddress: 10.0.4.9
     agents:
@@ -436,11 +436,11 @@ profiles:
           - warmup
           - secondary
 
-  # Individual machine profiles for azure-arm64-client
-  azure-arm64-client-app:
+  # Individual machine profiles for azure-client
+  azure-client-app: # azurearm64client
     variables:
       serverAddress: 10.0.4.8
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -448,7 +448,7 @@ profiles:
         aliases:
           - main
 
-  azure-arm64-client-db:
+  azure-client-db:
     variables:
       databaseServer: 10.0.4.8
       downstreamAddress: 10.0.4.8
@@ -460,7 +460,7 @@ profiles:
           - downstream
           - extra
 
-  azure-arm64-client-load:
+  azure-client-load:
     variables:
       secondaryAddress: 10.0.4.8
     agents:
@@ -471,11 +471,11 @@ profiles:
           - warmup
           - secondary
 
-  # Individual machine profiles for azure-arm64-server
-  azure-arm64-server-app:
+  # Individual machine profiles for azure-server-arm64
+  azure-server-arm64-app: # azurearm64server
     variables:
       serverAddress: 10.0.4.7
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -483,7 +483,7 @@ profiles:
         aliases:
           - main
 
-  azure-arm64-server-db:
+  azure-server-arm64-db:
     variables:
       databaseServer: 10.0.4.7
       downstreamAddress: 10.0.4.7
@@ -495,7 +495,7 @@ profiles:
           - downstream
           - extra
 
-  azure-arm64-server-load:
+  azure-server-arm64-load:
     variables:
       secondaryAddress: 10.0.4.7
     agents:
@@ -506,11 +506,11 @@ profiles:
           - warmup
           - secondary
 
-  # Individual machine profiles for azure-client
-  azure-client-app:
+  # Individual machine profiles for azure2-client
+  azure2-client-app:
     variables:
       serverAddress: 10.0.4.5
-      cores: TODO
+      cores: 2
     agents:
       application:
         endpoints:
@@ -518,7 +518,7 @@ profiles:
         aliases:
           - main
 
-  azure-client-db:
+  azure2-client-db:
     variables:
       databaseServer: 10.0.4.5
       downstreamAddress: 10.0.4.5
@@ -530,7 +530,7 @@ profiles:
           - downstream
           - extra
 
-  azure-client-load:
+  azure2-client-load:
     variables:
       secondaryAddress: 10.0.4.5
     agents:
@@ -541,11 +541,11 @@ profiles:
           - warmup
           - secondary
 
-  # Individual machine profiles for azure-db
-  azure-db-app:
+  # Individual machine profiles for azure2-db
+  azure2-db-app:
     variables:
       serverAddress: 10.0.4.6
-      cores: TODO
+      cores: 2
     agents:
       application:
         endpoints:
@@ -553,7 +553,7 @@ profiles:
         aliases:
           - main
 
-  azure-db-db:
+  azure2-db-db:
     variables:
       databaseServer: 10.0.4.6
       downstreamAddress: 10.0.4.6
@@ -565,7 +565,7 @@ profiles:
           - downstream
           - extra
 
-  azure-db-load:
+  azure2-db-load:
     variables:
       secondaryAddress: 10.0.4.6
     agents:
@@ -576,11 +576,11 @@ profiles:
           - warmup
           - secondary
 
-  # Individual machine profiles for azure-server
-  azure-server-app:
+  # Individual machine profiles for azure2-server-amd64
+  azure2-server-amd64-app:
     variables:
       serverAddress: 10.0.4.4
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -588,7 +588,7 @@ profiles:
         aliases:
           - main
 
-  azure-server-db:
+  azure2-server-amd64-db:
     variables:
       databaseServer: 10.0.4.4
       downstreamAddress: 10.0.4.4
@@ -600,7 +600,7 @@ profiles:
           - downstream
           - extra
 
-  azure-server-load:
+  azure2-server-amd64-load:
     variables:
       secondaryAddress: 10.0.4.4
     agents:
@@ -615,7 +615,7 @@ profiles:
   idna-amd-lin-app:
     variables:
       serverAddress: 10.0.4.13
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -650,7 +650,7 @@ profiles:
   idna-amd-win-app:
     variables:
       serverAddress: 10.0.4.15
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -685,7 +685,7 @@ profiles:
   idna-intel-lin-app:
     variables:
       serverAddress: 10.0.4.12
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -720,7 +720,7 @@ profiles:
   idna-intel-win-app:
     variables:
       serverAddress: 10.0.4.14
-      cores: TODO
+      cores: 4
     agents:
       application:
         endpoints:
@@ -760,7 +760,7 @@ profiles:
   cobalt-cloud-lin-client-app:
     variables:
       serverAddress: 10.2.2.13
-      cores: TODO
+      cores: 16
     agents:
       application:
         endpoints:
@@ -795,7 +795,7 @@ profiles:
   cobalt-cloud-lin-db-app:
     variables:
       serverAddress: 10.2.2.14
-      cores: TODO
+      cores: 16
     agents:
       application:
         endpoints:
@@ -830,7 +830,7 @@ profiles:
   cobalt-cloud-lin-server-app:
     variables:
       serverAddress: 10.2.2.15
-      cores: TODO
+      cores: 16
     agents:
       application:
         endpoints:
@@ -865,7 +865,7 @@ profiles:
   cobalt-cloud-lin-server-azure-linux3-app:
     variables:
       serverAddress: 10.2.2.16
-      cores: TODO
+      cores: 16
     agents:
       application:
         endpoints:

--- a/build/benchmarks-ci-azure-eastus2.yml
+++ b/build/benchmarks-ci-azure-eastus2.yml
@@ -31,75 +31,27 @@ jobs:
 
 # GROUP 1
 
-- job: Trends_Database_Cobalt_Cloud_Linux
-  displayName: 1- Trends Database Cobalt Cloud Linux
+- job: Containers_Cobalt_Cloud_Lin_Server
+  displayName: 1- Containers Cobalt Cloud Lin Server
   pool: server
   timeoutInMinutes: 120
   dependsOn: []
   condition: succeededOrFailed()
   steps:
-  - template: trend-database-scenarios.yml
+  - template: containers-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
       
 # GROUP 2
 
-- job: Trends_Cobalt_Cloud_Linux
-  displayName: 2- Trends Cobalt Cloud Linux
+- job: Containers_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 2- Containers Cobalt Cloud Lin Server Azure Linux3
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
-# GROUP 3
-
-- job: Baselines_Database_Cobalt_Cloud_Linux
-  displayName: 3- Baselines Database Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Trends_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-database-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
-# GROUP 4
-
-- job: Baselines_Cobalt_Cloud_Linux
-  displayName: 4- Baselines Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Cobalt_Cloud_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
-      
-# GROUP 5
-
-- job: Containers_Cobalt_Cloud_Linux
-  displayName: 5- Containers Cobalt Cloud Linux
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Cobalt_Cloud_Linux]
+  dependsOn: [Containers_Cobalt_Cloud_Lin_Server]
   condition: succeededOrFailed()
   steps:
   - template: containers-scenarios.yml
@@ -107,15 +59,79 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
+      
+# GROUP 3
+
+- job: Baselines_Database_Cobalt_Cloud_Lin_Server
+  displayName: 3- Baselines Database Cobalt Cloud Lin Server
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Containers_Cobalt_Cloud_Lin_Server_Azure_Linux3]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
+      
+# GROUP 4
+
+- job: Baselines_Database_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 4- Baselines Database Cobalt Cloud Lin Server Azure Linux3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Database_Cobalt_Cloud_Lin_Server]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
+      
+# GROUP 5
+
+- job: Baselines_Cobalt_Cloud_Lin_Server
+  displayName: 5- Baselines Cobalt Cloud Lin Server
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Database_Cobalt_Cloud_Lin_Server_Azure_Linux3]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load "
       
 # GROUP 6
 
-- job: Mvc_Cobalt_Cloud_Linux
-  displayName: 6- Mvc Cobalt Cloud Linux
+- job: Baselines_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 6- Baselines Cobalt Cloud Lin Server Azure Linux3
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Containers_Cobalt_Cloud_Linux]
+  dependsOn: [Baselines_Cobalt_Cloud_Lin_Server]
+  condition: succeededOrFailed()
+  steps:
+  - template: baselines-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load "
+      
+# GROUP 7
+
+- job: MVC_Cobalt_Cloud_Lin_Server
+  displayName: 7- MVC Cobalt Cloud Lin Server
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Baselines_Cobalt_Cloud_Lin_Server_Azure_Linux3]
   condition: succeededOrFailed()
   steps:
   - template: mvc-scenarios.yml
@@ -123,15 +139,63 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin "
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
       
-# GROUP 7
+# GROUP 8
 
-- job: Trends_Database_Cobalt_Cloud_Linux_AL3
-  displayName: 7- Trends Database Cobalt Cloud Linux AL3
+- job: MVC_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 8- MVC Cobalt Cloud Lin Server Azure Linux3
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Mvc_Cobalt_Cloud_Linux]
+  dependsOn: [MVC_Cobalt_Cloud_Lin_Server]
+  condition: succeededOrFailed()
+  steps:
+  - template: mvc-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
+      
+# GROUP 9
+
+- job: Trends_Cobalt_Cloud_Lin_Server
+  displayName: 9- Trends Cobalt Cloud Lin Server
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [MVC_Cobalt_Cloud_Lin_Server_Azure_Linux3]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load "
+      
+# GROUP 10
+
+- job: Trends_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 10- Trends Cobalt Cloud Lin Server Azure Linux3
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Cobalt_Cloud_Lin_Server]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: cobaltcloud
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load "
+      
+# GROUP 11
+
+- job: Trends_Database_Cobalt_Cloud_Lin_Server
+  displayName: 11- Trends Database Cobalt Cloud Lin Server
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Cobalt_Cloud_Lin_Server_Azure_Linux3]
   condition: succeededOrFailed()
   steps:
   - template: trend-database-scenarios.yml
@@ -139,85 +203,21 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
-      
-# GROUP 8
-
-- job: Trends_Cobalt_Cloud_Linux_AL3
-  displayName: 8- Trends Cobalt Cloud Linux AL3
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Cobalt_Cloud_Linux_AL3]
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
-      
-# GROUP 9
-
-- job: Baselines_Database_Cobalt_Cloud_Linux_AL3
-  displayName: 9- Baselines Database Cobalt Cloud Linux AL3
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Trends_Cobalt_Cloud_Linux_AL3]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-database-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
-      
-# GROUP 10
-
-- job: Baselines_Cobalt_Cloud_Linux_AL3
-  displayName: 10- Baselines Cobalt Cloud Linux AL3
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Cobalt_Cloud_Linux_AL3]
-  condition: succeededOrFailed()
-  steps:
-  - template: baselines-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
-      
-# GROUP 11
-
-- job: Containers_Cobalt_Cloud_Linux_AL3
-  displayName: 11- Containers Cobalt Cloud Linux AL3
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [Baselines_Cobalt_Cloud_Linux_AL3]
-  condition: succeededOrFailed()
-  steps:
-  - template: containers-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: cobaltcloud
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
       
 # GROUP 12
 
-- job: Mvc_Cobalt_Cloud_Linux_AL3
-  displayName: 12- Mvc Cobalt Cloud Linux AL3
+- job: Trends_Database_Cobalt_Cloud_Lin_Server_Azure_Linux3
+  displayName: 12- Trends Database Cobalt Cloud Lin Server Azure Linux3
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Containers_Cobalt_Cloud_Linux_AL3]
+  dependsOn: [Trends_Database_Cobalt_Cloud_Lin_Server]
   condition: succeededOrFailed()
   steps:
-  - template: mvc-scenarios.yml
+  - template: trend-database-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: cobaltcloud
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile cobalt-cloud-lin-al3 "
+      arguments: "$(ciProfile) --profile cobalt-cloud-lin-server-azure-linux3-app --profile cobalt-cloud-lin-client-load --profile cobalt-cloud-lin-db-db "
       

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -31,161 +31,161 @@ jobs:
 
 # GROUP 1
 
-- job: Trends_Database_Azure_Linux
-  displayName: 1- Trends Database Azure Linux
+- job: Containers_Azure_Server_Arm64
+  displayName: 1- Containers Azure Server Arm64
   pool: server
   timeoutInMinutes: 120
   dependsOn: []
   condition: succeededOrFailed()
   steps:
-  - template: trend-database-scenarios.yml
+  - template: containers-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azure-lin "
+      arguments: "$(ciProfile) --profile azure-server-arm64-app --profile azure-client-load --profile azure-db-db "
       
-- job: Trends_Database_Azure_Arm64_Linux
-  displayName: 1- Trends Database Azure Arm64 Linux
+- job: Containers_Azure2_Server_Amd64
+  displayName: 1- Containers Azure2 Server Amd64
   pool: server
   timeoutInMinutes: 120
   dependsOn: []
   condition: succeededOrFailed()
   steps:
-  - template: trend-database-scenarios.yml
+  - template: containers-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
+      arguments: "$(ciProfile) --profile azure2-server-amd64-app --profile azure2-client-load --profile azure2-db-db "
       
 # GROUP 2
 
-- job: Trends_Azure_Linux
-  displayName: 2- Trends Azure Linux
+- job: Baselines_Database_Azure_Server_Arm64
+  displayName: 2- Baselines Database Azure Server Arm64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
+  dependsOn: [Containers_Azure_Server_Arm64, Containers_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: baselines-database-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azure-lin "
+      arguments: "$(ciProfile) --profile azure-server-arm64-app --profile azure-client-load --profile azure-db-db "
       
-- job: Trends_Azure_Arm64_Linux
-  displayName: 2- Trends Azure Arm64 Linux
+- job: Baselines_Database_Azure2_Server_Amd64
+  displayName: 2- Baselines Database Azure2 Server Amd64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Database_Azure_Linux, Trends_Database_Azure_Arm64_Linux]
+  dependsOn: [Containers_Azure_Server_Arm64, Containers_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: trend-scenarios.yml
+  - template: baselines-database-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
+      arguments: "$(ciProfile) --profile azure2-server-amd64-app --profile azure2-client-load --profile azure2-db-db "
       
 # GROUP 3
 
-- job: Baselines_Database_Azure_Linux
-  displayName: 3- Baselines Database Azure Linux
+- job: Baselines_Azure_Server_Arm64
+  displayName: 3- Baselines Azure Server Arm64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Database_Azure_Server_Arm64, Baselines_Database_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: baselines-database-scenarios.yml
+  - template: baselines-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azure-lin "
+      arguments: "$(ciProfile) --profile azure-server-arm64-app --profile azure-client-load "
       
-- job: Baselines_Database_Azure_Arm64_Linux
-  displayName: 3- Baselines Database Azure Arm64 Linux
+- job: Baselines_Azure2_Server_Amd64
+  displayName: 3- Baselines Azure2 Server Amd64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Trends_Azure_Linux, Trends_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Database_Azure_Server_Arm64, Baselines_Database_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: baselines-database-scenarios.yml
+  - template: baselines-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
+      arguments: "$(ciProfile) --profile azure2-server-amd64-app --profile azure2-client-load "
       
 # GROUP 4
 
-- job: Baselines_Azure_Linux
-  displayName: 4- Baselines Azure Linux
+- job: Trends_Azure_Server_Arm64
+  displayName: 4- Trends Azure Server Arm64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Azure_Server_Arm64, Baselines_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: baselines-scenarios.yml
+  - template: trend-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azure-lin "
+      arguments: "$(ciProfile) --profile azure-server-arm64-app --profile azure-client-load "
       
-- job: Baselines_Azure_Arm64_Linux
-  displayName: 4- Baselines Azure Arm64 Linux
+- job: Trends_Azure2_Server_Amd64
+  displayName: 4- Trends Azure2 Server Amd64
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Database_Azure_Linux, Baselines_Database_Azure_Arm64_Linux]
+  dependsOn: [Baselines_Azure_Server_Arm64, Baselines_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: baselines-scenarios.yml
+  - template: trend-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
+      arguments: "$(ciProfile) --profile azure2-server-amd64-app --profile azure2-client-load "
       
 # GROUP 5
 
-- job: Containers_Azure_Intel_Linux
-  displayName: 5- Containers Azure Intel Linux
+- job: Trends_Idna_Amd_Lin
+  displayName: 5- Trends Idna Amd Lin
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
+  dependsOn: [Trends_Azure_Server_Arm64, Trends_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: containers-scenarios.yml
+  - template: trend-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azure-lin "
+      arguments: "$(ciProfile) --profile idna-amd-lin-app --profile idna-intel-lin-load "
       
-- job: Containers_Azure_Arm64_Linux
-  displayName: 5- Containers Azure Arm64 Linux
+- job: Trends_Idna_Amd_Win
+  displayName: 5- Trends Idna Amd Win
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Baselines_Azure_Linux, Baselines_Azure_Arm64_Linux]
+  dependsOn: [Trends_Azure_Server_Arm64, Trends_Azure2_Server_Amd64]
   condition: succeededOrFailed()
   steps:
-  - template: containers-scenarios.yml
+  - template: trend-scenarios.yml
     parameters:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile aspnet-azurearm64-lin "
+      arguments: "$(ciProfile) --profile idna-amd-win-app --profile azure2-db-load "
       
 # GROUP 6
 
-- job: IDNA_Azure_Amd_Linux
-  displayName: 6- IDNA Azure Amd Linux
+- job: Trends_Idna_Intel_Lin
+  displayName: 6- Trends Idna Intel Lin
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [Containers_Azure_Intel_Linux, Containers_Azure_Arm64_Linux]
+  dependsOn: [Trends_Idna_Amd_Lin, Trends_Idna_Amd_Win]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -193,45 +193,13 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azure
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-amd-lin "
+      arguments: "$(ciProfile) --profile idna-intel-lin-app --profile idna-amd-lin-load "
       
-# GROUP 7
-
-- job: IDNA_Azure_Intel_Linux
-  displayName: 7- IDNA Azure Intel Linux
+- job: Trends_Idna_Intel_Win
+  displayName: 6- Trends Idna Intel Win
   pool: server
   timeoutInMinutes: 120
-  dependsOn: [IDNA_Azure_Amd_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: azure
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-intel-lin "
-      
-# GROUP 8
-
-- job: IDNA_Azure_Amd_Windows
-  displayName: 8- IDNA Azure Amd Windows
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [IDNA_Azure_Intel_Linux]
-  condition: succeededOrFailed()
-  steps:
-  - template: trend-scenarios.yml
-    parameters:
-      connection: ASPNET Benchmarks Service Bus
-      serviceBusQueueName: azure
-      serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-amd-win "
-      
-- job: IDNA_Azure_Intel_Windows
-  displayName: 8- IDNA Azure Intel Windows
-  pool: server
-  timeoutInMinutes: 120
-  dependsOn: [IDNA_Azure_Intel_Linux]
+  dependsOn: [Trends_Idna_Amd_Lin, Trends_Idna_Amd_Win]
   condition: succeededOrFailed()
   steps:
   - template: trend-scenarios.yml
@@ -239,6 +207,35 @@ jobs:
       connection: ASPNET Benchmarks Service Bus
       serviceBusQueueName: azurearm64
       serviceBusNamespace: aspnetbenchmarks
-      arguments: "$(ciProfile) --profile idna-intel-win "
+      arguments: "$(ciProfile) --profile idna-intel-win-app --profile azure2-db-load "
       
+# GROUP 7
 
+- job: Trends_Database_Azure_Server_Arm64
+  displayName: 7- Trends Database Azure Server Arm64
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Idna_Intel_Lin, Trends_Idna_Intel_Win]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: azure
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile azure-server-arm64-app --profile azure-client-load --profile azure-db-db "
+      
+- job: Trends_Database_Azure2_Server_Amd64
+  displayName: 7- Trends Database Azure2 Server Amd64
+  pool: server
+  timeoutInMinutes: 120
+  dependsOn: [Trends_Idna_Intel_Lin, Trends_Idna_Intel_Win]
+  condition: succeededOrFailed()
+  steps:
+  - template: trend-database-scenarios.yml
+    parameters:
+      connection: ASPNET Benchmarks Service Bus
+      serviceBusQueueName: azurearm64
+      serviceBusNamespace: aspnetbenchmarks
+      arguments: "$(ciProfile) --profile azure2-server-amd64-app --profile azure2-client-load --profile azure2-db-db "
+      

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -1,0 +1,307 @@
+{
+  "metadata": {
+    "name": "Azure CI Benchmarks Configuration",
+    "description": "Combined machines and scenarios for continuous integration benchmarks on Azure",
+    "version": "1.0",
+    "schedule": "0 9/12 * * *",
+    "queues": [
+      "azure",
+      "azurearm64"
+    ],
+    "yaml_generation": {
+      "target_yaml_count": 2,
+      "schedule_offset_hours": 6
+    }
+  },
+  "machines": [
+    {
+      "name": "azure-arm64-db",
+      "capabilities": {
+        "db": {
+          "priority": 1,
+          "profiles": [
+            "azure-arm64-db-db"
+          ],
+          "default_profile": "azure-arm64-db-db"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "azure-arm64-db-load"
+          ],
+          "default_profile": "azure-arm64-db-load"
+        },
+        "sut": {
+          "priority": 3,
+          "profiles": [
+            "azure-arm64-db-app"
+          ],
+          "default_profile": "azure-arm64-db-app"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure-arm64-client",
+      "capabilities": {
+        "load": {
+          "priority": 1,
+          "profiles": [
+            "azure-arm64-client-load"
+          ],
+          "default_profile": "azure-arm64-client-load"
+        },
+        "sut": {
+          "priority": 2,
+          "profiles": [
+            "azure-arm64-client-app"
+          ],
+          "default_profile": "azure-arm64-client-app"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure-arm64-client-db"
+          ],
+          "default_profile": "azure-arm64-client-db"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure-arm64-server",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "azure-arm64-server-app"
+          ],
+          "default_profile": "azure-arm64-server-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "azure-arm64-server-load"
+          ],
+          "default_profile": "azure-arm64-server-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure-arm64-server-db"
+          ],
+          "default_profile": "azure-arm64-server-db"
+        }
+      },
+      "preferred_partners": [
+        "azure-arm64-client",
+        "azure-arm64-db"
+      ]
+    },
+    {
+      "name": "azure-client",
+      "capabilities": {
+        "load": {
+          "priority": 1,
+          "profiles": [
+            "azure-client-load"
+          ],
+          "default_profile": "azure-client-load"
+        },
+        "sut": {
+          "priority": 2,
+          "profiles": [
+            "azure-client-app"
+          ],
+          "default_profile": "azure-client-app"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure-client-db"
+          ],
+          "default_profile": "azure-client-db"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure-db",
+      "capabilities": {
+        "db": {
+          "priority": 1,
+          "profiles": [
+            "azure-db-db"
+          ],
+          "default_profile": "azure-db-db"
+        },
+        "sut": {
+          "priority": 2,
+          "profiles": [
+            "azure-db-app"
+          ],
+          "default_profile": "azure-db-app"
+        },
+        "load": {
+          "priority": 3,
+          "profiles": [
+            "azure-db-load"
+          ],
+          "default_profile": "azure-db-load"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure-server",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "azure-server-app"
+          ],
+          "default_profile": "azure-server-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "azure-server-load"
+          ],
+          "default_profile": "azure-server-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure-server-db"
+          ],
+          "default_profile": "azure-server-db"
+        }
+      },
+      "preferred_partners": [
+        "azure-client",
+        "azure-db"
+      ]
+    },
+    {
+      "name": "idna-amd-lin",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "idna-amd-lin-app"
+          ],
+          "default_profile": "idna-amd-lin-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "idna-amd-lin-load"
+          ],
+          "default_profile": "idna-amd-lin-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "idna-amd-lin-db"
+          ],
+          "default_profile": "idna-amd-lin-db"
+        }
+      },
+      "preferred_partners": [
+        "idna-intel-lin",
+        "azure-db"
+      ]
+    },
+    {
+      "name": "idna-amd-win",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "idna-amd-win-app"
+          ],
+          "default_profile": "idna-amd-win-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "idna-amd-win-load"
+          ],
+          "default_profile": "idna-amd-win-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "idna-amd-win-db"
+          ],
+          "default_profile": "idna-amd-win-db"
+        }
+      },
+      "preferred_partners": [
+        "idna-amd-lin",
+        "azure-db"
+      ]
+    },
+    {
+      "name": "idna-intel-lin",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "idna-intel-lin-app"
+          ],
+          "default_profile": "idna-intel-lin-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "idna-intel-lin-load"
+          ],
+          "default_profile": "idna-intel-lin-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "idna-intel-lin-db"
+          ],
+          "default_profile": "idna-intel-lin-db"
+        }
+      },
+      "preferred_partners": [
+        "idna-amd-lin",
+        "azure-db"
+      ]
+    },
+    {
+      "name": "idna-intel-win",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "idna-intel-win-app"
+          ],
+          "default_profile": "idna-intel-win-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "idna-intel-win-load"
+          ],
+          "default_profile": "idna-intel-win-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "idna-intel-win-db"
+          ],
+          "default_profile": "idna-intel-win-db"
+        }
+      },
+      "preferred_partners": [
+        "idna-amd-lin",
+        "azure-db"
+      ]
+    }
+  ],
+  "scenarios": []
+}

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -303,5 +303,60 @@
       ]
     }
   ],
-  "scenarios": []
+  "scenarios": [
+    {
+      "name": "Baselines",
+      "template": "baselines-scenarios.yml",
+      "type": 2,
+      "target_machines": [
+        "azure-server-arm64",
+        "azure2-server-amd64"
+      ],
+      "estimated_runtime": 30.0
+    },
+    {
+      "name": "Baselines Database",
+      "template": "baselines-database-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "azure-server-arm64",
+        "azure2-server-amd64"
+      ],
+      "estimated_runtime": 45.0
+    },
+    {
+      "name": "Containers",
+      "template": "containers-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "azure-server-arm64",
+        "azure2-server-amd64"
+      ],
+      "estimated_runtime": 90.0
+    },
+    {
+      "name": "Trends",
+      "template": "trend-scenarios.yml",
+      "type": 2,
+      "target_machines": [
+        "azure-server-arm64",
+        "azure2-server-amd64",
+        "idna-amd-lin",
+        "idna-amd-win",
+        "idna-intel-lin",
+        "idna-intel-win"
+      ],
+      "estimated_runtime": 20.0
+    },
+    {
+      "name": "Trends Database",
+      "template": "trend-database-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "azure-server-arm64",
+        "azure2-server-amd64"
+      ],
+      "estimated_runtime": 15.0
+    }
+  ]
 }

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -21,25 +21,21 @@
           "priority": 1,
           "profiles": [
             "azure-db-db"
-          ],
-          "default_profile": "azure-db-db"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "azure-db-load"
-          ],
-          "default_profile": "azure-db-load"
+          ]
         },
         "sut": {
           "priority": 3,
           "profiles": [
             "azure-db-app"
-          ],
-          "default_profile": "azure-db-app"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "azure-client",
@@ -48,25 +44,21 @@
           "priority": 1,
           "profiles": [
             "azure-client-load"
-          ],
-          "default_profile": "azure-client-load"
+          ]
         },
         "sut": {
           "priority": 2,
           "profiles": [
             "azure-client-app"
-          ],
-          "default_profile": "azure-client-app"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "azure-client-db"
-          ],
-          "default_profile": "azure-client-db"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "azure-server-arm64",
@@ -75,22 +67,19 @@
           "priority": 1,
           "profiles": [
             "azure-server-arm64-app"
-          ],
-          "default_profile": "azure-server-arm64-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "azure-server-arm64-load"
-          ],
-          "default_profile": "azure-server-arm64-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "azure-server-arm64-db"
-          ],
-          "default_profile": "azure-server-arm64-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -105,25 +94,21 @@
           "priority": 1,
           "profiles": [
             "azure2-client-load"
-          ],
-          "default_profile": "azure2-client-load"
+          ]
         },
         "sut": {
           "priority": 2,
           "profiles": [
             "azure2-client-app"
-          ],
-          "default_profile": "azure2-client-app"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "azure2-client-db"
-          ],
-          "default_profile": "azure2-client-db"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "azure2-db",
@@ -132,25 +117,21 @@
           "priority": 1,
           "profiles": [
             "azure2-db-db"
-          ],
-          "default_profile": "azure2-db-db"
+          ]
         },
         "sut": {
           "priority": 2,
           "profiles": [
             "azure2-db-app"
-          ],
-          "default_profile": "azure2-db-app"
+          ]
         },
         "load": {
           "priority": 3,
           "profiles": [
             "azure2-db-load"
-          ],
-          "default_profile": "azure2-db-load"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "azure2-server-amd64",
@@ -159,22 +140,19 @@
           "priority": 1,
           "profiles": [
             "azure2-server-amd64-app"
-          ],
-          "default_profile": "azure2-server-amd64-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "azure2-server-amd64-load"
-          ],
-          "default_profile": "azure2-server-amd64-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "azure2-server-amd64-db"
-          ],
-          "default_profile": "azure2-server-amd64-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -189,22 +167,19 @@
           "priority": 1,
           "profiles": [
             "idna-amd-lin-app"
-          ],
-          "default_profile": "idna-amd-lin-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "idna-amd-lin-load"
-          ],
-          "default_profile": "idna-amd-lin-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "idna-amd-lin-db"
-          ],
-          "default_profile": "idna-amd-lin-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -219,22 +194,19 @@
           "priority": 1,
           "profiles": [
             "idna-amd-win-app"
-          ],
-          "default_profile": "idna-amd-win-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "idna-amd-win-load"
-          ],
-          "default_profile": "idna-amd-win-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "idna-amd-win-db"
-          ],
-          "default_profile": "idna-amd-win-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -249,22 +221,19 @@
           "priority": 1,
           "profiles": [
             "idna-intel-lin-app"
-          ],
-          "default_profile": "idna-intel-lin-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "idna-intel-lin-load"
-          ],
-          "default_profile": "idna-intel-lin-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "idna-intel-lin-db"
-          ],
-          "default_profile": "idna-intel-lin-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -279,22 +248,19 @@
           "priority": 1,
           "profiles": [
             "idna-intel-win-app"
-          ],
-          "default_profile": "idna-intel-win-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "idna-intel-win-load"
-          ],
-          "default_profile": "idna-intel-win-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "idna-intel-win-db"
-          ],
-          "default_profile": "idna-intel-win-db"
+          ]
         }
       },
       "preferred_partners": [

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -9,7 +9,7 @@
       "azurearm64"
     ],
     "yaml_generation": {
-      "target_yaml_count": 2,
+      "target_yaml_count": 1,
       "schedule_offset_hours": 6
     }
   },

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -15,88 +15,31 @@
   },
   "machines": [
     {
-      "name": "azure-arm64-db",
+      "name": "azure-db",
       "capabilities": {
         "db": {
           "priority": 1,
           "profiles": [
-            "azure-arm64-db-db"
+            "azure-db-db"
           ],
-          "default_profile": "azure-arm64-db-db"
+          "default_profile": "azure-db-db"
         },
         "load": {
           "priority": 2,
           "profiles": [
-            "azure-arm64-db-load"
+            "azure-db-load"
           ],
-          "default_profile": "azure-arm64-db-load"
+          "default_profile": "azure-db-load"
         },
         "sut": {
           "priority": 3,
           "profiles": [
-            "azure-arm64-db-app"
+            "azure-db-app"
           ],
-          "default_profile": "azure-arm64-db-app"
+          "default_profile": "azure-db-app"
         }
       },
       "preferred_partners": []
-    },
-    {
-      "name": "azure-arm64-client",
-      "capabilities": {
-        "load": {
-          "priority": 1,
-          "profiles": [
-            "azure-arm64-client-load"
-          ],
-          "default_profile": "azure-arm64-client-load"
-        },
-        "sut": {
-          "priority": 2,
-          "profiles": [
-            "azure-arm64-client-app"
-          ],
-          "default_profile": "azure-arm64-client-app"
-        },
-        "db": {
-          "priority": 3,
-          "profiles": [
-            "azure-arm64-client-db"
-          ],
-          "default_profile": "azure-arm64-client-db"
-        }
-      },
-      "preferred_partners": []
-    },
-    {
-      "name": "azure-arm64-server",
-      "capabilities": {
-        "sut": {
-          "priority": 1,
-          "profiles": [
-            "azure-arm64-server-app"
-          ],
-          "default_profile": "azure-arm64-server-app"
-        },
-        "load": {
-          "priority": 2,
-          "profiles": [
-            "azure-arm64-server-load"
-          ],
-          "default_profile": "azure-arm64-server-load"
-        },
-        "db": {
-          "priority": 3,
-          "profiles": [
-            "azure-arm64-server-db"
-          ],
-          "default_profile": "azure-arm64-server-db"
-        }
-      },
-      "preferred_partners": [
-        "azure-arm64-client",
-        "azure-arm64-db"
-      ]
     },
     {
       "name": "azure-client",
@@ -126,60 +69,117 @@
       "preferred_partners": []
     },
     {
-      "name": "azure-db",
-      "capabilities": {
-        "db": {
-          "priority": 1,
-          "profiles": [
-            "azure-db-db"
-          ],
-          "default_profile": "azure-db-db"
-        },
-        "sut": {
-          "priority": 2,
-          "profiles": [
-            "azure-db-app"
-          ],
-          "default_profile": "azure-db-app"
-        },
-        "load": {
-          "priority": 3,
-          "profiles": [
-            "azure-db-load"
-          ],
-          "default_profile": "azure-db-load"
-        }
-      },
-      "preferred_partners": []
-    },
-    {
-      "name": "azure-server",
+      "name": "azure-server-arm64",
       "capabilities": {
         "sut": {
           "priority": 1,
           "profiles": [
-            "azure-server-app"
+            "azure-server-arm64-app"
           ],
-          "default_profile": "azure-server-app"
+          "default_profile": "azure-server-arm64-app"
         },
         "load": {
           "priority": 2,
           "profiles": [
-            "azure-server-load"
+            "azure-server-arm64-load"
           ],
-          "default_profile": "azure-server-load"
+          "default_profile": "azure-server-arm64-load"
         },
         "db": {
           "priority": 3,
           "profiles": [
-            "azure-server-db"
+            "azure-server-arm64-db"
           ],
-          "default_profile": "azure-server-db"
+          "default_profile": "azure-server-arm64-db"
         }
       },
       "preferred_partners": [
         "azure-client",
         "azure-db"
+      ]
+    },
+    {
+      "name": "azure2-client",
+      "capabilities": {
+        "load": {
+          "priority": 1,
+          "profiles": [
+            "azure2-client-load"
+          ],
+          "default_profile": "azure2-client-load"
+        },
+        "sut": {
+          "priority": 2,
+          "profiles": [
+            "azure2-client-app"
+          ],
+          "default_profile": "azure2-client-app"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure2-client-db"
+          ],
+          "default_profile": "azure2-client-db"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure2-db",
+      "capabilities": {
+        "db": {
+          "priority": 1,
+          "profiles": [
+            "azure2-db-db"
+          ],
+          "default_profile": "azure2-db-db"
+        },
+        "sut": {
+          "priority": 2,
+          "profiles": [
+            "azure2-db-app"
+          ],
+          "default_profile": "azure2-db-app"
+        },
+        "load": {
+          "priority": 3,
+          "profiles": [
+            "azure2-db-load"
+          ],
+          "default_profile": "azure2-db-load"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "azure2-server-amd64",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "azure2-server-amd64-app"
+          ],
+          "default_profile": "azure2-server-amd64-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "azure2-server-amd64-load"
+          ],
+          "default_profile": "azure2-server-amd64-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "azure2-server-amd64-db"
+          ],
+          "default_profile": "azure2-server-amd64-db"
+        }
+      },
+      "preferred_partners": [
+        "azure2-client",
+        "azure2-db"
       ]
     },
     {
@@ -209,7 +209,7 @@
       },
       "preferred_partners": [
         "idna-intel-lin",
-        "azure-db"
+        "azure2-db"
       ]
     },
     {
@@ -239,7 +239,7 @@
       },
       "preferred_partners": [
         "idna-amd-lin",
-        "azure-db"
+        "azure2-db"
       ]
     },
     {
@@ -269,7 +269,7 @@
       },
       "preferred_partners": [
         "idna-amd-lin",
-        "azure-db"
+        "azure2-db"
       ]
     },
     {
@@ -299,7 +299,7 @@
       },
       "preferred_partners": [
         "idna-amd-lin",
-        "azure-db"
+        "azure2-db"
       ]
     }
   ],

--- a/build/benchmarks_ci_azure_eastus2.json
+++ b/build/benchmarks_ci_azure_eastus2.json
@@ -1,0 +1,193 @@
+{
+  "metadata": {
+    "name": "Azure CI Benchmarks Configuration",
+    "description": "Combined machines and scenarios for continuous integration benchmarks on Azure",
+    "version": "1.0",
+    "schedule": "0 9/12 * * *",
+    "queues": [
+      "cobaltcloud"
+    ],
+    "yaml_generation": {
+      "target_yaml_count": 1,
+      "schedule_offset_hours": 6
+    }
+  },
+  "machines": [
+    {
+      "name": "cobalt-cloud-lin-server",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "cobalt-cloud-lin-server-app"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "cobalt-cloud-lin-server-load"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "cobalt-cloud-lin-server-db"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-db"
+        }
+      },
+      "preferred_partners": [
+        "cobalt-cloud-lin-client",
+        "cobalt-cloud-lin-db"
+      ]
+    },
+    {
+      "name": "cobalt-cloud-lin-client",
+      "capabilities": {
+        "load": {
+          "priority": 1,
+          "profiles": [
+            "cobalt-cloud-lin-client-load"
+          ],
+          "default_profile": "cobalt-cloud-lin-client-load"
+        },
+        "db": {
+          "priority": 2,
+          "profiles": [
+            "cobalt-cloud-lin-client-db"
+          ],
+          "default_profile": "cobalt-cloud-lin-client-db"
+        },
+        "sut": {
+          "priority": 3,
+          "profiles": [
+            "cobalt-cloud-lin-client-app"
+          ],
+          "default_profile": "cobalt-cloud-lin-client-app"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "cobalt-cloud-lin-db",
+      "capabilities": {
+        "db": {
+          "priority": 1,
+          "profiles": [
+            "cobalt-cloud-lin-db-db"
+          ],
+          "default_profile": "cobalt-cloud-lin-db-db"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "cobalt-cloud-lin-db-load"
+          ],
+          "default_profile": "cobalt-cloud-lin-db-load"
+        },
+        "sut": {
+          "priority": 3,
+          "profiles": [
+            "cobalt-cloud-lin-db-app"
+          ],
+          "default_profile": "cobalt-cloud-lin-db-app"
+        }
+      },
+      "preferred_partners": []
+    },
+    {
+      "name": "cobalt-cloud-lin-server-azure-linux3",
+      "capabilities": {
+        "sut": {
+          "priority": 1,
+          "profiles": [
+            "cobalt-cloud-lin-server-azure-linux3-app"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-azure-linux3-app"
+        },
+        "load": {
+          "priority": 2,
+          "profiles": [
+            "cobalt-cloud-lin-server-azure-linux3-load"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-azure-linux3-load"
+        },
+        "db": {
+          "priority": 3,
+          "profiles": [
+            "cobalt-cloud-lin-server-azure-linux3-db"
+          ],
+          "default_profile": "cobalt-cloud-lin-server-azure-linux3-db"
+        }
+      },
+      "preferred_partners": [
+        "cobalt-cloud-lin-client",
+        "cobalt-cloud-lin-db"
+      ]
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "Baselines",
+      "template": "baselines-scenarios.yml",
+      "type": 2,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 30.0
+    },
+    {
+      "name": "Baselines Database",
+      "template": "baselines-database-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 45.0
+    },
+    {
+      "name": "Containers",
+      "template": "containers-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 90.0
+    },
+    {
+      "name": "MVC",
+      "template": "mvc-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 20.0
+    },
+    {
+      "name": "Trends",
+      "template": "trend-scenarios.yml",
+      "type": 2,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 20.0
+    },
+    {
+      "name": "Trends Database",
+      "template": "trend-database-scenarios.yml",
+      "type": 3,
+      "target_machines": [
+        "cobalt-cloud-lin-server",
+        "cobalt-cloud-lin-server-azure-linux3"
+      ],
+      "estimated_runtime": 15.0
+    }
+  ]
+}

--- a/build/benchmarks_ci_azure_eastus2.json
+++ b/build/benchmarks_ci_azure_eastus2.json
@@ -20,22 +20,19 @@
           "priority": 1,
           "profiles": [
             "cobalt-cloud-lin-server-app"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "cobalt-cloud-lin-server-load"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "cobalt-cloud-lin-server-db"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-db"
+          ]
         }
       },
       "preferred_partners": [
@@ -50,25 +47,21 @@
           "priority": 1,
           "profiles": [
             "cobalt-cloud-lin-client-load"
-          ],
-          "default_profile": "cobalt-cloud-lin-client-load"
+          ]
         },
         "db": {
           "priority": 2,
           "profiles": [
             "cobalt-cloud-lin-client-db"
-          ],
-          "default_profile": "cobalt-cloud-lin-client-db"
+          ]
         },
         "sut": {
           "priority": 3,
           "profiles": [
             "cobalt-cloud-lin-client-app"
-          ],
-          "default_profile": "cobalt-cloud-lin-client-app"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "cobalt-cloud-lin-db",
@@ -77,25 +70,21 @@
           "priority": 1,
           "profiles": [
             "cobalt-cloud-lin-db-db"
-          ],
-          "default_profile": "cobalt-cloud-lin-db-db"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "cobalt-cloud-lin-db-load"
-          ],
-          "default_profile": "cobalt-cloud-lin-db-load"
+          ]
         },
         "sut": {
           "priority": 3,
           "profiles": [
             "cobalt-cloud-lin-db-app"
-          ],
-          "default_profile": "cobalt-cloud-lin-db-app"
+          ]
         }
-      },
-      "preferred_partners": []
+      }
     },
     {
       "name": "cobalt-cloud-lin-server-azure-linux3",
@@ -104,22 +93,19 @@
           "priority": 1,
           "profiles": [
             "cobalt-cloud-lin-server-azure-linux3-app"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-azure-linux3-app"
+          ]
         },
         "load": {
           "priority": 2,
           "profiles": [
             "cobalt-cloud-lin-server-azure-linux3-load"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-azure-linux3-load"
+          ]
         },
         "db": {
           "priority": 3,
           "profiles": [
             "cobalt-cloud-lin-server-azure-linux3-db"
-          ],
-          "default_profile": "cobalt-cloud-lin-server-azure-linux3-db"
+          ]
         }
       },
       "preferred_partners": [


### PR DESCRIPTION
Switch to auto-scheduled setup for azure and azure_eastus2 ci runs. This includes adding the .json configuration files for specifying the jobs to schedule, updating the yaml schedules themselves, and adding individual machine profiles for the azure machines. I have one more set of machines and jobs to add and then will finalize and add the scheduler I have been using to the repo.

Can't test run the pipelines as the profiles are needed but will make sure to watch the pipelines for success.