### PR TITLE
Update RazorSlices to 0.11.x

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -44,7 +44,7 @@
 
     <DapperVersion>2.1.66</DapperVersion>
     <DapperAotVersion>1.0.48</DapperAotVersion>
-    <RazorSlicesVersion>0.10.1</RazorSlicesVersion>
+    <RazorSlicesVersion>0.11.0</RazorSlicesVersion>
     <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
     <MicrosoftCrankEventSourcesVersion>0.2.0-alpha.24114.2</MicrosoftCrankEventSourcesVersion>
     <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -44,7 +44,7 @@
 
     <DapperVersion>2.1.66</DapperVersion>
     <DapperAotVersion>1.0.48</DapperAotVersion>
-    <RazorSlicesVersion>0.11.0</RazorSlicesVersion>
+    <RazorSlicesVersion>0.11.1</RazorSlicesVersion>
     <SystemCommandLineVersion>2.0.0-beta4.22272.1</SystemCommandLineVersion>
     <MicrosoftCrankEventSourcesVersion>0.2.0-alpha.24114.2</MicrosoftCrankEventSourcesVersion>
     <OpenTelemetryVersion>1.9.0</OpenTelemetryVersion>


### PR DESCRIPTION
## Summary
- Update the shared RazorSlices package version from 0.10.1 to 0.11.0.

## Validation
- Synced branch with `origin/main` before changing files.
- `dotnet restore` for the three affected projects succeeds when NuGet.org is provided as an additional source.

Note: restore using only the repository-configured feeds currently fails because `RazorSlices` 0.11.0 is available on NuGet.org but has not appeared in the configured `dotnet-public` feeds yet.