### PR TITLE
Fix Blazor Wasm and disable Ntex Fortunes in CI

### DIFF
--- a/build/containers-scenarios.yml
+++ b/build/containers-scenarios.yml
@@ -113,9 +113,17 @@ parameters:
   - displayName: Json NTex
     arguments: --scenario json_ntex --property scenario=JsonNTex
     condition: Math.round(Date.now() / 43200000) % 10 == 8 # once every 10 half-days
-  - displayName: Fortunes NTex
-    arguments: --scenario fortunes_ntex --property scenario=FortunesNTex
-    condition: Math.round(Date.now() / 43200000) % 10 == 9 # once every 10 half-days
+  # Fortunes NTex is disabled: its docker build (ntex-db.dockerfile in
+  # TechEmpower/FrameworkBenchmarks) breaks because the fafhrd91/postgres
+  # ntex-3 tokio-postgres fork it depends on is no longer compatible
+  # with newer ntex-bytes resolved from TechEmpower's caret-versioned
+  # dep. TechEmpower/FrameworkBenchmarks is archived
+  # (https://github.com/TechEmpower/FrameworkBenchmarks), so no fix is
+  # coming upstream. See build/frameworks-database-scenarios.yml for
+  # the matching disable.
+  # - displayName: Fortunes NTex
+  #   arguments: --scenario fortunes_ntex --property scenario=FortunesNTex
+  #   condition: Math.round(Date.now() / 43200000) % 10 == 9 # once every 10 half-days
 
 steps:
 - ${{ each scenario in parameters.scenarios }}:

--- a/build/frameworks-database-scenarios.yml
+++ b/build/frameworks-database-scenarios.yml
@@ -52,9 +52,20 @@ parameters:
     arguments: --scenario json_gin --load.variables.connections 512 --property scenario=JsonGin
 
   #  Ntex (Rust)
-
-  - displayName: Ntex Fortunes
-    arguments: --scenario fortunes_ntex --load.variables.connections 512 --property scenario=FortunesNtex
+  #
+  # Ntex Fortunes is disabled: the docker build for ntex-db.dockerfile
+  # is broken because the TechEmpower workspace pulls in the
+  # fafhrd91/postgres `ntex-3` tokio-postgres fork (frozen at commit
+  # fbc7a17), which is no longer compatible with the latest ntex-bytes
+  # (1.6+) that cargo resolves from TechEmpower's caret-versioned
+  # `ntex-bytes = "1.5"`. The workspace fails to compile with E0308
+  # mismatched-types errors on `BytesMut` vs `BytePages`.
+  # TechEmpower/FrameworkBenchmarks is now archived
+  # (https://github.com/TechEmpower/FrameworkBenchmarks), so a real fix
+  # upstream is unlikely and not worth chasing. Re-enable if the ntex
+  # source is brought back in-tree or pinned to a working dep set.
+  # - displayName: Ntex Fortunes
+  #   arguments: --scenario fortunes_ntex --load.variables.connections 512 --property scenario=FortunesNtex
 
   #  Vertx (Java)
 

--- a/build/job-variables.yml
+++ b/build/job-variables.yml
@@ -25,7 +25,10 @@ variables:
   value: -j  https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/TechEmpower/PlatformBenchmarks/benchmarks.html.json
 
 - name: blazorWasmJobs
-  value: --config https://raw.githubusercontent.com/dotnet/aspnetcore/main/src/Components/benchmarkapps/Wasm.Performance/benchmarks.compose.json
+  # Use the local override under docker/wasm-performance/ instead of the upstream config
+  # at dotnet/aspnetcore. The local dockerfile installs Node.js 22 (Node 21 is EOL and
+  # recent aspnetcore npm dependencies require node 18 || 20 || >=22).
+  value: --config https://raw.githubusercontent.com/aspnet/Benchmarks/main/docker/wasm-performance/benchmarks.compose.json
 
 
 - name: mvcJobs

