### PR TITLE
Revert "Update cobalt hosted azure linux 3 IP addresses (#2133)"

### DIFF
--- a/build/ci.profile.yml
+++ b/build/ci.profile.yml
@@ -447,46 +447,46 @@ profiles:
 
   cobalt-hosted-lin-server-azure-linux3-app:
     variables:
-      serverAddress: 10.57.32.77
+      serverAddress: 10.57.32.95
       cores: 56
     agents:
       application:
         endpoints:
-          - http://10.57.32.77:5001
+          - http://10.57.32.95:5001
         aliases:
           - main
 
   cobalt-hosted-lin-server-azure-linux3-28-app:
     variables:
-      serverAddress: 10.57.32.77
+      serverAddress: 10.57.32.95
       cores: 28
     agents:
       application:
         cpuSet: 0-27
         endpoints:
-          - http://10.57.32.77:5001
+          - http://10.57.32.95:5001
         aliases:
           - main
 
   cobalt-hosted-lin-client-azure-linux3-load:
     variables:
-      secondaryAddress: 10.57.32.76
+      secondaryAddress: 10.57.32.96
     agents:
       load:
         endpoints:
-          - http://10.57.32.76:5001
+          - http://10.57.32.96:5001
         aliases:
           - warmup
           - secondary
 
   cobalt-hosted-lin-db-azure-linux3-db:
     variables:
-      databaseServer: 10.57.32.101
-      downstreamAddress: 10.57.32.101
+      databaseServer: 10.57.32.94
+      downstreamAddress: 10.57.32.94
     agents:
       db:
         endpoints:
-          - http://10.57.32.101:5001
+          - http://10.57.32.94:5001
         aliases:
           - downstream
           - extra


### PR DESCRIPTION
This reverts commit e907eb5fe8bcaa869d77b1528c343bc81233fe88. The DNS vs DHCP servers had a mismatch, and the machines were reassigned back to their previous IP addresses.