### PR TITLE
Add requiredOperatingSystem linux filter to Kestrel Linux rejection scenarios

### DIFF
--- a/build/trend-scenarios.yml
+++ b/build/trend-scenarios.yml
@@ -135,13 +135,13 @@ parameters:
     arguments: --scenario httpsys-hostheader-mismatch $(rejectionJobs) --property scenario=RejectionHostHeaderMismatchHttpSys --application.options.requiredOperatingSystem windows
 
   - displayName: "Kestrel Linux: Encoded URL symbols"
-    arguments: --scenario kestrel-encoded-url $(rejectionJobs) --property scenario=RejectionEncodedUrlKestrel
+    arguments: --scenario kestrel-encoded-url $(rejectionJobs) --property scenario=RejectionEncodedUrlKestrel --application.options.requiredOperatingSystem linux
 
   - displayName: "Kestrel Linux: Invalid Header"
-    arguments: --scenario kestrel-header-symbols $(rejectionJobs) --property scenario=RejectionInvalidHeaderKestrel
+    arguments: --scenario kestrel-header-symbols $(rejectionJobs) --property scenario=RejectionInvalidHeaderKestrel --application.options.requiredOperatingSystem linux
 
   - displayName: "Kestrel Linux: Host Header Mismatch"
-    arguments: --scenario kestrel-hostheader-mismatch $(rejectionJobs) --property scenario=RejectionHostHeaderMismatchKestrel
+    arguments: --scenario kestrel-hostheader-mismatch $(rejectionJobs) --property scenario=RejectionHostHeaderMismatchKestrel --application.options.requiredOperatingSystem linux
 
 steps:
 - ${{ each s in parameters.scenarios }}:


### PR DESCRIPTION
Add requiredOperatingSystem linux filter to Kestrel Linux rejection scenarios

The Kestrel Linux rejection scenarios (Encoded URL symbols, Invalid Header, Host Header Mismatch) were missing the --application.options.requiredOperatingSystem linux flag, causing them to be scheduled on Windows agents where OpenSSL is unsupported.