--- a/docker/wasm-performance/benchmarks.compose.json
+++ b/docker/wasm-performance/benchmarks.compose.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/aspnet/Benchmarks/master/src/BenchmarksDriver2/benchmarks.schema.json",
+  "scenarios": {
+    "blazorwasmbenchmark": {
+      "application": {
+        "job": "blazorwasmbenchmark"
+      }
+    }
+  },
+  "jobs": {
+    "blazorwasmbenchmark": {
+      "source": {
+        "repository": "https://github.com/aspnet/Benchmarks.git",
+        "branchOrCommit": "main",
+        "dockerFile": "docker/wasm-performance/dockerfile",
+        "dockerImageName": "blazorwasmbenchmark",
+        "dockerContextDirectory": "docker/wasm-performance"
+      },
+      "buildArguments": [
+        "gitBranch=main"
+      ],
+      "waitForExit": true,
+      "readyStateText": "Application started."
+    }
+  }
+}

--- a/docker/wasm-performance/dockerfile
+++ b/docker/wasm-performance/dockerfile
@@ -1,0 +1,45 @@
+# Local override of dotnet/aspnetcore's src/Components/benchmarkapps/Wasm.Performance/dockerfile.
+#
+# Differences from upstream:
+#   - Installs Node.js 22 (LTS) via setup_22.x instead of Node.js 21 (EOL).
+#     Recent npm dependencies in aspnetcore (e.g. balanced-match, brace-expansion,
+#     minimatch, eslint-visitor-keys, @tootallnate/once) require node 18, 20, or >=22.
+#     Node 21 is no longer supported and `npm run build` fails with ERR_REQUIRE_ESM.
+#
+# Track upstream: https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:latest AS build
+
+ENV StressRunDuration=0
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Setup for nodejs
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    libunwind-dev \
+    nodejs \
+    git
+
+ARG gitBranch=main
+
+WORKDIR /src
+ADD https://api.github.com/repos/dotnet/aspnetcore/git/ref/heads/${gitBranch} /aspnetcore.commit
+
+RUN git init \
+    && git fetch https://github.com/aspnet/aspnetcore ${gitBranch} \
+    && git reset --hard FETCH_HEAD \
+    && git submodule update --init \
+    && git remote add origin https://github.com/aspnet/aspnetcore
+
+RUN ./restore.sh
+RUN npm run build
+RUN .dotnet/dotnet publish -c Release -r linux-x64 --sc true -o /app ./src/Components/benchmarkapps/Wasm.Performance/Driver/Wasm.Performance.Driver.csproj
+RUN chmod +x /app/Wasm.Performance.Driver
+
+WORKDIR /app
+FROM mcr.microsoft.com/playwright/dotnet:v1.58.0-jammy-amd64 AS final
+COPY --from=build ./app ./
+COPY ./exec.sh ./
+
+ENTRYPOINT [ "bash", "./exec.sh" ]

--- a/docker/wasm-performance/exec.sh
+++ b/docker/wasm-performance/exec.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./Wasm.Performance.Driver $StressRunDuration


