### PR TITLE
Add CSRF benchmark

### DIFF
--- a/build/trend-scenarios.yml
+++ b/build/trend-scenarios.yml
@@ -100,9 +100,9 @@ parameters:
   - displayName: Antiforgery Token Generation
     arguments: --scenario antiforgery-generation $(antiforgeryJobs) --property scenario=AntiforgeryTokenGeneration
   - displayName: CSRF Accepted
-    arguments: --scenario csrf-accepted $(antiforgeryJobs) --property scenario=CsrfAccepted
+    arguments: --scenario csrf-accepted $(antiforgeryJobs) --property scenario=AntiforgeryCsrfAccepted
   - displayName: CSRF Rejected
-    arguments: --scenario csrf-rejected $(antiforgeryJobs) --property scenario=CsrfRejected
+    arguments: --scenario csrf-rejected $(antiforgeryJobs) --property scenario=AntiforgeryCsrfRejected
 
 # TLS
 

--- a/build/trend-scenarios.yml
+++ b/build/trend-scenarios.yml
@@ -99,6 +99,10 @@ parameters:
     arguments: --scenario antiforgery-validation $(antiforgeryJobs) --property scenario=AntiforgeryTokenValidation
   - displayName: Antiforgery Token Generation
     arguments: --scenario antiforgery-generation $(antiforgeryJobs) --property scenario=AntiforgeryTokenGeneration
+  - displayName: CSRF Accepted
+    arguments: --scenario csrf-accepted $(antiforgeryJobs) --property scenario=CsrfAccepted
+  - displayName: CSRF Rejected
+    arguments: --scenario csrf-rejected $(antiforgeryJobs) --property scenario=CsrfRejected
 
 # TLS
 

--- a/scenarios/antiforgery.benchmarks.yml
+++ b/scenarios/antiforgery.benchmarks.yml
@@ -5,6 +5,7 @@ imports:
 variables:
   serverPort: 5000
   serverScheme: http
+  scenario: antiforgery
 
 jobs:
   antiforgerybenchmarks:
@@ -13,7 +14,7 @@ jobs:
       branchOrCommit: main
       project: src/BenchmarksApps/Antiforgery/Antiforgery.csproj
     readyStateText: Application started.
-    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}}"
+    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --scenario {{scenario}}"
 
 scenarios:
 
@@ -46,3 +47,27 @@ scenarios:
       job: wrk
       variables:
         path: /noOp
+
+  csrf-accepted:
+    application:
+      job: antiforgerybenchmarks
+      variables:
+        scenario: csrf
+    load:
+      job: wrk
+      variables:
+        path: /csrf
+        script: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+        scriptArguments: same-origin
+
+  csrf-rejected:
+    application:
+      job: antiforgerybenchmarks
+      variables:
+        scenario: csrf
+    load:
+      job: wrk
+      variables:
+        path: /csrf
+        script: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+        scriptArguments: cross-site

--- a/scenarios/antiforgery.benchmarks.yml
+++ b/scenarios/antiforgery.benchmarks.yml
@@ -6,6 +6,7 @@ variables:
   serverPort: 5000
   serverScheme: http
   scenario: antiforgery
+  debug: false
 
 jobs:
   antiforgerybenchmarks:
@@ -14,7 +15,7 @@ jobs:
       branchOrCommit: main
       project: src/BenchmarksApps/Antiforgery/Antiforgery.csproj
     readyStateText: Application started.
-    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --scenario {{scenario}}"
+    arguments: "--urls {{serverScheme}}://{{serverAddress}}:{{serverPort}} --scenario {{scenario}} --debug {{debug}}"
 
 scenarios:
 
@@ -58,7 +59,8 @@ scenarios:
       variables:
         path: /csrf
         script: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
-        scriptArguments: same-origin
+        customHeaders:
+          - "Sec-Fetch-Site: same-origin"
 
   csrf-rejected:
     application:
