### PR TITLE
Remove azure.profile.yml link from tls.benchmarks.yml

### DIFF
--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -3,7 +3,6 @@
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
   - https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml?raw=true
   - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
-  - https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true
 
 variables:
   serverPort: 5000


### PR DESCRIPTION
Remove azure.profile.yml link from tls.benchmarks.yml as it is currently duplicating the config reference causing the application to get send twice in a single run. Other files leave azure.profile.yml to be set at the build/*-scenarios.yml level, so this brings that to being copied.