### PR TITLE
Disable composite R2R + .NET 11 benchmark scenarios

### DIFF
--- a/build/crossgen2-scenarios.yml
+++ b/build/crossgen2-scenarios.yml
@@ -33,9 +33,12 @@ parameters:
   - displayName: Default
     arguments: --property profile=default
     condition: 'true'
-  # Disabled: consistently fails with ILCompiler.CodeGenerationFailedException (IndexOutOfRangeException
-  # in CorInfoImpl.HandleToModuleToken) during the crossgen2 composite publish, and on Windows runs has
-  # caused crank to hang, blocking the rest of the jobs in the pipeline.
+  # Disabled: fails with ILCompiler.CodeGenerationFailedException (IndexOutOfRangeException
+  # in CorInfoImpl.HandleToModuleToken) during the crossgen2 composite publish, and on
+  # Windows runs causes crank to hang, blocking the rest of the jobs in the pipeline.
+  # Root cause fixed by dotnet/runtime#129053 (composite R2R token corruption for
+  # devirtualized async-variant callees, merged 2026-06-06). Re-enable once that fix
+  # flows into the .NET 11 SDK consumed by the benchmark agents.
   - displayName: CG2 composite # since 6.0-preview4 CG2 is the default when PublishReadyToRun=true is set 
     arguments: --property profile=composite --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishReadyToRunComposite=true /p:PublishReadyToRunUseCrossgen2=true \"
     condition: 'false'

--- a/build/nativeaot-scenarios.yml
+++ b/build/nativeaot-scenarios.yml
@@ -34,7 +34,10 @@ parameters:
 
   - displayName: Goldilocks Stage 1 (CoreCLR - Trim R2R SingleFile)
     arguments: --scenario basicminimalapipublishtrimr2rsinglefile $(goldilocksJobs) --property scenario=Stage1TrimR2RSingleFile --property publish=coreclr --application.environmentVariables DOTNET_GCDynamicAdaptationMode=1
-    condition: 'true'
+    # Disabled: hits dotnet/runtime crossgen2 composite R2R bug on async-variant callees
+    # (Kestrel Http1ChunkedEncodingMessageBody.PumpAsync). Re-enable once
+    # https://github.com/dotnet/runtime/pull/129053 flows into the .NET 11 SDK.
+    condition: 'false'
 
   - displayName: Goldilocks Stage 1 (NativeAOT)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.DotNet.ILCompiler version
@@ -70,7 +73,9 @@ parameters:
 
   - displayName: Goldilocks Stage 2 (CoreCLR - Trim R2R SingleFile)
     arguments: --scenario todosapipublishtrimr2rsinglefile $(goldilocksJobs) --property scenario=Stage2TrimR2RSingleFile --property publish=coreclr --application.environmentVariables DOTNET_GCDynamicAdaptationMode=1
-    condition: 'true'
+    # Disabled: see note on "Goldilocks Stage 1 (CoreCLR - Trim R2R SingleFile)" above.
+    # Re-enable once https://github.com/dotnet/runtime/pull/129053 flows into the .NET 11 SDK.
+    condition: 'false'
 
   - displayName: Goldilocks Stage 2 (NativeAOT)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.DotNet.ILCompiler version
@@ -106,7 +111,9 @@ parameters:
 
   - displayName: Goldilocks gRPC Stage 1 (CoreCLR - Trim R2R SingleFile)
     arguments: --scenario basicgrpcpublishtrimr2rsinglefile $(goldilocksJobs) --property scenario=Stage1GrpcTrimR2RSingleFile --property publish=coreclr --application.environmentVariables DOTNET_GCDynamicAdaptationMode=1
-    condition: 'true'
+    # Disabled: see note on "Goldilocks Stage 1 (CoreCLR - Trim R2R SingleFile)" above.
+    # Re-enable once https://github.com/dotnet/runtime/pull/129053 flows into the .NET 11 SDK.
+    condition: 'false'
 
   - displayName: Goldilocks gRPC Stage 1 (NativeAOT)
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.DotNet.ILCompiler version

