### PR TITLE
Replace blob redirect URLs with direct raw.githubusercontent.com URLs

### DIFF
--- a/build/ci.profile.yml
+++ b/build/ci.profile.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/packages.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/packages.yml
 
 profiles:
   short:

--- a/build/job-variables.yml
+++ b/build/job-variables.yml
@@ -88,8 +88,8 @@ variables:
 - name: containerMatrixJobs
   value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/containers.benchmarks.yml
 - name: minimalJobs
-  value: --config https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml?raw=true
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml
 - name: blazorSsrJobs
-  value: --config https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/TechEmpower/BlazorSSR/blazorssr.benchmarks.yml?raw=true
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/TechEmpower/BlazorSSR/blazorssr.benchmarks.yml
 - name: razorPagesJobs
-  value: --config https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/TechEmpower/RazorPages/razorpages.benchmarks.yml?raw=true
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/TechEmpower/RazorPages/razorpages.benchmarks.yml

--- a/build/prbenchmarks.aspnetcore.config.yml
+++ b/build/prbenchmarks.aspnetcore.config.yml
@@ -21,7 +21,7 @@ components:
             --application.options.outputFiles .\artifacts\bin\Microsoft.AspNetCore.Routing\release\net10.0\
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net11.0 --application.options.collectCounters true --relay 
+defaults: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/azure.profile.yml --application.framework net11.0 --application.options.collectCounters true --relay 
 
 # the first value is the default if none is specified
 profiles:

--- a/build/prbenchmarks.efcore.config.yml
+++ b/build/prbenchmarks.efcore.config.yml
@@ -9,7 +9,7 @@ components:
             --application.options.outputFiles .\artifacts\bin\EFCore.Sqlite.Benchmarks\Release\net8.0\
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --application.framework net8.0 --relay 
+defaults: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/azure.profile.yml --application.framework net8.0 --relay 
 
 # the first value is the default if none is specified
 profiles:
@@ -24,56 +24,56 @@ profiles:
 benchmarks:
     AddDataVariations:
       description: AddDataVariations
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario AddDataVariations
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario AddDataVariations
 
     ChildVariations:
       description: ChildVariations
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario ChildVariations
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario ChildVariations
 
     Delete:
       description: Delete
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Delete
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Delete
 
     ExistingDataVariations:
       description: ExistingDataVariations
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario ExistingDataVariations
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario ExistingDataVariations
 
     Funcletization:
       description: Funcletization
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Funcletization
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Funcletization
 
     Initialization:
       description: Initialization
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Initialization
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Initialization
 
     Insert:
       description: Insert
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Insert
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Insert
 
     Mixed:
       description: Mixed
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Mixed
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Mixed
 
     ParentVariations:
       description: ParentVariations
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario ParentVariations
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario ParentVariations
 
     RawSqlQuery:
       description: RawSqlQuery
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario RawSqlQuery
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario RawSqlQuery
 
     SimpleQuery:
       description: SimpleQuery
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario SimpleQuery
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario SimpleQuery
 
     NavigationsQuery:
       description: NavigationsQuery
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario NavigationsQuery
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario NavigationsQuery
 
     QueryCompilation:
       description: QueryCompilation
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario QueryCompilation
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario QueryCompilation
 
     Update:
       description: Update
-      arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/efcore.benchmarks.yml?raw=true --scenario Update
+      arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/efcore.benchmarks.yml --scenario Update

--- a/build/prbenchmarks.runtime.linux_arm64.config.yml
+++ b/build/prbenchmarks.runtime.linux_arm64.config.yml
@@ -17,7 +17,7 @@ components:
             --{{job}}.options.outputFiles ./artifacts/tests/coreclr/Linux.arm64.Release/tests/Core_Root/
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --{{job}}.framework net11.0 --relay 
+defaults: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/azure.profile.yml --{{job}}.framework net11.0 --relay 
 
 variables:
     job: application

