### PR TITLE
Disable Ntex scenarios in CI (Plaintext, Json, Fortunes)

### DIFF
--- a/build/containers-scenarios.yml
+++ b/build/containers-scenarios.yml
@@ -110,12 +110,22 @@ parameters:
     arguments: --scenario fortunes_vertx --property scenario=FortunesVertx
     condition: Math.round(Date.now() / 43200000) % 10 == 9 # once every 10 half-days
 
-  - displayName: Json NTex
-    arguments: --scenario json_ntex --property scenario=JsonNTex
-    condition: Math.round(Date.now() / 43200000) % 10 == 8 # once every 10 half-days
-  - displayName: Fortunes NTex
-    arguments: --scenario fortunes_ntex --property scenario=FortunesNTex
-    condition: Math.round(Date.now() / 43200000) % 10 == 9 # once every 10 half-days
+  # Json NTex and Fortunes NTex are disabled: their docker builds
+  # (ntex-plt.dockerfile and ntex-db.dockerfile in TechEmpower/
+  # FrameworkBenchmarks) all fail because the ntex workspace has
+  # `tokio-postgres` as a top-level dep on the fafhrd91/postgres
+  # ntex-3 fork (commit fbc7a17), which is no longer compatible
+  # with newer ntex-bytes resolved from TechEmpower's caret-versioned
+  # `ntex-bytes = "1.5"`. TechEmpower/FrameworkBenchmarks is archived
+  # (https://github.com/TechEmpower/FrameworkBenchmarks), so no fix
+  # is coming upstream. See build/frameworks-scenarios.yml and
+  # build/frameworks-database-scenarios.yml for the matching disables.
+  # - displayName: Json NTex
+  #   arguments: --scenario json_ntex --property scenario=JsonNTex
+  #   condition: Math.round(Date.now() / 43200000) % 10 == 8 # once every 10 half-days
+  # - displayName: Fortunes NTex
+  #   arguments: --scenario fortunes_ntex --property scenario=FortunesNTex
+  #   condition: Math.round(Date.now() / 43200000) % 10 == 9 # once every 10 half-days
 
 steps:
 - ${{ each scenario in parameters.scenarios }}:

--- a/build/frameworks-database-scenarios.yml
+++ b/build/frameworks-database-scenarios.yml
@@ -52,9 +52,22 @@ parameters:
     arguments: --scenario json_gin --load.variables.connections 512 --property scenario=JsonGin
 
   #  Ntex (Rust)
-
-  - displayName: Ntex Fortunes
-    arguments: --scenario fortunes_ntex --load.variables.connections 512 --property scenario=FortunesNtex
+  #
+  # Ntex Fortunes is disabled: the docker build for ntex-db.dockerfile
+  # is broken because the TechEmpower ntex workspace has `tokio-postgres`
+  # as a top-level dependency pointing at the fafhrd91/postgres `ntex-3`
+  # fork (frozen at commit fbc7a17). That fork no longer compiles against
+  # the latest ntex-bytes (1.6+) that cargo resolves from TechEmpower's
+  # caret-versioned `ntex-bytes = "1.5"`, so every binary in the
+  # workspace - including ntex-db - fails with E0308 mismatched-types
+  # errors on `BytesMut` vs `BytePages`.
+  # TechEmpower/FrameworkBenchmarks is now archived
+  # (https://github.com/TechEmpower/FrameworkBenchmarks), so a real fix
+  # upstream is unlikely and not worth chasing. See
+  # build/frameworks-scenarios.yml for the matching Ntex Plaintext and
+  # Ntex Json disables.
+  # - displayName: Ntex Fortunes
+  #   arguments: --scenario fortunes_ntex --load.variables.connections 512 --property scenario=FortunesNtex
 
   #  Vertx (Java)
 

--- a/build/frameworks-scenarios.yml
+++ b/build/frameworks-scenarios.yml
@@ -41,11 +41,24 @@ parameters:
   # Scenarios are in frameworks-database-scenarios.yml since they require the db server
 
 #  Ntex (Rust)
