### PR TITLE
Use 1ES images on internal benchmark pool

### DIFF
--- a/build/prbenchmarks.yml
+++ b/build/prbenchmarks.yml
@@ -49,7 +49,7 @@ extends:
   parameters:
     pool:
       name: ASP.NET-Performance-Controller-new
-      image: MMSWindows2022-Secure
+      image: 1es-windows-2022
       os: windows
     sdl:
       sourceRepositoriesToScan:
@@ -67,7 +67,7 @@ extends:
         displayName: Benchmarks Windows Image
         pool:
           name: ASP.NET-Performance-Controller-new
-          image: MMSWindows2022-Secure
+          image: 1es-windows-2022
           os: windows
         timeoutInMinutes: 120
         steps:
@@ -168,7 +168,7 @@ extends:
         displayName: Benchmarks Linux Image
         pool:
           name: ASP.NET-Performance-Controller-new
-          image: MMSUbuntu22.04-Secure
+          image: 1es-ubuntu-2204
           os: linux
         timeoutInMinutes: 120
         steps:
@@ -223,4 +223,3 @@ extends:
           continueOnError: true
           env:
               APP_KEY: $(github.privatekey)
-

--- a/build/prbenchmarks.yml
+++ b/build/prbenchmarks.yml
@@ -48,7 +48,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: ASP.NET-Performance-Controller-new
+      name: NETCore1ESPool-Internal
       image: 1es-windows-2022
       os: windows
     sdl:
@@ -66,7 +66,7 @@ extends:
       - job: BenchmarkWindows
         displayName: Benchmarks Windows Image
         pool:
-          name: ASP.NET-Performance-Controller-new
+          name: NETCore1ESPool-Internal
           image: 1es-windows-2022
           os: windows
         timeoutInMinutes: 120
@@ -167,7 +167,7 @@ extends:
       - job: BenchmarkLinux
         displayName: Benchmarks Linux Image
         pool:
-          name: ASP.NET-Performance-Controller-new
+          name: NETCore1ESPool-Internal
           image: 1es-ubuntu-2204
           os: linux
         timeoutInMinutes: 120

--- a/build/regressionbot.yml
+++ b/build/regressionbot.yml
@@ -30,7 +30,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: ASP.NET-Performance-Controller-new
+      name: NETCore1ESPool-Internal
       image: 1es-windows-2022
       os: windows
     sdl:

--- a/build/regressionbot.yml
+++ b/build/regressionbot.yml
@@ -31,7 +31,7 @@ extends:
   parameters:
     pool:
       name: ASP.NET-Performance-Controller-new
-      image: MMSWindows2022-Secure
+      image: 1es-windows-2022
       os: windows
     sdl:
       policheck:


### PR DESCRIPTION
Replace MMS images with 1ES Windows and Ubuntu images and move the benchmark pipelines to NETCore1ESPool-Internal.

Validation:
- Regression-bot run 3030031 succeeded on the dev branch.
- Pull Request Benchmarks run 3030030 is queued/not started.
- Previous runs on ASP.NET-Performance-Controller-new failed because the 1ES image names were not registered in that pool.