--- a/build/prbenchmarks.runtime.windows_arm64.config.yml
+++ b/build/prbenchmarks.runtime.windows_arm64.config.yml
@@ -17,7 +17,7 @@ components:
             --{{job}}.options.outputFiles .\artifacts\tests\coreclr\windows.arm64.Release\tests\Core_Root\
 
 # default arguments that are always used on crank commands
-defaults: --config https://github.com/aspnet/Benchmarks/blob/main/build/azure.profile.yml?raw=true --{{job}}.framework net11.0 --relay 
+defaults: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/build/azure.profile.yml --{{job}}.framework net11.0 --relay 
 
 variables:
     job: application

--- a/build/sslstream-scenarios.yml
+++ b/build/sslstream-scenarios.yml
@@ -25,13 +25,13 @@ parameters:
     type: object
     default:
       - displayName: "SslStream"
-        arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/sslstream.benchmarks.yml?raw=true --property transport=SslStream
+        arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/sslstream.benchmarks.yml --property transport=SslStream
 
   - name: quicTransport
     type: object
     default:
       - displayName: "QUIC"
-        arguments: --config https://github.com/aspnet/Benchmarks/blob/main/scenarios/quic.benchmarks.yml?raw=true --property transport=QUIC --property tlsVersion=1.3 --property tlsResume=no-resume
+        arguments: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/quic.benchmarks.yml --property transport=QUIC --property tlsVersion=1.3 --property tlsResume=no-resume
 
   - name: readWriteScenarios
     type: object

--- a/scenarios/antiforgery.benchmarks.yml
+++ b/scenarios/antiforgery.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/aspnet.profiles.standard.yml
+++ b/scenarios/aspnet.profiles.standard.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/packages.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/packages.yml
 
 profiles:
   short:

--- a/scenarios/aspnet.profiles.yml
+++ b/scenarios/aspnet.profiles.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/packages.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/packages.yml
 
 variables:
   localendpoint: http://localhost:5010

--- a/scenarios/blazor.benchmarks.yml
+++ b/scenarios/blazor.benchmarks.yml
@@ -1,8 +1,8 @@
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
-  - https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/Lighthouse/lighthouse.yml?raw=true
-  - https://github.com/aspnet/Benchmarks/blob/main/src/BenchmarksApps/RunTemplate/runtemplate.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Lighthouse/lighthouse.yml
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/RunTemplate/runtemplate.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/containers.benchmarks.yml
+++ b/scenarios/containers.benchmarks.yml
@@ -1,5 +1,5 @@
-﻿imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/te.benchmarks.yml?raw=true
+imports:
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/te.benchmarks.yml
 
 jobs:
   aspnet:

--- a/scenarios/database.benchmarks.yml
+++ b/scenarios/database.benchmarks.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/dotnet.benchmarks.yml
+++ b/scenarios/dotnet.benchmarks.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://github.com/aspnet/benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 jobs:
   dotnet:

--- a/scenarios/efcore.benchmarks.yml
+++ b/scenarios/efcore.benchmarks.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   
 jobs:
   efcore:

--- a/scenarios/goldilocks.benchmarks.yml
+++ b/scenarios/goldilocks.benchmarks.yml
@@ -1,9 +1,9 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.H2Load/h2load.yml
 

--- a/scenarios/grpc.benchmarks.yml
+++ b/scenarios/grpc.benchmarks.yml
@@ -1,8 +1,8 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.grpc.yml --scenario grpcaspnetcoreserver-grpcnetclient --profile aspnet-physical-lin --variable scenario=unary --variable streams=70
 
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   - https://raw.githubusercontent.com/grpc/grpc-dotnet/master/perf/benchmarkapps/GrpcClient/grpc-client.yml
   - https://raw.githubusercontent.com/grpc/grpc-dotnet/master/perf/benchmarkapps/GrpcAspNetCoreServer/grpc-aspnetcore-server.yml
   - https://raw.githubusercontent.com/grpc/grpc-dotnet/master/perf/benchmarkapps/GrpcCoreServer/grpc-core-server.yml