@@ -70,4 +72,5 @@ scenarios:
       variables:
         path: /csrf
         script: https://raw.githubusercontent.com/aspnet/Benchmarks/main/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
-        scriptArguments: cross-site
+        customHeaders:
+          - "Sec-Fetch-Site: cross-site"

--- a/src/BenchmarksApps/Antiforgery/Program.cs
+++ b/src/BenchmarksApps/Antiforgery/Program.cs
@@ -1,7 +1,18 @@
 using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Logging.ClearProviders();
+
+var debug = builder.Configuration.GetValue<bool>("debug");
+if (debug)
+{
+    builder.Logging.AddFilter("Microsoft", LogLevel.Warning);
+    builder.Logging.AddFilter("Microsoft.AspNetCore.Antiforgery.CsrfProtectionMiddleware", LogLevel.Debug);
+}
+else
+{
+    builder.Logging.ClearProviders();
+}
 
 // "csrf" exercises the auto-injected cross-origin (Sec-Fetch) CSRF protection in isolation,
 // so the token-based antiforgery services/middleware are left out to avoid overriding its verdict.
@@ -14,6 +25,31 @@ if (tokenAntiforgeryEnabled)
 }
 
 var app = builder.Build();
+
+if (debug)
+{
+    var requestCount = 0;
+    app.Use(async (context, next) =>
+    {
+        var n = Interlocked.Increment(ref requestCount);
+        if (n <= 20)
+        {
+            var request = context.Request;
+            Console.WriteLine($"[debug] #{n} {request.Method} {request.Path}{request.QueryString}");
+            foreach (var header in request.Headers)
+            {
+                Console.WriteLine($"[debug] #{n}   {header.Key}: {header.Value}");
+            }
+        }
+
+        await next(context);
+
+        if (n <= 20)
+        {
+            Console.WriteLine($"[debug] #{n} -> {context.Response.StatusCode}");
+        }
+    });
+}
 
 if (tokenAntiforgeryEnabled)
 {

--- a/src/BenchmarksApps/Antiforgery/Program.cs
+++ b/src/BenchmarksApps/Antiforgery/Program.cs
@@ -2,32 +2,55 @@ using Microsoft.AspNetCore.Antiforgery;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
-builder.Services.AddAntiforgery(options => options.HeaderName = "XSRF-TOKEN");
+
+// "csrf" exercises the auto-injected cross-origin (Sec-Fetch) CSRF protection in isolation,
+// so the token-based antiforgery services/middleware are left out to avoid overriding its verdict.
+var scenario = builder.Configuration["scenario"] ?? "antiforgery";
+var tokenAntiforgeryEnabled = !string.Equals(scenario, "csrf", StringComparison.OrdinalIgnoreCase);
+
+if (tokenAntiforgeryEnabled)
+{
+    builder.Services.AddAntiforgery(options => options.HeaderName = "XSRF-TOKEN");
+}
 
 var app = builder.Build();
-app.UseAntiforgery();
+
+if (tokenAntiforgeryEnabled)
+{
+    app.UseAntiforgery();
+}
 
 app.MapGet("/", () => Results.Ok("hello world!"));
-app.MapGet("/noOp", (HttpContext ctx, IAntiforgery antiforgery) => Results.Ok());
 
-// GET https://localhost:55471/auth
-app.MapGet("/auth", (HttpContext ctx, IAntiforgery antiforgery) =>
+// POST endpoint guarded only by the auto-injected cross-origin CSRF protection.
+// Sec-Fetch-Site: same-origin/none => 200; cross-site/same-site => 400.
+app.MapPost("/csrf", () => Results.Ok());
+
+// Token-based antiforgery endpoints. These depend on IAntiforgery, which is only
+// registered when the token-based antiforgery services are added above.
+if (tokenAntiforgeryEnabled)
 {
-    var token = antiforgery.GetAndStoreTokens(ctx);
-    ctx.Response.Headers.Append("XSRF-TOKEN", token.RequestToken!);
-    return Results.Ok();
-});
+    app.MapGet("/noOp", (HttpContext ctx, IAntiforgery antiforgery) => Results.Ok());
 
-// POST https://localhost:55471/validateToken
-app.MapPost("/validateToken", async (HttpContext ctx, IAntiforgery antiforgery) =>
-{
-    // HttpContext is expected to have 2 headers:
-    // 1) antiforgery token ("XSRF-TOKEN");
-    // 2) cookie token ("Cookie") with value of `.AspNetCore.Antiforgery.<unique-sequence>=<cookie_header>`
+    // GET https://localhost:55471/auth
+    app.MapGet("/auth", (HttpContext ctx, IAntiforgery antiforgery) =>
+    {
+        var token = antiforgery.GetAndStoreTokens(ctx);
+        ctx.Response.Headers.Append("XSRF-TOKEN", token.RequestToken!);
+        return Results.Ok();
+    });
 
-    await antiforgery.ValidateRequestAsync(ctx);    
-    return Results.Ok();
-});
+    // POST https://localhost:55471/validateToken
+    app.MapPost("/validateToken", async (HttpContext ctx, IAntiforgery antiforgery) =>
+    {
+        // HttpContext is expected to have 2 headers:
+        // 1) antiforgery token ("XSRF-TOKEN");
+        // 2) cookie token ("Cookie") with value of `.AspNetCore.Antiforgery.<unique-sequence>=<cookie_header>`
+
+        await antiforgery.ValidateRequestAsync(ctx);
+        return Results.Ok();
+    });
+}
 
 await app.StartAsync();
 Console.WriteLine("Application started.");

