### PR TITLE
Add monthly NuGet updates to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,14 @@ updates:
       interval: weekly
       day: "sunday"
       time: "11:00" # 11am UTC
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+registries:
+  dotnet-public:
+    type: nuget-feed
+    url: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
 updates:
   - package-ecosystem: gomod
     directory: "/"
@@ -8,6 +12,8 @@ updates:
       time: "11:00" # 11am UTC
   - package-ecosystem: "nuget"
     directory: "/"
+    registries:
+      - dotnet-public
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
Adds monthly NuGet version updates (grouped, minor/patch only) to the existing Dependabot config on `main`.