### PR TITLE
Fix Blazor Wasm and Ntex Fortunes docker builds in CI

### DIFF
--- a/build/job-variables.yml
+++ b/build/job-variables.yml
@@ -25,7 +25,10 @@ variables:
   value: -j  https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/benchmarks.html.json
 
 - name: blazorWasmJobs
-  value: --config https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Components/benchmarkapps/Wasm.Performance/benchmarks.compose.json
+  # Use the local override under docker/wasm-performance/ instead of the upstream config
+  # at dotnet/aspnetcore. The local dockerfile installs Node.js 22 (Node 21 is EOL and
+  # recent aspnetcore npm dependencies require node 18 || 20 || >=22).
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/docker/wasm-performance/benchmarks.compose.json
 
 
 - name: mvcJobs

--- a/docker/ntex-techempower/ntex-db.dockerfile
+++ b/docker/ntex-techempower/ntex-db.dockerfile
@@ -1,0 +1,34 @@
+# Local override of TechEmpower/FrameworkBenchmarks frameworks/Rust/ntex/ntex-db.dockerfile.
+#
+# See docker/ntex-techempower/ntex-plt.dockerfile for the rationale (in short:
+# ntex-bytes 1.6 broke compatibility with the fafhrd91/postgres ntex-3 tokio-postgres
+# fork, so we pin ntex-bytes to =1.5.4 here).
+FROM rust:1.93
+
+# Disable simd at jsonescape
+# ENV CARGO_CFG_JSONESCAPE_DISABLE_AUTO_SIMD=
+
+RUN apt-get update -yqq && apt-get install -yqq cmake g++ git
+
+ARG TECHEMPOWER_REF=master
+
+WORKDIR /tmp
+RUN git clone --depth=1 --branch ${TECHEMPOWER_REF} \
+    https://github.com/TechEmpower/FrameworkBenchmarks.git framework-benchmarks \
+    && mkdir -p /ntex \
+    && cp -a framework-benchmarks/frameworks/Rust/ntex/. /ntex/ \
+    && rm -rf framework-benchmarks
+
+WORKDIR /ntex
+
+# Pin ntex-bytes to =1.5.4 so the workspace stays on the BytesMut-compatible API
+# used by the fafhrd91/postgres ntex-3 tokio-postgres fork.
+RUN sed -i 's|ntex-bytes = { version = "1.5", features=\["simd"\] }|ntex-bytes = { version = "=1.5.4", features=["simd"] }|' Cargo.toml \
+    && grep '^ntex-bytes' Cargo.toml
+
+RUN cargo clean
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release --features="tokio"
+
+EXPOSE 8080
+
+CMD ./target/release/ntex-db

--- a/docker/ntex-techempower/ntex-plt.dockerfile
+++ b/docker/ntex-techempower/ntex-plt.dockerfile
@@ -1,0 +1,42 @@
+# Local override of TechEmpower/FrameworkBenchmarks frameworks/Rust/ntex/ntex-plt.dockerfile.
+#
+# Why we override: The upstream Cargo.toml uses `ntex-bytes = { version = "1.5", ... }`
+# (semver caret), so cargo resolves to the latest 1.x. ntex-bytes 1.6.0 (released
+# 2026-05-02) introduced the BytePages type, which is incompatible with the
+# fafhrd91/postgres `ntex-3` tokio-postgres fork that still uses BytesMut. All
+# ntex binaries share one workspace and `cargo build --features="tokio"` pulls
+# tokio-postgres in transitively, so the workspace fails to compile.
+#
+# Workaround: clone TechEmpower's master branch from inside the container and pin
+# ntex-bytes to =1.5.4 before building. Drop this override once the upstream
+# fafhrd91/postgres fork is updated for ntex-bytes 1.6+ or TechEmpower pins
+# ntex-bytes themselves.
+FROM rust:1.93
+
+# Disable simd at jsonescape
+# ENV CARGO_CFG_JSONESCAPE_DISABLE_AUTO_SIMD=
+
+RUN apt-get update -yqq && apt-get install -yqq cmake g++ git
+
+ARG TECHEMPOWER_REF=master
+
+WORKDIR /tmp
+RUN git clone --depth=1 --branch ${TECHEMPOWER_REF} \
+    https://github.com/TechEmpower/FrameworkBenchmarks.git framework-benchmarks \
+    && mkdir -p /ntex \
+    && cp -a framework-benchmarks/frameworks/Rust/ntex/. /ntex/ \
+    && rm -rf framework-benchmarks
+
+WORKDIR /ntex
+
+# Pin ntex-bytes to =1.5.4 so the workspace stays on the BytesMut-compatible API
+# used by the fafhrd91/postgres ntex-3 tokio-postgres fork.
+RUN sed -i 's|ntex-bytes = { version = "1.5", features=\["simd"\] }|ntex-bytes = { version = "=1.5.4", features=["simd"] }|' Cargo.toml \
+    && grep '^ntex-bytes' Cargo.toml
+
+RUN cargo clean
+RUN RUSTFLAGS="-C target-cpu=native" cargo build --release --features="tokio"
+
+EXPOSE 8080
+
+CMD ./target/release/ntex-plt