--- a/scenarios/json.benchmarks.yml
+++ b/scenarios/json.benchmarks.yml
@@ -1,11 +1,11 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/mono.benchmarks.yml
+++ b/scenarios/mono.benchmarks.yml
@@ -3,7 +3,7 @@
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/orchard.benchmarks.yml
+++ b/scenarios/orchard.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/plaintext.benchmarks.yml
+++ b/scenarios/plaintext.benchmarks.yml
@@ -1,11 +1,11 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverScheme: http

--- a/scenarios/platform.benchmarks.yml
+++ b/scenarios/platform.benchmarks.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config platform.benchmarks.yml --scenario json --profile aspnet-citrine-lin
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.standard.yml
 
 variables:
   serverScheme: http

--- a/scenarios/rejection.benchmarks.yml
+++ b/scenarios/rejection.benchmarks.yml
@@ -7,7 +7,7 @@ imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.PipeliningClient/pipelining.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/signalr.benchmarks.yml
+++ b/scenarios/signalr.benchmarks.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.signalr.yml --scenario signalr --variable scenario=broadcast --variable protocol=messagepack --variable transport=LongPolling --profile asp-perf-lin
 
 imports:
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/SignalRClient/signalrclient.yml
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/SignalR/signalrServer.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000

--- a/scenarios/staticfiles.benchmarks.yml
+++ b/scenarios/staticfiles.benchmarks.yml
@@ -3,7 +3,7 @@
 
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverScheme: http

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -1,7 +1,7 @@
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 jobs:
 

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -1,8 +1,8 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
   - https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml?raw=true
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/scenarios/websocket.benchmarks.yml
+++ b/scenarios/websocket.benchmarks.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config websocket.benchmarks.yml --scenario websocket --variable scenario=echo --profile aspnet-perf-lin
 
 imports:
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/WebsocketClient/websocketclient.yml
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Websocket/websocketServer.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000

--- a/src/Benchmarks/database.benchmarks.yml
+++ b/src/Benchmarks/database.benchmarks.yml
@@ -1,9 +1,9 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/WrkClient/wrk.yml
 
 variables:

--- a/src/Benchmarks/plaintext.benchmarks.yml
+++ b/src/Benchmarks/plaintext.benchmarks.yml
@@ -1,9 +1,9 @@
-﻿# Examples:
+# Examples:
 # --config plaintext.benchmarks.yml --scenario plaintext --profile aspnet-physical
 # --config benchmarks.compose.yml --scenario fortunes --profile aspnet-physical
 
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/WrkClient/wrk.yml
 
 variables:

--- a/src/BenchmarksApps/HelloWorldMiddleware/benchmarks.yml
+++ b/src/BenchmarksApps/HelloWorldMiddleware/benchmarks.yml
@@ -1,7 +1,7 @@
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
   serverPort: 5000

--- a/src/BenchmarksApps/Mvc/benchmarks.certapi.yml
+++ b/src/BenchmarksApps/Mvc/benchmarks.certapi.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.certapi.yml --scenario ApiCrudListProducts --profile aspnet-perf-lin
 
 imports:
 - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
 - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Mvc/mvcserver.yml
-- https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+- https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000
@@ -25,7 +25,7 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx
 
     # List products
   ApiCrudListProducts:
@@ -42,7 +42,7 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx
 
     # Get an individual product
   ApiCrudGetProductDetails:
@@ -59,7 +59,7 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx
 
    # Add product
   ApiCrudAddProduct:
@@ -78,7 +78,7 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx
 
     # Update product
   ApiCrudUpdateProduct:
@@ -97,7 +97,7 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx
 
     # Remove a product item
   ApiCrudDeleteProduct:
