### PR TITLE
Update Dependabot NuGet updates from monthly to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     registries:
       - dotnet-public
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       nuget:
         patterns:


### PR DESCRIPTION
Changes the Dependabot schedule for NuGet updates from `monthly` to `weekly`.