### PR TITLE
Remove erroneous curly brace in src/BenchmarksApps/Lighthouse/package-lock.json

### DIFF
--- a/src/BenchmarksApps/Lighthouse/package-lock.json
+++ b/src/BenchmarksApps/Lighthouse/package-lock.json
@@ -177,15 +177,10 @@
         "@sentry/hub": "6.19.7",
         "@sentry/types": "6.19.7",
         "@sentry/utils": "6.19.7",
-        "cookie": "^0.4.1",
+        "cookie": "0.7.2",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "version": "0.7.2",
-        "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/cookie/-/cookie-0.7.2.tgz",
-        "integrity": "sha1-VWNpxHKiupEPKXmJG1JrNDYjftc="
       }
     },
     "@sentry/types": {

--- a/src/BenchmarksApps/Lighthouse/package.json
+++ b/src/BenchmarksApps/Lighthouse/package.json
@@ -16,5 +16,8 @@
     "lighthouse": "12.2.1",
     "open": "^10.0.4",
     "puppeteer": "^22.3.0"
+  },
+  "overrides": {
+    "cookie@>0.4.0 <0.7.2": "0.7.2"
   }
 }


### PR DESCRIPTION
This got introduced in https://github.com/aspnet/Benchmarks/pull/2032 and newer versions of npm now fail to parse the package-lock.json