@@ -115,4 +115,4 @@ scenarios:
         serverScheme: https
         # [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Benchmark code, not a secret")]
         certPwd: testPassword
-        certPath: https://github.com/aspnet/benchmarks/blob/main/src/Benchmarks/testCert.pfx?raw=true
+        certPath: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/Benchmarks/testCert.pfx

--- a/src/BenchmarksApps/Mvc/benchmarks.crudapi.yml
+++ b/src/BenchmarksApps/Mvc/benchmarks.crudapi.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.crudapi.yml --scenario ApiCrudListProducts --profile aspnet-perf-lin
 
 imports:
 - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
 - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Mvc/mvcserver.yml
-- https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+- https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/Mvc/benchmarks.jwtapi.yml
+++ b/src/BenchmarksApps/Mvc/benchmarks.jwtapi.yml
@@ -1,10 +1,10 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.jwtapi.yml --scenario ApiCrudListProducts --profile aspnet-perf-lin
 
 imports:
 - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
 - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Mvc/mvcserver.yml
-- https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+- https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/Mvc/benchmarks.mvcjson.yml
+++ b/src/BenchmarksApps/Mvc/benchmarks.mvcjson.yml
@@ -1,11 +1,11 @@
-﻿# Examples:
+# Examples:
 # --config benchmarks.mvcjson.yml --scenario MvcJson2k --profile aspnet-perf-lin
 
 imports:
 - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
 - https://raw.githubusercontent.com/dotnet/crank/master/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
 - https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Mvc/mvcserver.yml
-- https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+- https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/Samples/Template/sample.yml
+++ b/src/BenchmarksApps/Samples/Template/sample.yml
@@ -1,8 +1,8 @@
-﻿# Examples:
+# Examples:
 # --config platform.benchmarks.yml --scenario json --profile aspnet-citrine-lin
 
 imports:
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
 
 jobs:

--- a/src/BenchmarksApps/TechEmpower/BlazorSSR/blazorssr.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/BlazorSSR/blazorssr.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.standard.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/Minimal/minimal.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.standard.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/TechEmpower/Mvc/mvc.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/Mvc/mvc.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.standard.yml
 
 variables:
     serverPort: 5000

--- a/src/BenchmarksApps/TechEmpower/RazorPages/razorpages.benchmarks.yml
+++ b/src/BenchmarksApps/TechEmpower/RazorPages/razorpages.benchmarks.yml
@@ -1,6 +1,6 @@
-﻿imports:
+imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
-  - https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.standard.yml?raw=true
+  - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.standard.yml
 
 variables:
     serverPort: 5000


### PR DESCRIPTION
## Problem

The crank controller intermittently fails to load benchmark configuration files when they use GitHub blob URLs with `?raw=true` suffix (e.g. `https://github.com/aspnet/Benchmarks/blob/main/scenarios/packages.yml?raw=true`). These URLs require a 302 redirect to `raw.githubusercontent.com`, and the redirect occasionally fails on the perf-lab crank controllers.

This causes **CONFIG_LOAD failures** in benchmark pipeline runs. For example, in [pipeline 1208 build 2919710](https://dev.azure.com/dnceng/internal/_build/results?buildId=2919710), 54 tasks across Grpc Gold Win, Proxies Gold Lin, and Baselines Intel Lin failed with:
```
Configuration 'https://github.com/aspnet/Benchmarks/blob/main/scenarios/packages.yml?raw=true' could not be loaded.
```

Meanwhile, config files using direct `raw.githubusercontent.com` URLs (35 of them in `job-variables.yml`) never exhibit this issue.

## Probable fix

Replace all `github.com/aspnet/Benchmarks/blob/main/...?raw=true` URLs with direct `raw.githubusercontent.com/aspnet/Benchmarks/main/...` URLs across 40 config files. This eliminates the redirect hop and makes config loading reliable.

## Changes

- 40 files updated
- 88 URL replacements (blob → raw)
- No functional change — both URL forms serve identical content