### PR TITLE
Disable Crossgen2 Json CG2 composite job

### DIFF
--- a/build/crossgen2-scenarios.yml
+++ b/build/crossgen2-scenarios.yml
@@ -33,9 +33,12 @@ parameters:
   - displayName: Default
     arguments: --property profile=default
     condition: 'true'
+  # Disabled: consistently fails with ILCompiler.CodeGenerationFailedException (IndexOutOfRangeException
+  # in CorInfoImpl.HandleToModuleToken) during the crossgen2 composite publish, and on Windows runs has
+  # caused crank to hang, blocking the rest of the jobs in the pipeline.
   - displayName: CG2 composite # since 6.0-preview4 CG2 is the default when PublishReadyToRun=true is set 
     arguments: --property profile=composite --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishReadyToRunComposite=true /p:PublishReadyToRunUseCrossgen2=true \"
-    condition: 'true'
+    condition: 'false'
   - displayName: CG2 non-composite  # /p:PublishReadyToRunComposite=false is the default
     arguments: --property profile=non-composite --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishReadyToRunUseCrossgen2=true /p:PublishReadyToRunComposite=false\"
     condition: 'true'


### PR DESCRIPTION
Disables the `CG2 composite` profile in `build/crossgen2-scenarios.yml` (used by both `benchmarks-ci-01` and `benchmarks-ci-02`) by flipping its `condition` to `'false'`, matching the pattern already used for the `CG2 composite avx2` profile.

### Why

The Json CG2 composite job has been consistently failing during the crossgen2 composite publish step with:

```
error : Unhandled exception. ILCompiler.CodeGenerationFailedException: Code generation failed for method
        'Async variant: [Microsoft.AspNetCore.Components.Server]
         Microsoft.AspNetCore.Components.Server.Circuits.RemoteJSDataStream.CompletePipeAndDisposeStream(Exception)'
 ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
    at Internal.IL.Stubs.ILStubMethodIL.GetObject(...)
    at Internal.JitInterface.CorInfoImpl.HandleToModuleToken(...)
    at Internal.JitInterface.CorInfoImpl.ComputeMethodWithToken(...)
    at Internal.JitInterface.CorInfoImpl.getCallInfo(...)
    ...
error NETSDK1096: Optimizing assemblies for performance failed. ...
```

On the Windows leg this has additionally caused `crank` to hang/get stuck, which then prevents all of the remaining jobs in the pipeline from running. Disabling the profile keeps the rest of the crossgen2 scenarios (Default, CG2 non-composite) running while we wait for the underlying crossgen2 issue to be resolved.

### Scope

- Only the `CG2 composite` profile entry under the shared `crossgen2-scenarios.yml` template is changed; both `benchmarks-ci-01.yml` and `benchmarks-ci-02.yml` consume this template, so the job is disabled in both pipelines with a single change.
- `Default`, `CG2 non-composite`, and the already-disabled `CG2 composite avx2` profiles are unchanged.

Marking as draft for review.
