### PR TITLE
Update dependencies and clean up some warnings for net11.0 support

### DIFF
--- a/src/Benchmarks/Data/World.cs
+++ b/src/Benchmarks/Data/World.cs
@@ -10,7 +10,6 @@ namespace Benchmarks.Data
     [Table("world")]
     public class World
     {
-        [UseColumnAttribute] // Fixes DAP043 warning
         [Column("id")]
         public int Id { get; set; }
 
@@ -18,7 +17,6 @@ namespace Benchmarks.Data
         [NotMapped, DbValue(Ignore = true)]
         public int _Id { get; set; }
 
-        [UseColumnAttribute] // Fixes DAP043 warning
         [Column("randomnumber")]
         public int RandomNumber { get; set; }
     }

--- a/src/Benchmarks/Startup.cs
+++ b/src/Benchmarks/Startup.cs
@@ -18,7 +18,6 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Npgsql;
 using System.IO;
 using Microsoft.AspNetCore.WebUtilities;
@@ -28,7 +27,7 @@ namespace Benchmarks
 {
     public class Startup
     {
-        public Startup(IWebHostEnvironment hostingEnv)
+        public Startup(IHostingEnvironment hostingEnv, Scenarios scenarios)
         {
             // Set up configuration sources.
             var builder = new ConfigurationBuilder()
@@ -39,27 +38,21 @@ namespace Benchmarks
                 .AddCommandLine(Program.Args);
 
             Configuration = builder.Build();
+
+            Scenarios = scenarios;
         }
 
         public IConfigurationRoot Configuration { get; set; }
 
-        public Scenarios Scenarios { get; private set; }
+        public Scenarios Scenarios { get; }
 
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<AppSettings>(Configuration);
 
-            // Retrieve Scenarios that was registered in Program.Main
-            // We need it throughout ConfigureServices, so we must call BuildServiceProvider here.
-            // Warning suppression justification:
-            // Duplicate Scenarios will not cause issues as it is a singleton and we re-register the same instance below.
-            // Moving to a different pattern would require significant refactoring.
-#pragma warning disable ASP0000 // Do not call 'BuildServiceProvider' in 'ConfigureServices'
-            using (var serviceProvider = services.BuildServiceProvider())
-            {
-                Scenarios = serviceProvider.GetRequiredService<Scenarios>();
-            }
-#pragma warning restore ASP0000
+            // We re-register the Scenarios as an instance singleton here to avoid it being created again due to the
+            // registration done in Program.Main
+            services.AddSingleton(Scenarios);
 
             // Common DB services
             services.AddSingleton<IRandom, DefaultRandom>();
@@ -237,7 +230,7 @@ namespace Benchmarks
             }
         }
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
Update dependencies and clean up leftover warnings when building Benchmarks.csproj. This adds support for net11.0 when building the Benchmarks.csproj project with a clean build. This should also fix failing tech-empower testing in the optimization repo (or at least get us further along in the test).

The decently sized Program.cs change is really just taking the previous code and putting it inside of the ConfigureWebHost function.


When building net11, the warnings that were cleaned up were: 
```
dotnet build -c Release -f net11.0 /p:TargetFramework=net11.0
    info NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Benchmarks net11.0 succeeded with 4 warning(s) (26.3s) → bin\Release\net11.0\Benchmarks.dll
    C:\Users\<user>\repos\benchmarks\src\Benchmarks\Program.cs(58,38): warning ASPDEPR004: 'WebHostBuilder' is obsolete: 'WebHostBuilder is deprecated in favor of HostBuilder and WebApplicationBuilder. For more information, visit https://aka.ms/aspnet/deprecate/004.' (https://aka.ms/aspnet/deprecate/004)
    C:\Users\<user>\repos\benchmarks\src\Benchmarks\Program.cs(151,27): warning ASPDEPR008: 'IWebHostBuilder.Build()' is obsolete: 'IWebHost is obsolete. Use IHost instead. For more information, visit https://aka.ms/aspnet/deprecate/008.' (https://aka.ms/aspnet/deprecate/008)
    C:\Users\<user>\repos\benchmarks\src\Benchmarks\Data\World.cs(13,10): warning DAP043: Attach the [UseColumnAttribute] attribute to make Dapper consider [Column] (https://aot.dapperlib.dev/rules/DAP043)
    C:\Users\<user>\repos\benchmarks\src\Benchmarks\Data\World.cs(20,10): warning DAP043: Attach the [UseColumnAttribute] attribute to make Dapper consider [Column] (https://aot.dapperlib.dev/rules/DAP043)

Build succeeded with 4 warning(s) in 26.7s
```

I tested building this with the latest net11 alpha locally and it built successfully. What other testing should be done before merging this? 