--- a/build/singlefile-scenarios.yml
+++ b/build/singlefile-scenarios.yml
@@ -32,17 +32,30 @@ parameters:
 
   - displayName: Self-contained
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=false\" --property mode=SelfContained
+    condition: 'true'
+  # Disabled: hangs / fails with ILCompiler.CodeGenerationFailedException
+  # (IndexOutOfRangeException in CorInfoImpl.HandleToModuleToken) during the
+  # crossgen2 composite publish on .NET 11 preview SDKs predating
+  # dotnet/runtime#129053 ("Fix composite R2R token corruption for devirtualized
+  # async-variant callees", merged 2026-06-06). Re-enable once that fix flows
+  # into the SDK consumed by the benchmark agents.
   - displayName: Single-file
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true\" --property mode=SingleFile
+    condition: 'false'
   - displayName: Trimmed
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishSingleFile=true /p:PublishTrimmed=true\" --property mode=Trimmed
+    condition: 'false'
   - displayName: AOT
     # workaround https://github.com/dotnet/runtime/issues/81382 by explicitly referencing a Microsoft.DotNet.ILCompiler version
     arguments: --application.buildArguments \"/p:PublishAot=true /p:StripSymbols=true\" --property mode=Aot --application.packageReferences \"Microsoft.DotNet.ILCompiler=$(MicrosoftNETCoreAppPackageVersion)\"
+    condition: 'true'
+  # Disabled: see note on "Single-file" above (dotnet/runtime#129053).
   - displayName: R2RComposite-Windows
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishReadyToRunComposite=true /p:PublishSingleFile=true /p:RuntimeIdentifier=win-x64\" --property mode=R2RComposite --property rid=win-x64 --application.options.requiredOperatingSystem windows
+    condition: 'false'
   - displayName: R2RComposite-Linux
     arguments: --application.buildArguments \"/p:PublishReadyToRun=true /p:PublishReadyToRunComposite=true /p:PublishSingleFile=true /p:RuntimeIdentifier=linux-x64\" --property mode=R2RComposite --property rid=linux-x64 --application.options.requiredOperatingSystem linux
+    condition: 'false'
 
 steps:
 - ${{ each s in parameters.scenarios }}:
@@ -60,6 +73,6 @@ steps:
         messageBody: |
           {
             "name": "crank",
-            "condition": "(${{ parameters.condition }})",
+            "condition": "(${{ parameters.condition }}) && (${{ mode.condition }})",
             "args": [ "${{ s.arguments }} ${{ mode.arguments }} ${{ parameters.arguments }} --application.framework net11.0 --application.options.collectCounters true --no-metadata --no-measurements --load.options.reuseBuild true --session $(session) --description \"${{ s.displayName }} ${{ mode.displayName }} $(System.JobDisplayName)\" --property buildId=\"$(buildId)\" --property buildNumber=\"$(buildNumber)\" --command-line-property --table SingleFileBenchmarks --sql SQL_CONNECTION_STRING --cert-tenant-id SQL_SERVER_TENANTID --cert-client-id SQL_SERVER_CLIENTID --cert-path SQL_SERVER_CERT_PATH --cert-sni --chart" ]
           }


### PR DESCRIPTION
These scenarios all hang/crash in crossgen2 with IndexOutOfRangeException on .NET 11 preview SDKs that predate dotnet/runtime#129053 ("Fix composite R2R token corruption for devirtualized async-variant callees", merged 2026-06-06). The repro hits Kestrel's Http1ChunkedEncodingMessageBody.PumpAsync during composite R2R compilation; crossgen2 then fails to terminate, causing the crank-agent 10-minute build timeout we saw on 2026-06-08.

build/singlefile-scenarios.yml: comment out Single-file, Trimmed,
  R2RComposite-Windows, R2RComposite-Linux modes.
build/crossgen2-scenarios.yml: comment out "CG2 composite" and
  "CG2 composite avx2" profiles.
build/nativeaot-scenarios.yml: set condition to 'false' on the three
  Goldilocks "Trim R2R SingleFile" jobs (Stage1, Stage2, gRPC Stage1).

Self-contained, AOT, non-composite R2R, and all NativeAOT scenarios remain enabled - the bug is composite-R2R-specific.

Re-enable once the runtime fix flows into the .NET 11 SDK consumed by the benchmark agents.