### PR TITLE
Fix OrchardCore Net8.0 and Net9.0 baseline runs

### DIFF
--- a/build/baselines-scenarios.yml
+++ b/build/baselines-scenarios.yml
@@ -31,16 +31,16 @@ parameters:
   - displayName: "10.0"
     arguments: --application.framework net10.0 --property framework=net10.0 --application.noGlobalJson false
 
-# Orchard Baselines (uses release/2.2 branch for net8.0 and net9.0)
+# Orchard Baselines (uses release/2.2 branch for net8.0 and main#eefd4a1659cd48e56b681b5bcff2cc92b349b464 for net9.0)
 - name: orchardBaselines
   type: object
   default:
 
   - displayName: "8.0"
-    arguments: --application.framework net8.0 --property framework=net8.0 --application.branchOrCommit release/2.2
+    arguments: --application.framework net8.0 --property framework=net8.0 --application.source.branchOrCommit release/2.2
 
   - displayName: "9.0"
-    arguments: --application.framework net9.0 --property framework=net9.0 --application.branchOrCommit release/2.2
+    arguments: --application.framework net9.0 --property framework=net9.0 --application.source.branchOrCommit main#eefd4a1659cd48e56b681b5bcff2cc92b349b464
 
   - displayName: "10.0"
     arguments: --application.framework net10.0 --property framework=net10.0 --application.noGlobalJson false


### PR DESCRIPTION
Update OrchardCore net8 and net9 baseline runs to use release/2.2 branch, the latest branch that supports building for net8 and net9. Verified for both net8 and net9 locally. Different branchOrCommit options are being used for net8.0 and net9.0 as neither of the 2 selected were compatible with both.