--- a/src/BenchmarksApps/Antiforgery/Program.cs
+++ b/src/BenchmarksApps/Antiforgery/Program.cs
@@ -19,6 +19,7 @@ else
 // so the token-based antiforgery services/middleware are left out to avoid overriding its verdict.
 var scenario = builder.Configuration["scenario"] ?? "antiforgery";
 var tokenAntiforgeryEnabled = !string.Equals(scenario, "csrf", StringComparison.OrdinalIgnoreCase);
+Console.WriteLine($"Scenario: '{scenario}'. Token-based antiforgery enabled: {tokenAntiforgeryEnabled}.");
 
 if (tokenAntiforgeryEnabled)
 {

--- a/src/BenchmarksApps/Antiforgery/Program.cs
+++ b/src/BenchmarksApps/Antiforgery/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -59,8 +60,7 @@ if (tokenAntiforgeryEnabled)
 app.MapGet("/", () => Results.Ok("hello world!"));
 
 // POST endpoint guarded only by the auto-injected cross-origin CSRF protection.
-// Sec-Fetch-Site: same-origin/none => 200; cross-site/same-site => 400.
-app.MapPost("/csrf", () => Results.Ok());
+app.MapPost("/csrf", ([FromForm] string name) => Results.Ok());
 
 // Token-based antiforgery endpoints. These depend on IAntiforgery, which is only
 // registered when the token-based antiforgery services are added above.

--- a/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+++ b/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
@@ -1,0 +1,11 @@
+-- The header value is taken from the first script argument (wrk ... -- <value>),
+-- e.g. "same-origin" (accepted) or "cross-site" (rejected). Defaults to same-origin.
+
+wrk.method = "POST"
+
+local secFetchSite = "same-origin"
+if arg and arg[1] then
+   secFetchSite = arg[1]
+end
+
+wrk.headers["Sec-Fetch-Site"] = secFetchSite

--- a/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+++ b/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
@@ -1,11 +1,7 @@
--- The header value is taken from the first script argument (wrk ... -- <value>),
--- e.g. "same-origin" (accepted) or "cross-site" (rejected). Defaults to same-origin.
+-- POSTs to /csrf to exercise the auto-injected cross-origin (Sec-Fetch) CSRF protection.
+-- The Sec-Fetch-Site header is supplied per scenario via the wrk `customHeaders` variable
+-- ("same-origin" => accepted/200, "cross-site" => rejected/400). wrk delivers script `--`
+-- arguments only to init(args), so the header is sent through wrk's native --header instead
+-- to guarantee the value reliably reaches the server.
 
 wrk.method = "POST"
-
-local secFetchSite = "same-origin"
-if arg and arg[1] then
-   secFetchSite = arg[1]
-end
-
-wrk.headers["Sec-Fetch-Site"] = secFetchSite

--- a/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+++ b/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
@@ -1,8 +1,4 @@
 -- POSTs a form to /csrf to exercise the auto-injected cross-origin (Sec-Fetch) CSRF protection.
--- The endpoint binds [FromForm], so the request carries a urlencoded body; reading the form is what
--- triggers the (post-#67082 lazy) CSRF verdict. The Sec-Fetch-Site header is supplied per scenario
--- via the wrk `customHeaders` variable ("same-origin" => accepted/200, "cross-site" => rejected/400)
--- so it reliably reaches the server through wrk's native --header.
 
 wrk.method = "POST"
 wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"

--- a/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
+++ b/src/BenchmarksApps/Antiforgery/scripts/wrk-csrf.lua
@@ -1,7 +1,9 @@
--- POSTs to /csrf to exercise the auto-injected cross-origin (Sec-Fetch) CSRF protection.
--- The Sec-Fetch-Site header is supplied per scenario via the wrk `customHeaders` variable
--- ("same-origin" => accepted/200, "cross-site" => rejected/400). wrk delivers script `--`
--- arguments only to init(args), so the header is sent through wrk's native --header instead
--- to guarantee the value reliably reaches the server.
+-- POSTs a form to /csrf to exercise the auto-injected cross-origin (Sec-Fetch) CSRF protection.
+-- The endpoint binds [FromForm], so the request carries a urlencoded body; reading the form is what
+-- triggers the (post-#67082 lazy) CSRF verdict. The Sec-Fetch-Site header is supplied per scenario
+-- via the wrk `customHeaders` variable ("same-origin" => accepted/200, "cross-site" => rejected/400)
+-- so it reliably reaches the server through wrk's native --header.
 
 wrk.method = "POST"
+wrk.headers["Content-Type"] = "application/x-www-form-urlencoded"
+wrk.body = "name=benchmark"


### PR DESCRIPTION
Added 2 scenarios validating the success and failure mode for CSRF protection based on Sec-Fetch-* headers

## CSRF vs token-based Antiforgery

| Metric | csrf-accepted (POST /csrf, same-origin) | csrf-rejected (POST /csrf, cross-site) | antiforgery-validation (POST /validateToken) | antiforgery-generation (GET /auth) |
| --- | --- | --- | --- | --- |
| Requests/sec | 1,293,135 | 1,500,761 | 330,781 | 313,591 |
| Bad responses | 0 | 22,660,758 (100%) | 0 | 0 |
| Mean latency (ms) | 0.22 | 0.18 | 0.79 | 0.84 |
| Read throughput (MB/s) | 113.46 | 144.56 | 29.03 | 174.35 |
| App Max CPU (%) | 84 | 82 | 80 | 79 |
| App Max Cores usage (%) | 4,652 | 4,631 | 4,480 | 4,417 |
| Max Allocation Rate (B/sec) | 1,920,113,992 | 1,075,997,152 | 1,420,808,064 | 1,539,728,472 |
| **Allocation per request (B)** | **~1,485** | **~717** | **~4,295** | **~4,910** |
| Max GC Heap Size (MB) | 41 | 46 | 35 | 37 |
| Max Time in GC (%) | 3 | 20 | 5 | 6 |

> Allocation per request = Max Allocation Rate (B/sec) ÷ Requests/sec.
> Both header-based CSRF paths sustain ~4× the throughput of token-based
> antiforgery at similar CPU, while allocating 3–6× less per request.
> Read throughput reflects response payload size: antiforgery-validation returns
> an empty body (29 MB/s) while antiforgery-generation echoes a token per response (174 MB/s).