### PR TITLE
Replace blob redirect URLs with direct raw.githubusercontent.com URLs - Continuation

### DIFF
--- a/build/httpclient-scenarios.yml
+++ b/build/httpclient-scenarios.yml
@@ -19,7 +19,7 @@ parameters:
 
 - name: httpClientJobs
   type: string
-  default: '--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml?raw=true'
+  default: '--config https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/httpclient.benchmarks.yml'
 
 - name: tfm
   type: string

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -560,7 +560,7 @@ These scenarios are running [dotnet micro benchmarks](https://github.com/dotnet/
 ### Sample
 
 ```
-crank --config https://github.com/aspnet/benchmarks/blob/main/scenarios/dotnet.benchmarks.yml?raw=true --scenario linq --profile aspnet-perf-win
+crank --config https://raw.githubusercontent.com/aspnet/benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario linq --profile aspnet-perf-win
 ```
 
 ### Available scenarios
@@ -571,7 +571,7 @@ crank --config https://github.com/aspnet/benchmarks/blob/main/scenarios/dotnet.b
 The scenario named `custom` can be used to pass any custom filter variable like so:
 
 ```
-crank --config https://github.com/aspnet/benchmarks/blob/main/scenarios/dotnet.benchmarks.yml?raw=true --scenario custom --profile aspnet-perf-win --variable filter=*LinqBenchmarks*
+crank --config https://raw.githubusercontent.com/aspnet/benchmarks/main/scenarios/dotnet.benchmarks.yml --scenario custom --profile aspnet-perf-win --variable filter=*LinqBenchmarks*
 ```
 
 ## FAQ

--- a/scenarios/tls.benchmarks.yml
+++ b/scenarios/tls.benchmarks.yml
@@ -1,7 +1,7 @@
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.HttpClient/httpclient.yml
-  - https://github.com/dotnet/crank/blob/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml?raw=true
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Wrk/wrk.yml
   - https://raw.githubusercontent.com/aspnet/Benchmarks/main/scenarios/aspnet.profiles.yml
 
 variables:


### PR DESCRIPTION
# Motivation
This pull request is following the work done in [https://github.com/aspnet/Benchmarks/pull/2159](https://github.com/aspnet/Benchmarks/pull/2159), some files still needed the change.

# Description
It updates several configuration files and documentation to use the correct raw content URLs for benchmark scenario files, ensuring consistent and direct access to the necessary YAML files. The changes remove the unnecessary `?raw=true` query parameter and standardize the use of `raw.githubusercontent.com` URLs.

**Configuration and Documentation Updates:**

* **Configuration File Updates:**
  - Updated the `httpClientJobs` parameter in `build/httpclient-scenarios.yml` to use the direct `raw.githubusercontent.com` URL without the `?raw=true` query parameter.
  - Changed the import path for the `wrk.yml` file in `scenarios/tls.benchmarks.yml` to use the `raw.githubusercontent.com` URL, removing the `?raw=true` query parameter for consistency.

* **Documentation Updates:**
  - Updated sample commands in `scenarios/README.md` to use the correct `raw.githubusercontent.com` URLs for benchmark configuration files, removing the `?raw=true` query parameter. [[1]](diffhunk://#diff-02bf733d02e63bad2cbb82f0b55ed17540ec65fa56960d60929ae568befe1c1aL563-R563) [[2]](diffhunk://#diff-02bf733d02e63bad2cbb82f0b55ed17540ec65fa56960d60929ae568befe1c1aL574-R574)

# Changes
No functional change — both URL forms serve identical content.