### PR TITLE
Fix GoServer and GoClient Docker builds by running go mod tidy

### DIFF
--- a/src/BenchmarksApps/Grpc/GoClient/go.mod
+++ b/src/BenchmarksApps/Grpc/GoClient/go.mod
@@ -1,16 +1,17 @@
 module github.com/grpc/grpc-dotnet
 
-go 1.21
+go 1.23.0
+
+toolchain go1.23.7
 
 require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
-	github.com/golang/glog v1.2.4
 )
 
 require (
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d // indirect
 )

--- a/src/BenchmarksApps/Grpc/GoClient/go.sum
+++ b/src/BenchmarksApps/Grpc/GoClient/go.sum
@@ -1,11 +1,11 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d h1:JU0iKnSg02Gmb5ZdV8nYsKEKsP6o/FGVWTrw4i1DA9A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=

--- a/src/BenchmarksApps/Grpc/GoServer/go.mod
+++ b/src/BenchmarksApps/Grpc/GoServer/go.mod
@@ -1,16 +1,17 @@
 module github.com/grpc/grpc-dotnet
 
-go 1.21
+go 1.23.0
+
+toolchain go1.23.7
 
 require (
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
-	github.com/golang/glog v1.2.4
 )
 
 require (
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d // indirect
 )

--- a/src/BenchmarksApps/Grpc/GoServer/go.sum
+++ b/src/BenchmarksApps/Grpc/GoServer/go.sum
@@ -1,11 +1,11 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d h1:JU0iKnSg02Gmb5ZdV8nYsKEKsP6o/FGVWTrw4i1DA9A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240711142825-46eb208f015d/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=


### PR DESCRIPTION
## Fix GoServer and GoClient Docker builds by running `go mod tidy`

### Problem
All Go gRPC Docker builds have been failing in benchmark pipeline 1208 since August 2025 (commit e810874, PR #2107). The failure affects **40 tasks per Linux job** (Grpc Gold Lin + Grpc Intel Lin = 80 total), accounting for the largest share of pipeline failures.

The error (visible only on crank agent build logs):
```
missing go.sum entry for module providing package golang.org/x/net/trace
missing go.sum entry for module providing package golang.org/x/net/http2
missing go.sum entry for module providing package golang.org/x/net/http2/hpack
```

### Root Cause
PR #2107 updated `golang.org/x/net` from `v0.33.0` to `v0.38.0` in `go.mod` for GoServer and GoClient, but **did not run `go mod tidy`** to update `go.sum`. The `go.sum` files still contain checksums for `v0.33.0`, causing `go build` inside Docker to fail with missing checksum entries.

This is exactly the same issue that was fixed for **BasicGoServer** in PR #2149 (Feb 10, 2026) — but GoServer and GoClient were missed.

### Fix
Run `go mod tidy` in both directories, which:
- Updates `go.sum` to match `go.mod` (x/net v0.33.0 → v0.38.0)
- Updates `go` directive from 1.21 to 1.23.0 (with toolchain go1.23.7)
- Removes unused `github.com/golang/glog` dependency
- Updates transitive dependencies (x/sys, x/text)

### Impact
This should fix **80 DOCKER_BUILD failures per pipeline run** across Grpc Gold Lin and Grpc Intel Lin jobs.
