### PR TITLE
Update EF Core benchmark framework target to net11.0

### DIFF
--- a/scenarios/efcore.benchmarks.yml
+++ b/scenarios/efcore.benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
       jobType: short
     arguments: --job {{jobType}} --filter {{filter}} --memory
     # force .NET version as the project currently uses a variable
-    framework: net10.0
+    framework: net11.0
     options:
       benchmarkDotNet: true
 


### PR DESCRIPTION
The EF Core repo (dotnet/efcore main branch) has moved its projects to target net11.0 (updated global.json and using NetCurrent for TFM), but the benchmark scenario was still forcing net10.0. This caused NETSDK1045 errors on the build agent since the .NET 10 SDK cannot compile net11.0 projects. We also wanted to update to get test runs using latest net11 anyways.