--- a/docker/wasm-performance/benchmarks.compose.json
+++ b/docker/wasm-performance/benchmarks.compose.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/BenchmarksDriver2/benchmarks.schema.json",
+  "scenarios": {
+    "blazorwasmbenchmark": {
+      "application": {
+        "job": "blazorwasmbenchmark"
+      }
+    }
+  },
+  "jobs": {
+    "blazorwasmbenchmark": {
+      "source": {
+        "repository": "https://github.com/aspnet/Benchmarks.git",
+        "branchOrCommit": "main",
+        "dockerFile": "docker/wasm-performance/dockerfile",
+        "dockerImageName": "blazorwasmbenchmark",
+        "dockerContextDirectory": "docker/wasm-performance"
+      },
+      "buildArguments": [
+        "gitBranch=main"
+      ],
+      "waitForExit": true,
+      "readyStateText": "Application started."
+    }
+  }
+}

--- a/docker/wasm-performance/dockerfile
+++ b/docker/wasm-performance/dockerfile
@@ -1,0 +1,45 @@
+# Local override of dotnet/aspnetcore's src/Components/benchmarkapps/Wasm.Performance/dockerfile.
+#
+# Differences from upstream:
+#   - Installs Node.js 22 (LTS) via setup_22.x instead of Node.js 21 (EOL).
+#     Recent npm dependencies in aspnetcore (e.g. balanced-match, brace-expansion,
+#     minimatch, eslint-visitor-keys, @tootallnate/once) require node 18, 20, or >=22.
+#     Node 21 is no longer supported and `npm run build` fails with ERR_REQUIRE_ESM.
+#
+# Track upstream: https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:latest AS build
+
+ENV StressRunDuration=0
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Setup for nodejs
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libunwind-dev \
+    nodejs \
+    git
+
+ARG gitBranch=main
+
+WORKDIR /src
+ADD https://api.github.com/repos/dotnet/aspnetcore/git/ref/heads/${gitBranch} /aspnetcore.commit
+
+RUN git init \
+    && git fetch https://github.com/aspnet/aspnetcore ${gitBranch} \
+    && git reset --hard FETCH_HEAD \
+    && git submodule update --init \
+    && git remote add origin https://github.com/aspnet/aspnetcore
+
+RUN ./restore.sh
+RUN npm run build
+RUN .dotnet/dotnet publish -c Release -r linux-x64 --sc true -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+RUN chmod +x /app/Wasm.Performance.Driver
+
+WORKDIR /app
+FROM mcr.microsoft.com/playwright/dotnet:v1.58.0-jammy-amd64 AS final
+COPY --from=build ./app ./
+COPY ./exec.sh ./
+
+ENTRYPOINT [ "bash", "./exec.sh" ]

--- a/docker/wasm-performance/exec.sh
+++ b/docker/wasm-performance/exec.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./Wasm.Performance.Driver $StressRunDuration

--- a/scenarios/te.benchmarks.yml
+++ b/scenarios/te.benchmarks.yml
@@ -74,11 +74,16 @@ jobs:
 
   ntex: # json and plaintext scenarios
     source:
-      repository: https://github.com/TechEmpower/FrameworkBenchmarks.git
-      branchOrCommit: master
-      dockerFile: frameworks/Rust/ntex/ntex-plt.dockerfile
+      # NOTE: Local docker/ntex-techempower/ override is used here instead of pulling the
+      # dockerfile directly from TechEmpower/FrameworkBenchmarks. The local dockerfile
+      # clones TechEmpower master from inside the container and pins ntex-bytes to
+      # =1.5.4 to work around ntex-bytes 1.6 breaking the fafhrd91/postgres ntex-3
+      # tokio-postgres fork. Switch back once the upstream fork is updated.
+      repository: https://github.com/aspnet/Benchmarks.git
+      branchOrCommit: main
+      dockerFile: docker/ntex-techempower/ntex-plt.dockerfile
       dockerImageName: ntex-plt
-      dockerContextDirectory: frameworks/Rust/ntex/
+      dockerContextDirectory: docker/ntex-techempower
     readyStateText: Started http server
     arguments: --add-host="tfb-database:{{databaseServer}}"
     noClean: true
@@ -358,8 +363,10 @@ scenarios:
     application:
       job: ntex
       source: 
-        dockerFile: frameworks/Rust/ntex/ntex-db.dockerfile
+        # Override to the local ntex-db dockerfile (see ntex job above for context).
+        dockerFile: docker/ntex-techempower/ntex-db.dockerfile
         dockerImageName: ntex-db
+        dockerContextDirectory: docker/ntex-techempower
       readyStateText: Starting http server
     load:
       job: wrk


