### PR TITLE
Increase Blazor Wasm crank timeout to 20 minutes

### DIFF
--- a/build/blazor-scenarios.yml
+++ b/build/blazor-scenarios.yml
@@ -54,6 +54,7 @@ steps:
         {
           "name": "crank",
           "condition": "(${{ parameters.condition }})",
+          "timeout": "00:20:00",
           "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --application.framework net11.0 --command-line-property --table BlazorWasm --sql SQL_CONNECTION_STRING --cert-tenant-id SQL_SERVER_TENANTID --cert-client-id SQL_SERVER_CLIENTID --cert-path SQL_SERVER_CERT_PATH --cert-sni --chart" ]
         }
 


### PR DESCRIPTION
The Blazor Wasm benchmark was timing out at the default 10-minute crank timeout. Add explicit timeout of 20 minutes to the crank job message body.

This was timing out in the Gold tests while taking 9m 40s in the Intel Perf Lin tests for Blazor Wasm, so I expect slightly upping the timeout time to help with the Gold tests not finishing. Pipeline run hitting this error: https://dev.azure.com/dnceng/internal/_build/results?buildId=2919052&view=results.