### PR TITLE
Update the start time for the azure ci runs to be at 2 twice a day

### DIFF
--- a/build/benchmarks-ci-azure-eastus2.yml
+++ b/build/benchmarks-ci-azure-eastus2.yml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 9/12 * * *"
+- cron: "0 2/12 * * *"
   always: true # always run the pipeline even if there have not been source code changes since the last successful scheduled run.
   branches:
     include:

--- a/build/benchmarks-ci-azure.yml
+++ b/build/benchmarks-ci-azure.yml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "0 9/12 * * *"
+- cron: "0 2/12 * * *"
   always: true # always run the pipeline even if there have not been source code changes since the last successful scheduled run.
   branches:
     include:

--- a/build/benchmarks_ci_azure.json
+++ b/build/benchmarks_ci_azure.json
@@ -3,7 +3,7 @@
     "name": "Azure CI Benchmarks Configuration",
     "description": "Combined machines and scenarios for continuous integration benchmarks on Azure",
     "version": "1.0",
-    "schedule": "0 9/12 * * *",
+    "schedule": "0 2/12 * * *",
     "queues": [
       "azure",
       "azurearm64"

--- a/build/benchmarks_ci_azure_eastus2.json
+++ b/build/benchmarks_ci_azure_eastus2.json
@@ -3,7 +3,7 @@
     "name": "Azure CI Benchmarks Configuration",
     "description": "Combined machines and scenarios for continuous integration benchmarks on Azure",
     "version": "1.0",
-    "schedule": "0 9/12 * * *",
+    "schedule": "0 2/12 * * *",
     "queues": [
       "cobaltcloud"
     ],


### PR DESCRIPTION
Update the start time for the azure ci runs to be at 2 twice a day rather than 9 to ensure we don't have machines restart during testing. The goal of this is to fix machines become disconnected/unavailable as the daily update for them runs.