### PR TITLE
Fix Blazor Wasm build timeout by setting agent-side buildTimeout

### DIFF
--- a/build/blazor-scenarios.yml
+++ b/build/blazor-scenarios.yml
@@ -55,7 +55,7 @@ steps:
           "name": "crank",
           "condition": "(${{ parameters.condition }})",
           "timeout": "00:20:00",
-          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --application.framework net11.0 --command-line-property --table BlazorWasm --sql SQL_CONNECTION_STRING --cert-tenant-id SQL_SERVER_TENANTID --cert-client-id SQL_SERVER_CLIENTID --cert-path SQL_SERVER_CERT_PATH --cert-sni --chart" ]
+          "args": [ "${{ parameters.arguments }} --session $(session) ${{ s.arguments }} --application.buildTimeout 00:20:00 --application.framework net11.0 --command-line-property --table BlazorWasm --sql SQL_CONNECTION_STRING --cert-tenant-id SQL_SERVER_TENANTID --cert-client-id SQL_SERVER_CLIENTID --cert-path SQL_SERVER_CERT_PATH --cert-sni --chart" ]
         }
 
 - ${{ each s in parameters.lighthouseScenarios }}:


### PR DESCRIPTION
PR #2158 increased the controller-level session `timeout` in the Service Bus message body to 20 minutes, but the crank **agent's** build step still used the default 10-minute `DefaultBuildTimeout` from [dotnet/crank](https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Agent/Startup.cs). The `Build is taking too long. Halting build.` error (e.g. [build 2921804](https://dev.azure.com/dnceng/internal/_build/results?buildId=2921804&view=logs&j=498143a6-e4dc-535f-b54c-28a8c7800fd5&t=51059d75-297d-56be-ca99-fe90133dc142)) was the agent killing the build, not the controller timing out.

This adds `--application.buildTimeout 00:20:00` to the crank args so the agent allows 20 minutes for the Blazor WASM application to build, matching the pattern used in `mono-scenarios.yml` for long-building scenarios.

Ref: https://github.com/aspnet/Benchmarks/pull/2158
[Testing](https://dev.azure.com/dnceng/internal/_build/results?buildId=2922017&view=results)