### PR TITLE
Add NoResetOnClose=true to PostgreSQL connection strings missing it

### DIFF
--- a/scenarios/database.benchmarks.yml
+++ b/scenarios/database.benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
     arguments: "--nonInteractive true --scenarios {{scenario}} --urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --server {{server}} --kestrelTransport {{transport}} --protocol {{protocol}}"
     environmentVariables:
       database: PostgresQL
-      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;Enlist=false;Max Auto Prepare=4
+      connectionString: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=18;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
 
   postgresql:
     source:

--- a/scenarios/mono.benchmarks.yml
+++ b/scenarios/mono.benchmarks.yml
@@ -166,7 +166,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -184,7 +184,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -202,7 +202,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -220,7 +220,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -418,7 +418,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -435,7 +435,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -452,7 +452,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:
@@ -469,7 +469,7 @@ scenarios:
         - "/p:IsDatabase=true"
       environmentVariables:
         database: PostgreSQL
-        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;Enlist=false;Max Auto Prepare=4
+        connectionstring: Server={{databaseServer}};Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=4
     load:
       job: wrk
       variables:


### PR DESCRIPTION
Commit 36ab8b94 removed Multiplexing=true and tightened Program.cs to require NoResetOnClose=true, but missed adding it to connection strings that previously relied on Multiplexing=true to pass the check.

Fixes Fortunes, Fortunes EF, and Fortune Dapper failures in the benchmarks-ci-01 Trends Database pipeline.