### PR DESCRIPTION
Both **Blazor Wasm** and **Ntex Fortunes** have been failing in [benchmarks-ci-02](https://dev.azure.com/dnceng/internal/_build?definitionId=1209) since mid‑April. The last green run was `20260326.1` on Mar 26; every run since has failed on a `docker build --pull` for one of these two scenarios. Both come from upstream dockerfiles outside this repo that have rolled forward in incompatible ways. Take a different approach for each.

### Investigation

Reproduced both failing crank commands from build [2974764](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764) on Docker Desktop:

- `Blazor Wasm` → `docker build --pull --build-arg gitBranch=main -t benchmarks_dockerfile -f src/Components/benchmarkapps/Wasm.Performance/dockerfile .../src/Components/benchmarkapps/Wasm.Performance` ([log](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764&view=logs&j=067b1604-d0b1-59c3-3a7e-5b1821bffa06))
- `Ntex Fortunes` → `docker build --pull -t benchmarks_ntex-db -f frameworks/Rust/ntex/ntex-db.dockerfile .../frameworks/Rust/ntex/` ([log](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764&view=logs&j=7d01d3ed-b5f5-5365-c558-281d7cec2748))

#### Blazor Wasm
[`dotnet/aspnetcore`'s wasm dockerfile](https://github.com/dotnet/aspnetcore/blob/main/src/Components/benchmarkapps/Wasm.Performance/dockerfile) installs Node.js 21 via `https://deb.nodesource.com/setup_21.x`. Node 21 went EOL in June 2024 and recent aspnetcore npm dependencies require `node 18 || 20 || >=22`:

```
npm WARN EBADENGINE Unsupported engine { package: 'balanced-match@4.0.4', required: { node: '18 || 20 || >=22' }, current: { node: 'v21.7.3', npm: '10.5.0' } }
npm WARN EBADENGINE Unsupported engine { package: 'brace-expansion@5.0.5', ... }
...
[!] Error: require() of ES Module /src/node_modules/@tootallnate/once/dist/index.js from /src/node_modules/http-proxy-agent/dist/agent.js not supported.
Error [ERR_REQUIRE_ESM]: ...
npm ERR! Lifecycle script `build:debug` failed with error
```

#### Ntex Fortunes
TechEmpower's `frameworks/Rust/ntex/Cargo.toml` uses `ntex-bytes = { version = "1.5", features=["simd"] }` — caret semver, so cargo resolves to the newest 1.x. [ntex-bytes 1.6.0 shipped 2026-05-02](https://crates.io/crates/ntex-bytes/versions) and introduced the `BytePages` type, which the [fafhrd91/postgres `ntex-3` tokio-postgres fork](https://github.com/fafhrd91/postgres/tree/ntex-3) (frozen at `fbc7a17`) does not understand — it still uses `BytesMut`. The workspace builds `tokio-postgres` for every binary when `--features=tokio` is set, so the ntex-db image cannot be produced:

```
error[E0308]: mismatched types
   --> /usr/local/cargo/git/checkouts/postgres-.../tokio-postgres/src/query.rs:77:52
   |
77 |             encode_bind(statement, params, "", buf)?;
   |             -----------                        ^^^ expected `&mut BytesMut`, found `&mut BytePages`
error: could not compile `tokio-postgres` (lib) due to 9 previous errors
```

### Fix

**Blazor Wasm** — short-term local workaround under `docker/wasm-performance/`: copy of upstream's `dockerfile`, `exec.sh`, and a new `benchmarks.compose.json`, with `setup_21.x` → `setup_22.x` and the source repo pointing at this repo so crank picks up the override. `build/job-variables.yml` now points `blazorWasmJobs` at the local compose JSON.

A real upstream fix is in flight: **[dotnet/aspnetcore#66686](https://github.com/dotnet/aspnetcore/pull/66686)**. Once that merges, drop `docker/wasm-performance/` and revert `build/job-variables.yml` back to the upstream config URL.

**Ntex Fortunes** — disable. [`TechEmpower/FrameworkBenchmarks` is now archived](https://github.com/TechEmpower/FrameworkBenchmarks) (last push 2026‑03‑24), so a real upstream fix is not coming. Comment out the `Ntex Fortunes` entry in the two places it runs:
- `build/frameworks-database-scenarios.yml`
- `build/containers-scenarios.yml`

Each disable carries a comment explaining the failure mode and pointing at the other site, so it's easy to re-enable as a pair if someone forks/pins the ntex source back into a working state. Ntex Plaintext and Ntex Json continue to run; their binaries don't link tokio-postgres, so the ntex-plt build is unaffected.

### Verification

Ran the exact crank `docker build --pull` invocation locally on Docker Desktop, fetching source from the same `dotnet/aspnetcore` `main` commit (`29e4b0d3`):

| Dockerfile | Result |
| --- | --- |
| `dotnet/aspnetcore` main (`setup_21.x`) — control | ❌ fails at `RUN npm run build` with the `ERR_REQUIRE_ESM` shown above |
| `docker/wasm-performance/dockerfile` (this PR, `setup_22.x`) | ✅ `npm run build` succeeds, publishes `Wasm.Performance.Driver`, final playwright image is produced |
| same fix on the upstream branch [`LoopedBard3/aspnetcore:loopedbard3/wasm-perf-node22`](https://github.com/LoopedBard3/aspnetcore/tree/loopedbard3/wasm-perf-node22) | ✅ identical end-to-end success |
