### PR TITLE
Fix nuget restore in prbenchmarks.yml and regressionbot.yml

### DIFF
--- a/build/prbenchmarks.yml
+++ b/build/prbenchmarks.yml
@@ -73,9 +73,10 @@ extends:
         steps:
         - checkout: dotnet-crank
           path: crank
+          workspaceRepo: true
           fetchDepth: 1
           displayName: Checkout dotnet-crank
-        - powershell: dotnet build --framework net8.0 -c release $(Pipeline.Workspace)/crank/src/Microsoft.Crank.PullRequestBot/
+        - powershell: dotnet build --framework net8.0 -c release src/Microsoft.Crank.PullRequestBot/
           displayName: Build PR benchmarks
         - checkout: self
           fetchDepth: 1
@@ -89,7 +90,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/aspnetcore `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.aspnetcore.config.yml `
                   --app-id $(github.appid) `
@@ -109,7 +110,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/efcore `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.efcore.config.yml `
                   --app-id $(github.appid) `
@@ -129,7 +130,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/runtime `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.runtime.windows_x64.config.yml `
                   --app-id $(github.appid) `
@@ -150,7 +151,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/runtime `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.runtime.windows_arm64.config.yml `
                   --app-id $(github.appid) `
@@ -173,9 +174,10 @@ extends:
         steps:
         - checkout: dotnet-crank
           path: crank
+          workspaceRepo: true
           fetchDepth: 1
           displayName: Checkout dotnet-crank
-        - powershell: dotnet build --framework net8.0 -c release $(Pipeline.Workspace)/crank/src/Microsoft.Crank.PullRequestBot/
+        - powershell: dotnet build --framework net8.0 -c release src/Microsoft.Crank.PullRequestBot/
           displayName: Build PR benchmarks
         - checkout: self
           fetchDepth: 1
@@ -189,7 +191,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/runtime `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.runtime.linux_x64.config.yml `
                   --app-id $(github.appid) `
@@ -209,7 +211,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $buildUrl="$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)" 
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
+              dotnet artifacts/bin/Microsoft.Crank.PullRequestBot/release/net8.0/crank-pr.dll `
                   --repository https://github.com/dotnet/runtime `
                   --config $(Pipeline.Workspace)/benchmarks/build/prbenchmarks.runtime.linux_arm64.config.yml `
                   --app-id $(github.appid) `

--- a/build/regressionbot.yml
+++ b/build/regressionbot.yml
@@ -55,9 +55,10 @@ extends:
         steps:
         - checkout: dotnet-crank
           path: crank
+          workspaceRepo: true
           fetchDepth: 1
           displayName: Checkout dotnet-crank
-        - powershell: dotnet build --framework net8.0 -c release $(Pipeline.Workspace)/crank/src/Microsoft.Crank.RegressionBot/
+        - powershell: dotnet build --framework net8.0 -c release src/Microsoft.Crank.RegressionBot/
           displayName: Build regression bot
         - checkout: self
           fetchDepth: 1
@@ -69,7 +70,7 @@ extends:
             scriptType: ps
             scriptLocation: inlineScript
             inlineScript: |
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.RegressionBot/release/net8.0/Microsoft.Crank.RegressionBot.dll `
+              dotnet artifacts/bin/Microsoft.Crank.RegressionBot/release/net8.0/Microsoft.Crank.RegressionBot.dll `
                   --config $(Pipeline.Workspace)/benchmarks/build/regressions.config.yml `
                   --connectionstring BENCHMARKSBOT_ConnectionString `
                   --repository-id $(github.repositoryId) `
@@ -79,7 +80,7 @@ extends:
                   --app-key BENCHMARKSBOT_GitHubAppKey `
                   --verbose
               
-              dotnet $(Pipeline.Workspace)/crank/artifacts/bin/Microsoft.Crank.RegressionBot/release/net8.0/Microsoft.Crank.RegressionBot.dll `
+              dotnet artifacts/bin/Microsoft.Crank.RegressionBot/release/net8.0/Microsoft.Crank.RegressionBot.dll `
                   --config $(Pipeline.Workspace)/benchmarks/build/regressions.blazor.config.yml `
                   --connectionstring BENCHMARKSBOT_ConnectionString `
                   --repository-id $(github.repositoryId) `


### PR DESCRIPTION
In the pipeline dotnet restore was accidentally not using the nuget.config in the repo since we ran dotnet from the checkout root. Instead we can set `workspaceRoot: true` on the crank checkout step to make it the default working directory.

This fixes network isolation violations in the pipelines.

/cc @LoopedBard3 @sebastienros 