### PR TITLE
Add Deviation and StDev columns to Blazor first-ui regression template

### DIFF
--- a/build/regressions.blazor.config.yml
+++ b/build/regressions.blazor.config.yml
@@ -96,14 +96,15 @@ templates:
     [PowerBI Dashboard](https://aka.ms/aspnet/benchmarks)
 
   first-ui: |
-    | Scenario | Environment | Date | Old (ms) | New (ms) | Change | Dependencies |
-    | -------- | ----------- | ---- | -------- | -------- | ------ | ------------ |
+    | Scenario | Environment | Date | Old (ms) | New (ms) | Change | Deviation | StDev | Dependencies |
+    | -------- | ----------- | ---- | -------- | -------- | ------ | --------- | ----- | ------------ |
     {%- for regression in Regressions -%}
     {%- assign r = regression.CurrentResult -%}
     {%- assign p = regression.PreviousResult -%}
     {%- assign build = r.Data.jobs.application.results['blazorwasm/time-to-first-ui'] -%}
     {%- assign prevBuild = p.Data.jobs.application.results['blazorwasm/time-to-first-ui'] | at_least: 1 -%}
     {%- assign change = regression.Change | times: 100 | divided_by: prevBuild -%}
+    {%- assign deviation = regression.Change | divided_by: regression.StandardDeviation -%}
     {%- capture changes -%}
     <details>
         <summary>Changes</summary> 
@@ -147,7 +148,7 @@ templates:
         {%- endfor -%}
         </table></details>
     {%- endcapture %}
-    | {{r.Scenario}} {% if regression.HasRecovered %}[Fixed]{% endif %} | {{r.Description}} | {{r.DateTimeUtc | format_date: 'G'}} | {{prevBuild | format_number: 'N0' }} | {{build | format_number: 'N0' }} | {{change | format_number: 'N2'}} % ({{regression.Change | format_number: 'N0'}}) {% if regression.Change < 0 %} :thumbsup: {% else %} :thumbsdown: {% endif %}| {{ changes | strip_newlines }} |
+    | {{r.Scenario}} {% if regression.HasRecovered %}[Fixed]{% endif %} | {{r.Description}} | {{r.DateTimeUtc | format_date: 'G'}} | {{prevBuild | format_number: 'N0' }} | {{build | format_number: 'N0' }} | {{change | format_number: 'N2'}} % ({{regression.Change | format_number: 'N0'}}) {% if regression.Change < 0 %} :thumbsup: {% else %} :thumbsdown: {% endif %}| {{deviation | format_number: 'N2'}} σ | {{ regression.StandardDeviation | format_number: 'N2'}} | {{ changes | strip_newlines }} |
     {%- endfor %}
 
     [PowerBI Dashboard](https://aka.ms/aspnet/benchmarks)


### PR DESCRIPTION
### What

Adds the **Deviation** and **StDev** columns to the `first-ui` regression report template in `build/regressions.blazor.config.yml` (the template used for the `blazorwasm/time-to-first-ui` probe).

### Why

Time-to-first-ui regression issues (e.g. dotnet/aspnetcore#68100) were missing the Deviation/StDev columns that the `rps` (e.g. dotnet/aspnetcore#67745) and `download-size` templates already render. The cause was purely cosmetic: the `first-ui` template header simply never defined those two columns — it mirrored the `start-time` template, which also omits them.

The underlying data is already computed by crank''s RegressionBot and available on the `Regression` object (`regression.StandardDeviation`, with `deviation = regression.Change / regression.StandardDeviation`), exactly as the sibling `download-size` template already uses it. So this is a template-only change with no dependency on run data.

`StDev` is formatted `N2` (rather than the `download-size` template''s `N0`) since time-to-first-ui values are small millisecond quantities where sub-integer standard deviations are meaningful.

### Notes

- This is separate from and complementary to dotnet/aspnetcore#68119, which populates the **Dependencies** column for the same scenario.
- Validated that the YAML still parses and the header/separator/data rows all have matching column counts (9).