### PR DESCRIPTION
Both **Blazor Wasm** and **Ntex Fortunes** have been failing in [benchmarks-ci-02](https://dev.azure.com/dnceng/internal/_build?definitionId=1209) since mid‑April. The last green run was `20260326.1` on Mar 26; every run since has failed on a `docker build --pull` for one of these two scenarios. Both failures come from upstream dockerfiles outside this repo that have rolled forward in incompatible ways. Add local overrides under `docker/` so the benchmarks repo controls these two builds directly.

### Investigation

Reproduced both failing crank commands from build [2974764](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764) on Docker Desktop:

- `Blazor Wasm`  →  `docker build --pull --build-arg gitBranch=main -t benchmarks_dockerfile -f src/Components/benchmarkapps/Wasm.Performance/dockerfile .../src/Components/benchmarkapps/Wasm.Performance` ([log](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764&view=logs&j=067b1604-d0b1-59c3-3a7e-5b1821bffa06))
- `Ntex Fortunes`  →  `docker build --pull -t benchmarks_ntex-db -f frameworks/Rust/ntex/ntex-db.dockerfile .../frameworks/Rust/ntex/` ([log](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764&view=logs&j=7d01d3ed-b5f5-5365-c558-281d7cec2748))

#### Blazor Wasm
[`dotnet/aspnetcore`'s wasm dockerfile](https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/dockerfile) installs Node.js 21 via `https://deb.nodesource.com/setup_21.x`. Node 21 went EOL in June 2024 and recent aspnetcore npm dependencies require `node 18 || 20 || >=22`:

```
npm WARN EBADENGINE Unsupported engine { package: 'balanced-match@4.0.4', required: { node: '18 || 20 || >=22' }, current: { node: 'v21.7.3', npm: '10.5.0' } }
npm WARN EBADENGINE Unsupported engine { package: 'brace-expansion@5.0.5', ... }
...
[!] Error: require() of ES Module /src/node_modules/@tootallnate/once/dist/index.js from /src/node_modules/http-proxy-agent/dist/agent.js not supported.
Error [ERR_REQUIRE_ESM]: ...
npm ERR! Lifecycle script `build:debug` failed with error
```

#### Ntex Fortunes (and Ntex Plaintext / Ntex Json)
TechEmpower's `frameworks/Rust/ntex/Cargo.toml` uses `ntex-bytes = { version = "1.5", features=["simd"] }` — caret semver, so cargo resolves to the newest 1.x. [ntex-bytes 1.6.0 shipped 2026-05-02](https://crates.io/crates/ntex-bytes/versions) and introduced the `BytePages` type, which the [fafhrd91/postgres `ntex-3` tokio-postgres fork](https://github.com/fafhrd91/postgres/tree/ntex-3) (frozen at `fbc7a17`) does not understand — it still uses `BytesMut`. Because the workspace builds `tokio-postgres` for every binary when `--features=tokio` is set, *all* ntex docker builds fail with E0308 mismatched-types errors, not just the database scenario:

```
error[E0308]: mismatched types
   --> /usr/local/cargo/git/checkouts/postgres-.../tokio-postgres/src/query.rs:77:52
   |
77 |             encode_bind(statement, params, "", buf)?;
   |             -----------                        ^^^ expected `&mut BytesMut`, found `&mut BytePages`
error: could not compile `tokio-postgres` (lib) due to 9 previous errors
```

### Fix

Two narrowly-scoped overrides:

1. **`docker/wasm-performance/`** — copy of upstream's `dockerfile`, `exec.sh`, and a new `benchmarks.compose.json`, with `setup_21.x` → `setup_22.x` and the source repo pointing at this repo so crank picks up the override. `build/job-variables.yml` now points `blazorWasmJobs` at the local compose JSON.

2. **`docker/ntex-techempower/{ntex-plt,ntex-db}.dockerfile`** — a thin replacement that clones TechEmpower master from inside the container, then `sed -i` pins `ntex-bytes` to `=1.5.4` before `cargo build`. `scenarios/te.benchmarks.yml` updates the `ntex` job and the `fortunes_ntex` override to source these from `aspnet/Benchmarks` instead of the TechEmpower checkout.

### Verification

Ran the exact crank `docker build --pull` invocations locally on Docker Desktop after both fixes:

| Image | Result |
| --- | --- |
| `benchmarks_wasm_node22` (upstream dockerfile + setup_22.x) | ✅ build + publish succeed; produces playwright runtime image |
| `test_wasm_local` (local override under `docker/wasm-performance/`) | ✅ |
| `test_ntex-plt_local` (local override) | ✅ `Finished release profile [optimized] target(s) in 52.40s` |
| `test_ntex-db_local` (local override) | ✅ same, both `ntex-db` and `ntex-plt` binaries produced; `Cargo.lock` shows `ntex-bytes 1.5.4` as expected |

### Notes for follow-up

Both overrides are intentionally temporary:
- Drop `docker/wasm-performance/` once [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/dockerfile) bumps to Node 22 upstream.
- Drop `docker/ntex-techempower/` once [fafhrd91/postgres `ntex-3`](https://github.com/fafhrd91/postgres/tree/ntex-3) is updated for `ntex-bytes 1.6+` (or TechEmpower itself pins `ntex-bytes`).