+#
+# Ntex Plaintext and Ntex Json are disabled: the docker build for
+# ntex-plt.dockerfile is broken because the TechEmpower ntex
+# workspace has `tokio-postgres` as a top-level dependency pointing
+# at the fafhrd91/postgres `ntex-3` fork (frozen at commit fbc7a17).
+# That fork no longer compiles against the latest ntex-bytes (1.6+)
+# that cargo resolves from TechEmpower's caret-versioned
+# `ntex-bytes = "1.5"`, so every binary in the workspace - including
+# ntex-plt - fails with E0308 mismatched-types errors on `BytesMut`
+# vs `BytePages`. TechEmpower/FrameworkBenchmarks is now archived
+# (https://github.com/TechEmpower/FrameworkBenchmarks), so a real
+# fix upstream is unlikely. See build/frameworks-database-scenarios.yml
+# for the matching Ntex Fortunes disable.
 
-  - displayName: Ntex Plaintext
-    arguments: --scenario plaintext_ntex --load.variables.connections 1024 --property scenario=PlaintextNtex
-  - displayName: Ntex Json
-    arguments: --scenario json_ntex --load.variables.connections 512 --property scenario=JsonNtex
+  # - displayName: Ntex Plaintext
+  #   arguments: --scenario plaintext_ntex --load.variables.connections 1024 --property scenario=PlaintextNtex
+  # - displayName: Ntex Json
+  #   arguments: --scenario json_ntex --load.variables.connections 512 --property scenario=JsonNtex
 
 #  Vertx (Java)
 


### PR DESCRIPTION
All three Ntex scenarios (Plaintext, Json, Fortunes) have been failing in [benchmarks-ci-01](https://dev.azure.com/dnceng/internal/_build?definitionId=1208) and [benchmarks-ci-02](https://dev.azure.com/dnceng/internal/_build?definitionId=1209) every run since the Mar 26 build. The docker builds for both `ntex-plt.dockerfile` and `ntex-db.dockerfile` fail to compile:

```
error[E0308]: mismatched types
   --> /usr/local/cargo/git/checkouts/postgres-.../tokio-postgres/src/query.rs:77:52
   |
77 |             encode_bind(statement, params, "", buf)?;
   |             -----------                        ^^^ expected `&mut BytesMut`, found `&mut BytePages`
error: could not compile `tokio-postgres` (lib) due to 9 previous errors
```

### Root cause

In `TechEmpower/FrameworkBenchmarks/frameworks/Rust/ntex/Cargo.toml`, `tokio-postgres` is a **top-level** dependency (not feature-gated) pointing at the [fafhrd91/postgres `ntex-3` fork](https://github.com/fafhrd91/postgres/tree/ntex-3) (frozen at commit `fbc7a17`). Every ntex binary in the workspace builds it — including `ntex-plt`, not just `ntex-db`.

The caret-versioned `ntex-bytes = { version = "1.5", features=["simd"] }` resolves to [ntex-bytes 1.6.0](https://crates.io/crates/ntex-bytes/versions) (released 2026-05-02), which introduced the `BytePages` type. The fafhrd91 fork still uses `BytesMut`, so the workspace fails to compile end-to-end.

[`TechEmpower/FrameworkBenchmarks` is now archived](https://github.com/TechEmpower/FrameworkBenchmarks) (last push 2026‑03‑24), so a real upstream fix is not coming.

### Change

Comment out all three Ntex scenarios in the three places they run:

| File | Scenarios disabled |
| --- | --- |
| `build/frameworks-scenarios.yml` | Ntex Plaintext, Ntex Json |
| `build/frameworks-database-scenarios.yml` | Ntex Fortunes |
| `build/containers-scenarios.yml` | Json NTex, Fortunes NTex |

Each disable carries an explanatory comment that cross-references the other sites, so it's easy to re-enable as a set if someone forks/pins the ntex source back into a working state.

### Context

Failing crank invocations from the latest CI runs:

- `Ntex Plaintext` ([build 2974984](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974984)): `docker build --pull -t benchmarks_ntex-plt -f frameworks/Rust/ntex/ntex-plt.dockerfile .../frameworks/Rust/ntex/`
- `Ntex Json` (same build): same dockerfile, exits 101
- `Ntex Fortunes` ([build 2974764](https://dev.azure.com/dnceng/internal/_build/results?buildId=2974764)): `docker build --pull -t benchmarks_ntex-db -f frameworks/Rust/ntex/ntex-db.dockerfile .../frameworks/Rust/ntex/`

Drafting for visibility — the Blazor Wasm half of the CI red is being addressed separately ([dotnet/aspnetcore#66686](https://github.com/dotnet/aspnetcore/pull/66686) upstream, with a short-term local workaround in [LoopedBard3/Benchmarks#4](https://github.com/LoopedBard3/Benchmarks/pull/4)).
